### PR TITLE
[CXB-184] Add telemetry component support.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,6 +174,7 @@ dependencies {
     svrImplementation fileTree(dir: "${project.rootDir}/third_party/svr/", include: ['*.jar'])
     implementation 'com.android.support:design:26.1.0'
     implementation 'com.google.vr:sdk-audio:1.140.0'
+    implementation "org.mozilla.components:telemetry:0.10"
 }
 
 if (findProject(':wavesdk')) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -20,6 +20,7 @@ import android.widget.FrameLayout;
 
 import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.audio.VRAudioTheme;
+import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 import org.mozilla.vrbrowser.ui.BrowserWidget;
 import org.mozilla.vrbrowser.ui.KeyboardWidget;
 import org.mozilla.vrbrowser.ui.NavigationBarWidget;
@@ -117,6 +118,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 createOffscreenDisplay();
             }
         });
+        TelemetryWrapper.init(this);
         initializeWorld();
     }
 
@@ -142,15 +144,23 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    protected void onStop() {
+        super.onStop();
+        TelemetryWrapper.stopMainActivity(this);
+    }
+
+    @Override
     protected void onPause() {
         mAudioEngine.pauseEngine();
         super.onPause();
+        TelemetryWrapper.stopSession(this);
     }
 
     @Override
     protected void onResume() {
         mAudioEngine.resumeEngine();
         super.onResume();
+        TelemetryWrapper.startSession(this);
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -1,0 +1,101 @@
+package org.mozilla.vrbrowser.telemetry;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.StrictMode;
+import android.support.annotation.UiThread;
+import org.mozilla.telemetry.Telemetry;
+import org.mozilla.telemetry.TelemetryHolder;
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+import org.mozilla.telemetry.event.TelemetryEvent;
+import org.mozilla.telemetry.net.HttpURLConnectionTelemetryClient;
+import org.mozilla.telemetry.ping.TelemetryCorePingBuilder;
+import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder;
+import org.mozilla.telemetry.schedule.jobscheduler.JobSchedulerTelemetryScheduler;
+import org.mozilla.telemetry.serialize.JSONPingSerializer;
+import org.mozilla.telemetry.storage.FileTelemetryStorage;
+import org.mozilla.vrbrowser.BuildConfig;
+import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.ui.SettingsStore;
+
+
+public class TelemetryWrapper {
+    private final static String APP_NAME = "FirefoxReality";
+
+    private class Category {
+        private static final String ACTION = "action";
+    }
+
+    private class Method {
+        private static final String FOREGROUND = "foreground";
+        private static final String BACKGROUND = "background";
+    }
+
+    private class Object {
+        private static final String APP = "app";
+    }
+
+    // We should call this at the application initial stage. Instead,
+    // it would be called when users turn on/off the setting of telemetry.
+    // e.g., SettingsStore.getInstance(context).setTelemetryEnabled();
+    public static void init(Context aContext) {
+        // When initializing the telemetry library it will make sure that all directories exist and
+        // are readable/writable.
+        final StrictMode.ThreadPolicy threadPolicy = StrictMode.allowThreadDiskWrites();
+        try {
+            final Resources resources = aContext.getResources();
+            final boolean telemetryEnabled = SettingsStore.getInstance(aContext).isTelemetryEnabled();
+            final TelemetryConfiguration configuration = new TelemetryConfiguration(aContext)
+                    .setServerEndpoint("https://incoming.telemetry.mozilla.org")
+                    .setAppName(APP_NAME + "_" + BuildConfig.FLAVOR)
+                    .setUpdateChannel(BuildConfig.BUILD_TYPE)
+                    .setPreferencesImportantForTelemetry(resources.getString(R.string.settings_key_locale))
+                    .setCollectionEnabled(telemetryEnabled)
+                    .setUploadEnabled(telemetryEnabled)
+                    .setBuildId(String.valueOf(BuildConfig.VERSION_CODE));
+            
+            final JSONPingSerializer serializer = new JSONPingSerializer();
+            final FileTelemetryStorage storage = new FileTelemetryStorage(configuration, serializer);
+            final HttpURLConnectionTelemetryClient client = new HttpURLConnectionTelemetryClient();
+            final JobSchedulerTelemetryScheduler scheduler = new JobSchedulerTelemetryScheduler();
+
+            TelemetryHolder.set(new Telemetry(configuration, storage, client, scheduler)
+                    .addPingBuilder(new TelemetryCorePingBuilder(configuration))
+                    .addPingBuilder(new TelemetryMobileEventPingBuilder(configuration)));
+        } finally {
+            StrictMode.setThreadPolicy(threadPolicy);
+        }
+    }
+
+    @UiThread
+    public static void startSession(Context aContext) {
+        if (!SettingsStore.getInstance(aContext).isTelemetryEnabled()) {
+            return;
+        }
+
+        TelemetryHolder.get().recordSessionStart();
+        TelemetryEvent.create(Category.ACTION, Method.FOREGROUND, Object.APP).queue();
+    }
+
+    @UiThread
+    public static void stopSession(Context aContext) {
+        if (!SettingsStore.getInstance(aContext).isTelemetryEnabled()) {
+            return;
+        }
+
+        TelemetryHolder.get().recordSessionEnd();
+        TelemetryEvent.create(Category.ACTION, Method.BACKGROUND, Object.APP).queue();
+    }
+
+    public static void stopMainActivity(Context aContext) {
+        if (!SettingsStore.getInstance(aContext).isTelemetryEnabled()) {
+            return;
+        }
+
+        TelemetryHolder.get()
+                .queuePing(TelemetryCorePingBuilder.TYPE)
+                .queuePing(TelemetryMobileEventPingBuilder.TYPE)
+                .scheduleUpload();
+    }
+}
+

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
@@ -3,9 +3,12 @@ package org.mozilla.vrbrowser.ui;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.StrictMode;
 import android.support.annotation.NonNull;
 
+import org.mozilla.telemetry.TelemetryHolder;
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 
 
 public class SettingsStore {
@@ -25,6 +28,8 @@ public class SettingsStore {
 
     private Context mContext;
     private SharedPreferences mPrefs;
+    // Enable telemetry by default (opt-out).
+    private final static boolean enableTelemetryByDefault = true;
 
     public SettingsStore(Context aContext) {
         mContext = aContext;
@@ -42,13 +47,29 @@ public class SettingsStore {
     }
 
     public boolean isTelemetryEnabled() {
-        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_telemetry), false);
+        // The first access to shared preferences will require a disk read.
+        final StrictMode.ThreadPolicy threadPolicy = StrictMode.allowThreadDiskReads();
+        try {
+            return mPrefs.getBoolean(
+                    mContext.getString(R.string.settings_key_telemetry), enableTelemetryByDefault);
+        } finally {
+            StrictMode.setThreadPolicy(threadPolicy);
+        }
     }
 
     public void setTelemetryEnabled(boolean isEnabled) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(mContext.getString(R.string.settings_key_telemetry), isEnabled);
         editor.commit();
+
+        // If the state of Telemetry is not the same, we reinitialize it.
+        final boolean hasEnabled = isTelemetryEnabled();
+        if (hasEnabled != isEnabled) {
+            TelemetryWrapper.init(mContext);
+        }
+
+        TelemetryHolder.get().getConfiguration().setUploadEnabled(isEnabled);
+        TelemetryHolder.get().getConfiguration().setCollectionEnabled(isEnabled);
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="settings_telemetry">Telemetry</string>
     <string name="settings_privacy">Privacy Policy</string>
     <string name="settings_key_crash">settings_crash</string>
+    <string name="settings_key_locale">settings_locale</string>
     <string name="settings_key_telemetry">settings_telemetry</string>
     <string name="private_policy_url">https://www.mozilla.org/en-US/privacy/firefox/</string>
     <string name="crash_reporting_restart">Restart Required</string>


### PR DESCRIPTION
Refer #57 and [FirefoxTV](https://github.com/mozilla-mobile/firefox-tv/blob/master/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt#L45). Adding [Android telemetry component support](https://github.com/mozilla-mobile/android-components), we measure the session spent time when using FxR.