### PR TITLE
Add 6DoF head tracking support to GVR

### DIFF
--- a/app/src/googlevr/AndroidManifest.xml
+++ b/app/src/googlevr/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.mozilla.vrbrowser">
+    <uses-feature android:name="android.hardware.vr.headtracking"
+        android:version="1"
+        android:required="false" />
+    <uses-feature android:name="android.hardware.vr.high_performance" android:required="true"/>
     <application>
         <activity android:name=".VRBrowserActivity"
             android:screenOrientation="landscape"


### PR DESCRIPTION
Not tested since I don't have a 6DoF headset but doesn't break the 3DoF daydream headsets.