### PR TITLE
Avoid deadlock when pausing the compositor in immersive mode

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -986,7 +986,7 @@ BrowserWorld::DrawWorld() {
 void
 BrowserWorld::DrawImmersive() {
   if (m.externalVR->IsFirstPresentingFrame()) {
-    VRBrowser::PauseCompositor();
+    m.externalVR->HandleFirstPresentingFrame();
   }
   m.device->SetRenderMode(device::RenderMode::Immersive);
   /*

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -263,12 +263,6 @@ ExternalVR::PullBrowserState(bool aBlock) {
   }
 
   m.firstPresentingFrame = !wasPresenting && IsPresenting();
-  if (m.firstPresentingFrame) {
-    m.system.displayState.mLastSubmittedFrameSuccessful = false;
-    m.system.displayState.mLastSubmittedFrameId = m.browser.layerState[0].layer_stereo_immersive.mFrameId;
-    m.lastFrameId = m.browser.layerState[0].layer_stereo_immersive.mFrameId;
-    PushSystemState();
-  }
   if (wasPresenting && !IsPresenting()) {
     m.lastFrameId = m.browser.layerState[0].layer_stereo_immersive.mFrameId;
     VRBrowser::ResumeCompositor();
@@ -278,6 +272,17 @@ ExternalVR::PullBrowserState(bool aBlock) {
 bool
 ExternalVR::IsFirstPresentingFrame() const {
   return IsPresenting() && m.firstPresentingFrame;
+}
+
+void
+ExternalVR::HandleFirstPresentingFrame() {
+  m.system.displayState.pausingCompositor = true;
+  m.system.displayState.mLastSubmittedFrameId = 0;
+  m.lastFrameId = 0;
+  PushSystemState();
+  VRBrowser::PauseCompositor();
+  m.system.displayState.pausingCompositor = false;
+  PushSystemState();
 }
 
 bool

--- a/app/src/main/cpp/ExternalVR.h
+++ b/app/src/main/cpp/ExternalVR.h
@@ -36,6 +36,7 @@ public:
   void PushSystemState();
   void PullBrowserState(bool aBlock = true);
   bool IsFirstPresentingFrame() const;
+  void HandleFirstPresentingFrame();
   bool IsPresenting() const;
   void RequestFrame(const vrb::Matrix& aHeadTransform);
   void GetFrameResult(int32_t& aSurfaceHandle, device::EyeRect& aLeftEye, device::EyeRect& aRightEye) const;

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -262,6 +262,7 @@ struct VRDisplayState
 
 #if defined(__ANDROID__)
   bool shutdown;
+  bool pausingCompositor;
 #endif // defined(__ANDROID__)
   char mDisplayName[kVRDisplayNameMaxLen];
   VRDisplayCapabilityFlags mCapabilityFlags;


### PR DESCRIPTION
Firefox Reality pauses the compositor when gfxVRExternal presentation begins.

There is a edge race condition which causes a deadlock. It happens when pausing the compositor while gfxVRExternal is waiting for a SubmitFrame result.