### PR TITLE
Fix #165: Map the remote controller APP button to BACK action

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -15,6 +15,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Keep;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
@@ -323,6 +324,18 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                     mLastRunnable = new SwipeRunnable();
                     mHandler.postDelayed(mLastRunnable, SwipeDelay);
                 }
+            }
+        });
+    }
+
+    @SuppressWarnings({"UnusedDeclaration"})
+    @Keep
+    void handleBack() {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK));
+                dispatchKeyEvent(new KeyEvent (KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK));
             }
         });
     }

--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -277,7 +277,7 @@ struct DeviceDelegateGoogleVR::State {
       }
       controllerDelegate->SetTransform(index, controller.transform);
       controllerDelegate->SetLeftHanded(index, controller.hand == ElbowModel::HandEnum::Left);
-      controllerDelegate->SetButtonCount(index, 2);
+      controllerDelegate->SetButtonCount(index, 1); // For immersive mode
       // Index 0 is the dummy button so skip it.
       for (int ix = 1; ix < GVR_CONTROLLER_BUTTON_COUNT; ix++) {
         const uint64_t buttonMask = (uint64_t) 0x01 << (ix - 1);
@@ -300,7 +300,7 @@ struct DeviceDelegateGoogleVR::State {
           controllerDelegate->SetAxes(index, immersiveAxes, kNumImmersiveAxes);
         }
         else if (ix == GVR_CONTROLLER_BUTTON_APP) {
-          controllerDelegate->SetButtonState(index, ControllerDelegate::BUTTON_MENU, 1, clicked, clicked);
+          controllerDelegate->SetButtonState(index, ControllerDelegate::BUTTON_APP, -1, clicked, clicked);
         }
       }
     }

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -193,6 +193,11 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
     if (!controller.enabled || (controller.index < 0)) {
       continue;
     }
+
+    if (!(controller.lastButtonState & ControllerDelegate::BUTTON_APP) && (controller.buttonState & ControllerDelegate::BUTTON_APP)) {
+      VRBrowser::HandleBack();
+    }
+
     vrb::Vector start = controller.transformMatrix.MultiplyPosition(vrb::Vector());
     vrb::Vector direction = controller.transformMatrix.MultiplyDirection(vrb::Vector(0.0f, 0.0f, -1.0f));
     WidgetPtr hitWidget;
@@ -277,6 +282,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
       VRBrowser::HandleMotionEvent(0, controller.index, JNI_FALSE, 0.0f, 0.0f);
       controller.widget = 0;
     }
