### PR TITLE
Treat warnings as errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
         }
         externalNativeBuild {
             cmake {
-                cppFlags "-std=c++14 -fexceptions -frtti" +
+                cppFlags "-std=c++14 -fexceptions -frtti -Werror" +
                          " -I" + file("src/main/cpp").absolutePath +
                          " -I" + file("src/main/cpp/vrb/include").absolutePath
                 arguments "-DANDROID_STL=c++_shared"


### PR DESCRIPTION
Treat warnings as errors. Currently the error checking is very permissive (e.g. a missing return statement doesn't trigger an error and causes random crashes at runtime...)

If we find this pedantic for some kind of warnings we can disable them in the future via:
> -Wno-error=foo Turn warning “foo” into an warning even if -Werror is specified.