### PR TITLE
[CXB-183] Native code symbol generator and uploader

### DIFF
--- a/tools/taskcluster/upload_symbols.sh
+++ b/tools/taskcluster/upload_symbols.sh
@@ -1,0 +1,11 @@
+#/bin/sh
+git clone git@github.com:MozillaReality/symbolgenerator.git tools/taskcluster/symbols && cd tools/taskcluster/symbols && git rebase origin/master && cd ../../..
+
+export PYTHONPATH="tools/taskcluster/symbols/third_party/python/redo:tools/taskcluster/symbols/third_party/python/requests"
+export OBJCOPY="tools/taskcluster/symbols/bin/arm-linux-androideabi-objcopy"
+
+python tools/taskcluster/symbols/symbolstore.py -c -s . tools/taskcluster/symbols/bin/dump_syms tools/taskcluster/symbols/crashreporter/crashreporter-symbols ./app/build/intermediates/cmake/googlevr/release/obj/armeabi-v7a/libnative-lib.so googlevr
+python tools/taskcluster/symbols/symbolstore.py -c -s . tools/taskcluster/symbols/bin/dump_syms tools/taskcluster/symbols/crashreporter/crashreporter-symbols ./app/build/intermediates/cmake/noapi/release/obj/armeabi-v7a/libnative-lib.so noapi
+python tools/taskcluster/symbols/symbolstore.py -c -s . tools/taskcluster/symbols/bin/dump_syms tools/taskcluster/symbols/crashreporter/crashreporter-symbols ./app/build/intermediates/cmake/wavevr/release/obj/armeabi-v7a/libnative-lib.so wavevr
+python tools/taskcluster/symbols/symbolstore.py -c -s . tools/taskcluster/symbols/bin/dump_syms tools/taskcluster/symbols/crashreporter/crashreporter-symbols ./app/build/intermediates/cmake/svr/release/obj/armeabi-v7a/libnative-lib.so svr
+python tools/taskcluster/symbols/symbolstore.py -c -s . tools/taskcluster/symbols/bin/dump_syms tools/taskcluster/symbols/crashreporter/crashreporter-symbols ./app/build/intermediates/cmake/oculusvr/release/obj/armeabi-v7a/libnative-lib.so oculusvr


### PR DESCRIPTION
Per #117. We make the `symbolstore.py` to help us generate symbols from `libxxx-lib.so`. It will call `dump_syms` that is built from Breadpad and `arm-linux-androideab-objcopy` that is from Android SDK. Then, we pack the output symbol files to a zip file and upload it to our symbol server.