### PR TITLE
Update to new moz_external_vr.h structures

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -290,10 +290,10 @@ void
 ExternalVR::RequestFrame(const vrb::Matrix& aHeadTransform) {
   vrb::Quaternion quaternion(aHeadTransform);
   vrb::Vector translation = aHeadTransform.GetTranslation();
-  memcpy(&(m.system.sensorState.orientation), quaternion.Data(),
-         sizeof(m.system.sensorState.orientation));
-  memcpy(&(m.system.sensorState.position), translation.Data(),
-         sizeof(m.system.sensorState.position));
+  memcpy(&(m.system.sensorState.pose.orientation), quaternion.Data(),
+         sizeof(m.system.sensorState.pose.orientation));
+  memcpy(&(m.system.sensorState.pose.position), translation.Data(),
+         sizeof(m.system.sensorState.pose.position));
   m.system.sensorState.inputFrameID++;
   m.system.displayState.mLastSubmittedFrameId = m.lastFrameId;
 


### PR DESCRIPTION
This will be needed for compatibility with GeckoView once [Bug 1470527](https://bugzilla.mozilla.org/show_bug.cgi?id=1470527) (Implement controller support for gfxVRExternal) lands in mozilla-central.

This is currently in mozilla-inbound:
https://hg.mozilla.org/integration/mozilla-inbound/rev/1e8eca5ec5c9