### PR TITLE
Fix keyboard on Daydream #127

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -202,6 +202,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     protected void onDestroy() {
+        for (Widget widget: mWidgets.values()) {
+            widget.releaseWidget();
+        }
+
         if (mOffscreenDisplay != null) {
             mOffscreenDisplay.release();
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/KeyboardWidget.java
@@ -450,15 +450,21 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     @Override
-    public void updateSelection(@NonNull GeckoSession session, int selStart, int selEnd, int compositionStart, int compositionEnd) {
+    public void updateSelection(@NonNull GeckoSession session, final int selStart, final int selEnd, final int compositionStart, final int compositionEnd) {
         if (mFocusedView != mBrowserWidget || mInputConnection == null) {
             return;
         }
 
-        if (compositionStart >= 0 && compositionEnd >= 0) {
-            mInputConnection.setComposingRegion(compositionStart, compositionEnd);
-        }
-        mInputConnection.setSelection(selStart, selEnd);
+        final InputConnection connection = mInputConnection;
+        postInputCommand(new Runnable() {
+            @Override
+            public void run() {
+                if (compositionStart >= 0 && compositionEnd >= 0) {
+                    connection.setComposingRegion(compositionStart, compositionEnd);
+                }
+                connection.setSelection(selStart, selEnd);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
- Release widgets on destroy to ensure that text listeners are cleared succesfully in the duplicated activity creations
- The updateSelection command was not sent with the correct handler