### PR TITLE
Increase max WebVR raf. Fixes delay when entering WebVR in some demos.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/SessionStore.java
@@ -464,6 +464,7 @@ public class SessionStore implements GeckoSession.NavigationDelegate, GeckoSessi
             out.write("pref(\"dom.vr.external.enabled\", true);\n".getBytes());
             out.write("pref(\"webgl.enable-surface-texture\", true);\n".getBytes());
             out.write("pref(\"apz.allow_double_tap_zooming\", false);\n".getBytes());
+            out.write("pref(\"dom.vr.display.rafMaxDuration\", 1000);\n".getBytes());
         } catch (FileNotFoundException e) {
             Log.e(LOGTAG, "Unable to create file: '" + prefFileName + "' got exception: " + e.toString());
         } catch (IOException e) {


### PR DESCRIPTION
More info here:  https://github.com/MozillaReality/FirefoxReality/issues/291
