### PR TITLE
Filter resource and jar URLs

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationURLBar.java
@@ -92,7 +92,12 @@ public class NavigationURLBar extends FrameLayout {
     public void setURL(String aURL) {
         int index = -1;
         if (aURL != null) {
-            index = aURL.indexOf("://");
+            if (aURL.startsWith("jar:"))
+                return;
+            else if (aURL.startsWith("resource:"))
+                aURL = "";
+            else
+                index = aURL.indexOf("://");
         }
         mURL.setText(aURL);
         if (index > 0) {


### PR DESCRIPTION
Fixes #130 

We are nor hiding all jar: and resources: URLs. Now when at home the URL bar is empty, same as Firefox does