+    controller.lastButtonState = controller.buttonState;
   }
   for (Widget* widget: active) {
     widget->TogglePointer(true);

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -239,23 +239,29 @@ ControllerContainer::SetButtonState(const int32_t aControllerIndex, const Button
 
   if (aPressed) {
     m.list[aControllerIndex].buttonState |= aWhichButton;
-    m.list[aControllerIndex].immersivePressedState |= immersiveButtonMask;
   } else {
     m.list[aControllerIndex].buttonState &= ~aWhichButton;
-    m.list[aControllerIndex].immersivePressedState &= ~immersiveButtonMask;
   }
 
-  if (aTouched) {
-    m.list[aControllerIndex].immersiveTouchedState |= immersiveButtonMask;
-  } else {
-    m.list[aControllerIndex].immersiveTouchedState &= ~immersiveButtonMask;
-  }
+  if (aImmersiveIndex >= 0) {
+    if (aPressed) {
+      m.list[aControllerIndex].immersivePressedState |= immersiveButtonMask;
+    } else {
+      m.list[aControllerIndex].immersivePressedState &= ~immersiveButtonMask;
+    }
 
-  float trigger = aImmersiveTrigger;
-  if (trigger < 0.0f) {
-    trigger = aPressed ? 1.0f : 0.0f;
+    if (aTouched) {
+      m.list[aControllerIndex].immersiveTouchedState |= immersiveButtonMask;
+    } else {
+      m.list[aControllerIndex].immersiveTouchedState &= ~immersiveButtonMask;
+    }
+
+    float trigger = aImmersiveTrigger;
+    if (trigger < 0.0f) {
+      trigger = aPressed ? 1.0f : 0.0f;
+    }
+    m.list[aControllerIndex].immersiveTriggerValues[aImmersiveIndex] = trigger;
   }
-  m.list[aControllerIndex].immersiveTriggerValues[aImmersiveIndex] = trigger;
 }
 
 void

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -22,7 +22,7 @@ public:
   enum Button {
     BUTTON_TRIGGER   = 1 << 0,
     BUTTON_TOUCHPAD  = 1 << 1,
-    BUTTON_MENU      = 1 << 2,
+    BUTTON_APP      = 1 << 2,
   };
 
   virtual void CreateController(const int32_t aControllerIndex, const int32_t aModelIndex, const std::string& aImmersiveName) = 0;

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -22,8 +22,8 @@ static const char* kHandleGestureName = "handleGesture";
 static const char* kHandleGestureSignature = "(I)V";
 static const char* kHandleResizeName = "handleResize";
 static const char* kHandleResizeSignature = "(IFF)V";
-static const char* kHandleTrayEventName = "handleTrayEvent";
-static const char* kHandleTrayEventSignature = "(I)V";
+static const char* kHandleBackEventName = "handleBack";
+static const char* kHandleBackEventSignature = "()V";
 static const char* kRegisterExternalContextName = "registerExternalContext";
 static const char* kRegisterExternalContextSignature = "(J)V";
 static const char* kPauseCompositorName = "pauseGeckoViewCompositor";
@@ -41,7 +41,7 @@ static jmethodID sHandleScrollEvent;
 static jmethodID sHandleAudioPose;
 static jmethodID sHandleGesture;
 static jmethodID sHandleResize;
-static jmethodID sHandleTrayEvent;
+static jmethodID sHandleBack;
 static jmethodID sRegisterExternalContext;
 static jmethodID sPauseCompositor;
 static jmethodID sResumeCompositor;
@@ -71,7 +71,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sHandleAudioPose = FindJNIMethodID(sEnv, browserClass, kHandleAudioPoseName, kHandleAudioPoseSignature);
   sHandleGesture = FindJNIMethodID(sEnv, browserClass, kHandleGestureName, kHandleGestureSignature);
   sHandleResize = FindJNIMethodID(sEnv, browserClass, kHandleResizeName, kHandleResizeSignature);
-  sHandleTrayEvent = FindJNIMethodID(sEnv, browserClass, kHandleTrayEventName, kHandleTrayEventSignature);
+  sHandleBack = FindJNIMethodID(sEnv, browserClass, kHandleBackEventName, kHandleBackEventSignature);
   sRegisterExternalContext = FindJNIMethodID(sEnv, browserClass, kRegisterExternalContextName, kRegisterExternalContextSignature);
   sPauseCompositor = FindJNIMethodID(sEnv, browserClass, kPauseCompositorName, kPauseCompositorSignature);
   sResumeCompositor = FindJNIMethodID(sEnv, browserClass, kResumeCompositorName, kResumeCompositorSignature);
@@ -94,7 +94,7 @@ VRBrowser::ShutdownJava() {
   sHandleAudioPose = nullptr;
   sHandleGesture = nullptr;
   sHandleResize = nullptr;
-  sHandleTrayEvent = nullptr;
+  sHandleBack = nullptr;
   sRegisterExternalContext = nullptr;
   sPauseCompositor = nullptr;
   sResumeCompositor = nullptr;
@@ -144,9 +144,9 @@ VRBrowser::HandleResize(jint aWidgetHandle, jfloat aWorldWidth, jfloat aWorldHei
 }
 
 void
-VRBrowser::HandleTrayEvent(jint aType) {
-  if (!ValidateMethodID(sEnv, sActivity, sHandleTrayEvent, __FUNCTION__)) { return; }
-  sEnv->CallVoidMethod(sActivity, sHandleTrayEvent, aType);
+VRBrowser::HandleBack() {
+  if (!ValidateMethodID(sEnv, sActivity, sHandleBack, __FUNCTION__)) { return; }
+  sEnv->CallVoidMethod(sActivity, sHandleBack);
   CheckJNIException(sEnv, __FUNCTION__);
 }
 

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -23,7 +23,7 @@ void HandleScrollEvent(jint aWidgetHandle, jint aController, jfloat aX, jfloat a
 void HandleAudioPose(jfloat qx, jfloat qy, jfloat qz, jfloat qw, jfloat px, jfloat py, jfloat pz);
 void HandleGesture(jint aType);
 void HandleResize(jint aWidgetHandle, jfloat aWorldWidth, jfloat aWorldHeight);
-void HandleTrayEvent(jint aType);
+void HandleBack();
 void RegisterExternalContext(jlong aContext);
 void PauseCompositor();
 void ResumeCompositor();

--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -150,7 +150,7 @@ InputCallback(struct android_app *aApp, AInputEvent *aEvent) {
       return 1;
 		}
 		else if (action == AKEY_EVENT_ACTION_UP && keyCode == AKEYCODE_MENU) {
-      ctx->mDevice->UpdateButtonState(ControllerDelegate::BUTTON_MENU, true);
+      ctx->mDevice->UpdateButtonState(ControllerDelegate::BUTTON_APP, true);
       return 1;
 		}
 		else if (keyCode == AKEYCODE_DPAD_LEFT) {

--- a/app/src/svr/cpp/DeviceDelegateSVR.cpp
+++ b/app/src/svr/cpp/DeviceDelegateSVR.cpp
@@ -223,7 +223,7 @@ struct DeviceDelegateSVR::State {
     const bool menuPressed = (bool)(state.buttonState & svrControllerButton::Start);
     controller->SetButtonState(aController, ControllerDelegate::BUTTON_TRIGGER, 0, triggerPressed, triggerPressed, controllerState.analog1D[0]);
     controller->SetButtonState(aController, ControllerDelegate::BUTTON_TOUCHPAD, 1, touchpadPressed, touchpadTouched);
-    controller->SetButtonState(aController, ControllerDelegate::BUTTON_MENU, 2, menuPressed, menuPressed);
+    controller->SetButtonState(aController, ControllerDelegate::BUTTON_APP, 2, menuPressed, menuPressed);
 
     if (aController == kHeadControllerId) {
       // Workaround for repeated KEY_DOWN events bug in ODG
@@ -580,7 +580,7 @@ DeviceDelegateSVR::ExitApp() {
 
 void
 DeviceDelegateSVR::UpdateButtonState(int32_t aWhichButton, bool pressed) {
-  int32_t buttonMask = aWhichButton == ControllerDelegate::BUTTON_MENU ? svrControllerButton::Start :
+  int32_t buttonMask = aWhichButton == ControllerDelegate::BUTTON_APP ? svrControllerButton::Start :
                                                                          svrControllerButton::PrimaryIndexTrigger;
   if (pressed) {
     m.headControllerState.buttonState |= buttonMask;

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -182,10 +182,10 @@ struct DeviceDelegateWaveVR::State {
       const bool touchpadTouched = WVR_GetInputTouchState(controller.type, WVR_InputId_Alias1_Touchpad);
       const bool menuPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Menu);
 
-      delegate->SetButtonCount(index, 3);
+      delegate->SetButtonCount(index, 2); // For immersive mode
       delegate->SetButtonState(index, ControllerDelegate::BUTTON_TRIGGER, 0, bumperPressed, bumperPressed);
       delegate->SetButtonState(index, ControllerDelegate::BUTTON_TOUCHPAD, 1, touchpadPressed, touchpadTouched);
-      delegate->SetButtonState(index, ControllerDelegate::BUTTON_MENU, 2, menuPressed, menuPressed);
+      delegate->SetButtonState(index, ControllerDelegate::BUTTON_APP, -1, menuPressed, menuPressed);
 
       const int32_t kNumAxes = 2;
       float immersiveAxes[kNumAxes] = { 0.0f, 0.0f };


### PR DESCRIPTION
Some follow-ups:

- We may need a better name for "SetButtonCount" because immersive mode can have different count from the app. Just added a comment for now.
- We may need to add a exit dialog confirmation in Vive Focus