### PR TITLE
Better handling of the app state and opened gecko sessions.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -27,6 +27,7 @@ import org.mozilla.vrbrowser.ui.BrowserWidget;
 import org.mozilla.vrbrowser.ui.KeyboardWidget;
 import org.mozilla.vrbrowser.ui.NavigationBarWidget;
 import org.mozilla.vrbrowser.ui.OffscreenDisplay;
+import org.mozilla.vrbrowser.ui.SettingsStore;
 import org.mozilla.vrbrowser.ui.SettingsWidget;
 import org.mozilla.vrbrowser.ui.TopBarWidget;
 
@@ -128,6 +129,21 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
         });
         initializeWorld();
+
+        int sessionId = SettingsStore.getInstance(this).getCurrentSessionId();
+        if (sessionId != SessionStore.NO_SESSION_ID) {
+            GeckoSession session = SessionStore.get().getSession(sessionId);
+            if (session != null) {
+                SessionStore.get().setCurrentSession(sessionId);
+                mPreviousSessionId = SettingsStore.getInstance(this).getPreviousSessionId();
+
+                if (session.getSettings().getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE)) {
+                    mNavigationBar.setPrivateBrowsingEnabled(true);
+                    mTopBar.setPrivateBrowsingEnabled(true);
+                    mBrowserWidget.setPrivateBrowsingEnabled(true);
+                }
+            }
+        }
     }
 
     protected void initializeWorld() {
@@ -191,6 +207,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (mPermissionDelegate != null) {
             mPermissionDelegate.release();
         }
+
+        SettingsStore.getInstance(this).setCurrentSeesionId(SessionStore.get().getCurrentSessionId());
+        SettingsStore.getInstance(this).setPreviousSeesionId(mPreviousSessionId);
+
         super.onDestroy();
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -136,12 +136,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             if (session != null) {
                 SessionStore.get().setCurrentSession(sessionId);
                 mPreviousSessionId = SettingsStore.getInstance(this).getPreviousSessionId();
-
-                if (session.getSettings().getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE)) {
-                    mNavigationBar.setPrivateBrowsingEnabled(true);
-                    mTopBar.setPrivateBrowsingEnabled(true);
-                    mBrowserWidget.setPrivateBrowsingEnabled(true);
-                }
             }
         }
     }
@@ -208,8 +202,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             mPermissionDelegate.release();
         }
 
-        SettingsStore.getInstance(this).setCurrentSeesionId(SessionStore.get().getCurrentSessionId());
-        SettingsStore.getInstance(this).setPreviousSeesionId(mPreviousSessionId);
+        SettingsStore.getInstance(this).setCurrentSessionId(SessionStore.get().getCurrentSessionId());
+        SettingsStore.getInstance(this).setPreviousSessionId(mPreviousSessionId);
 
         super.onDestroy();
     }
@@ -582,10 +576,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 mPreviousSessionId = sessionId;
             }
 
-            mNavigationBar.setPrivateBrowsingEnabled(true);
-            mTopBar.setPrivateBrowsingEnabled(true);
-            mBrowserWidget.setPrivateBrowsingEnabled(true);
-
         } else {
             fadeInWorld();
             // TODO: Fade in the browser window. Waiting for https://github.com/MozillaReality/FirefoxReality/issues/77
@@ -593,10 +583,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             int sessionId = SessionStore.get().getCurrentSessionId();
             SessionStore.get().setCurrentSession(mPreviousSessionId);
             mPreviousSessionId = sessionId;
-
-            mNavigationBar.setPrivateBrowsingEnabled(false);
-            mTopBar.setPrivateBrowsingEnabled(false);
-            mBrowserWidget.setPrivateBrowsingEnabled(false);
         }
     }
 
@@ -616,10 +602,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             int privateSessionId = SessionStore.get().getCurrentSessionId();
             SessionStore.get().setCurrentSession(mPreviousSessionId);
             mPreviousSessionId = SessionStore.NO_SESSION_ID;
-
-            mNavigationBar.setPrivateBrowsingEnabled(false);
-            mTopBar.setPrivateBrowsingEnabled(false);
-            mBrowserWidget.setPrivateBrowsingEnabled(false);
 
             SessionStore.get().removeSession(privateSessionId);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/BrowserWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/BrowserWidget.java
@@ -20,6 +20,7 @@ import android.view.inputmethod.InputConnection;
 
 import org.mozilla.gecko.gfx.GeckoDisplay;
 import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.SessionStore;
 import org.mozilla.vrbrowser.Widget;
