### PR TITLE
Get rid of WebVR condition spin waits in GeckoView side

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -247,6 +247,7 @@ ExternalVR::PushSystemState() {
   Lock lock(m.data.systemMutex);
   if (lock.IsLocked()) {
     memcpy(&(m.data.state), &(m.system), sizeof(mozilla::gfx::VRSystemState));
+    pthread_cond_signal(&m.data.systemCond);
   }
 }
 


### PR DESCRIPTION
Only one line needs to be added here.

GV side patch: https://bugzilla.mozilla.org/show_bug.cgi?id=1476380