### PR TITLE
[CXB-183] Enable crash report

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsStore.java
@@ -28,6 +28,7 @@ public class SettingsStore {
 
     private Context mContext;
     private SharedPreferences mPrefs;
+    private final static boolean enableCrashReportByDefault = true;
     // Enable telemetry by default (opt-out).
     private final static boolean enableTelemetryByDefault = true;
 
@@ -37,7 +38,7 @@ public class SettingsStore {
     }
 
     public boolean isCrashReportingEnabled() {
-        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_crash), false);
+        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_crash), enableCrashReportByDefault);
     }
 
     public void setCrashReportingEnabled(boolean isEnabled) {


### PR DESCRIPTION
Enable Java and GV crash report. I also refer MOZ_CRASH() from Gecko to give abort() when we need to crash it at the native code.