@@ -51,7 +52,6 @@ public class BrowserWidget extends View implements Widget, SessionStore.SessionC
         mHandle = ((WidgetManagerDelegate)aContext).newWidgetHandle();
         mWidgetPlacement = new WidgetPlacement(aContext);
         initializeWidgetPlacement(mWidgetPlacement);
-
     }
 
     private void initializeWidgetPlacement(WidgetPlacement aPlacement) {
@@ -180,6 +180,12 @@ public class BrowserWidget extends View implements Widget, SessionStore.SessionC
         Log.e(LOGTAG, "surfaceChanged: " + aId);
         mDisplay.surfaceChanged(mSurface, mWidth, mHeight);
         aSession.getTextInput().setView(this);
+
+        boolean isPrivateMode  = aSession.getSettings().getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE);
+        if (isPrivateMode)
+            setPrivateBrowsingEnabled(true);
+        else
+            setPrivateBrowsingEnabled(false);
     }
 
     // View
@@ -262,7 +268,7 @@ public class BrowserWidget extends View implements Widget, SessionStore.SessionC
         return (session != null) && session.getPanZoomController().onMotionEvent(aEvent);
     }
 
-    public void setPrivateBrowsingEnabled(boolean isEnabled) {
+    private void setPrivateBrowsingEnabled(boolean isEnabled) {
         // TODO: Fade in/out the browser window. Waiting for https://github.com/MozillaReality/FirefoxReality/issues/77
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 
 import org.mozilla.geckoview.GeckoResponse;
 import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.SessionStore;
 import org.mozilla.vrbrowser.Widget;
@@ -23,7 +24,7 @@ import org.mozilla.vrbrowser.audio.AudioEngine;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-public class NavigationBarWidget extends UIWidget implements GeckoSession.NavigationDelegate, GeckoSession.ProgressDelegate, GeckoSession.ContentDelegate, WidgetManagerDelegate.Listener {
+public class NavigationBarWidget extends UIWidget implements GeckoSession.NavigationDelegate, GeckoSession.ProgressDelegate, GeckoSession.ContentDelegate, WidgetManagerDelegate.Listener, SessionStore.SessionChangeListener {
     private static final String LOGTAG = "VRB";
     private AudioEngine mAudio;
     private NavigationBarButton mBackButton;
@@ -236,6 +237,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         SessionStore.get().addProgressListener(this);
         SessionStore.get().addContentListener(this);
         mWidgetManager.addListener(this);
+
+        SessionStore.get().addSessionChangeListener(this);
     }
 
     @Override
@@ -418,7 +421,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
     }
 
-    public void setPrivateBrowsingEnabled(boolean isEnabled) {
+    private void setPrivateBrowsingEnabled(boolean isEnabled) {
         mURLBar.setPrivateBrowsingEnabled(isEnabled);
 
         if (isEnabled) {
@@ -506,5 +509,25 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mWidgetPlacement.worldWidth = targetWidth;
         mWidgetPlacement.width = (int) (WidgetPlacement.dpDimension(getContext(), R.dimen.navigation_bar_width) * ratio);
         mWidgetManager.updateWidget(this);
+    }
+
+    // SessionStore.SessionChangeListener
+    @Override
+    public void onNewSession(GeckoSession aSession, int aId) {
+
+    }
+
+    @Override
+    public void onRemoveSession(GeckoSession aSession, int aId) {
+
+    }
+
+    @Override
+    public void onCurrentSessionChange(GeckoSession aSession, int aId) {
+        boolean isPrivateMode  = aSession.getSettings().getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE);
+        if (isPrivateMode)
+            setPrivateBrowsingEnabled(true);
+        else
+            setPrivateBrowsingEnabled(false);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
@@ -247,6 +247,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         SessionStore.get().removeNavigationListener(this);
         SessionStore.get().removeProgressListener(this);
         SessionStore.get().removeContentListener(this);
+        SessionStore.get().removeSessionChangeListener(this);
         mBrowserWidget = null;
         super.releaseWidget();
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
@@ -1,6 +1,5 @@
 package org.mozilla.vrbrowser.ui;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.StrictMode;
@@ -9,6 +8,7 @@ import android.support.annotation.NonNull;
 
 import org.mozilla.telemetry.TelemetryHolder;
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.SessionStore;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 
 
@@ -71,6 +71,27 @@ public class SettingsStore {
 
         TelemetryHolder.get().getConfiguration().setUploadEnabled(isEnabled);
         TelemetryHolder.get().getConfiguration().setCollectionEnabled(isEnabled);
+    }
+
+
+    public void setCurrentSeesionId(int sessionId) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_session_id), sessionId);
+        editor.commit();
+    }
+
+    public int getCurrentSessionId() {
+        return mPrefs.getInt(mContext.getString(R.string.settings_key_session_id), SessionStore.NO_SESSION_ID);
+    }
+
+    public void setPreviousSeesionId(int sessionId) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_previous_session_id), sessionId);
+        editor.commit();
+    }
+
+    public int getPreviousSessionId() {
+        return mPrefs.getInt(mContext.getString(R.string.settings_key_previous_session_id), SessionStore.NO_SESSION_ID);
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
@@ -74,7 +74,7 @@ public class SettingsStore {
     }
 
 
-    public void setCurrentSeesionId(int sessionId) {
+    public void setCurrentSessionId(int sessionId) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putInt(mContext.getString(R.string.settings_key_session_id), sessionId);
         editor.commit();
@@ -84,7 +84,7 @@ public class SettingsStore {
         return mPrefs.getInt(mContext.getString(R.string.settings_key_session_id), SessionStore.NO_SESSION_ID);
     }
 
-    public void setPreviousSeesionId(int sessionId) {
+    public void setPreviousSessionId(int sessionId) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putInt(mContext.getString(R.string.settings_key_previous_session_id), sessionId);
         editor.commit();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/TopBarWidget.java
@@ -9,11 +9,14 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
 
+import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.SessionStore;
 import org.mozilla.vrbrowser.WidgetPlacement;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 
-public class TopBarWidget extends UIWidget {
+public class TopBarWidget extends UIWidget implements SessionStore.SessionChangeListener {
     private static final String LOGTAG = "VRB";
 
     public interface TopBarDelegate {
@@ -56,6 +59,8 @@ public class TopBarWidget extends UIWidget {
         });
 
         mAudio = AudioEngine.fromContext(aContext);
+
+        SessionStore.get().addSessionChangeListener(this);
     }
 
     @Override
@@ -71,7 +76,7 @@ public class TopBarWidget extends UIWidget {
         aPlacement.parentAnchorY = 1.0f;
     }
 
-    public void setPrivateBrowsingEnabled(boolean isEnabled) {
+    private void setPrivateBrowsingEnabled(boolean isEnabled) {
         if (isEnabled) {
             mCloseButton.setBackground(getContext().getDrawable(R.drawable.main_button_private));
             mCloseButton.setTintColorList(R.drawable.main_button_icon_color_private);
@@ -82,7 +87,27 @@ public class TopBarWidget extends UIWidget {
         }
     }
 
+    // SessionStore.SessionChangeListener
     public void setDelegate(TopBarDelegate aDelegate) {
         mDelegate = aDelegate;
+    }
+
+    @Override
+    public void onNewSession(GeckoSession aSession, int aId) {
+
+    }
+
+    @Override
+    public void onRemoveSession(GeckoSession aSession, int aId) {
+
+    }
+
+    @Override
+    public void onCurrentSessionChange(GeckoSession aSession, int aId) {
+        boolean isPrivateMode  = aSession.getSettings().getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE);
+        if (isPrivateMode)
+            setPrivateBrowsingEnabled(true);
+        else
+            setPrivateBrowsingEnabled(false);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/TopBarWidget.java
@@ -76,6 +76,13 @@ public class TopBarWidget extends UIWidget implements SessionStore.SessionChange
         aPlacement.parentAnchorY = 1.0f;
     }
 
+    @Override
+    public void releaseWidget() {
+        SessionStore.get().removeSessionChangeListener(this);
+
+        super.releaseWidget();
+    }
+
     private void setPrivateBrowsingEnabled(boolean isEnabled) {
         if (isEnabled) {
             mCloseButton.setBackground(getContext().getDrawable(R.drawable.main_button_private));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="settings_key_crash">settings_crash</string>
     <string name="settings_key_locale">settings_locale</string>
     <string name="settings_key_telemetry">settings_telemetry</string>
+    <string name="settings_key_session_id">session_id</string>
+    <string name="settings_key_previous_session_id">previous_session_id</string>
     <string name="private_policy_url">https://www.mozilla.org/en-US/privacy/firefox/</string>
     <string name="crash_reporting_restart">Restart Required</string>
     <string name="crash_reporting_text">You must restart the Firefox Reality app in order to \ncomplete changes. Would you like to do that now?</string>


### PR DESCRIPTION
Fixes #91 

There were some situations were private sessions were not being correctly restored. For exmaple after leaving the app, in case you do not "continue" or "quit" and just go somewhere else an open the app later the app sessions were still alive but we were not restoring the private/public sessions correctly.

Please test in other headsets as I've only tested on Oculus Go and thetre might be some Android lifecycle related differences on those.