### PR TITLE
Fix tray collision check

### DIFF
--- a/app/src/main/cpp/Tray.cpp
+++ b/app/src/main/cpp/Tray.cpp
@@ -100,10 +100,10 @@ namespace {
 
     bool Intersect(const vrb::Vector& aStartPoint, const vrb::Vector& aDirection, vrb::Vector& aResult, bool& aInside) {
       const float dotNormals = aDirection.Dot(colliderNormal);
-//      if (dotNormals > -kEpsilon) {
-//        // Not pointed at the plane
-//        return false;
-//      }
+      if (dotNormals < -kEpsilon) {
+        // Not pointed at the plane
+        return false;
+      }
       const float dotV = (colliderMin - aStartPoint).Dot(colliderNormal);
 
       if ((dotV < kEpsilon) && (dotV > -kEpsilon)) {


### PR DESCRIPTION
Fixes #96 

When dot product betweeen direction and collider face normal is bigger than the threshold we are pointing to the collider, so return otherwise.