### PR TITLE
'Caps Lock' key should behave like a 'Shift' key does

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/CustomKeyboardView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/CustomKeyboardView.java
@@ -84,6 +84,8 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
 
         void onLongPress(Key popupKey);
 
+        void onMultiTap(Key popupKey);
+
         /**
          * Called when the user releases a key. This is sent after the {@link #onKey} is called.
          * For keys that repeat, this is only called once.
@@ -837,6 +839,9 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                         mTapCount = 0;
                     }
                     code = key.codes[mTapCount];
+
+                    if (mKeyboardActionListener != null)
+                        mKeyboardActionListener.onMultiTap(key);
                 }
                 mKeyboardActionListener.onKey(code, codes);
                 mKeyboardActionListener.onRelease(code);
@@ -1358,7 +1363,11 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
                 mTapCount = -1;
                 return;
             }
+
+        } else if (key.codes[0] == CustomKeyboard.KEYCODE_SHIFT) {
+            mInMultiTap = true;
         }
+
         if (eventTime > mLastTapTime + MULTITAP_INTERVAL || keyIndex != mLastSentIndex) {
             resetMultiTap();
         }

--- a/app/src/main/res/drawable/ic_icon_keyboard_caps.xml
+++ b/app/src/main/res/drawable/ic_icon_keyboard_caps.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="30dp"
+        android:height="30dp"
+        android:viewportWidth="200"
+        android:viewportHeight="200">
+
+    <path
+            android:fillColor="@color/fog"
+            android:strokeColor="@color/fog"
+            android:strokeWidth="5.67"
+            android:strokeLineJoin="round"
+            android:strokeLineCap="round"
+            android:pathData="M 81.6 141.4 H 118.4 V 148.5 H 81.6 V 141.4 Z" />
+    <path
+            android:fillColor="@color/fog"
+            android:strokeColor="@color/fog"
+            android:strokeWidth="5.67"
+            android:strokeLineJoin="round"
+            android:strokeLineCap="round"
+            android:pathData="M 81.6 131.6 L 118.4 131.6 L 118.4 102.4 L 140.4 102.4 L 100 51.5 L 59.7 102.4 L 81.6 102.4 Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_icon_keyboard_shift_off.xml
+++ b/app/src/main/res/drawable/ic_icon_keyboard_shift_off.xml
@@ -1,7 +1,7 @@
 <vector android:height="30dp" android:viewportHeight="200"
     android:viewportWidth="200" android:width="30dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#00000000" android:fillType="evenOdd"
+    <path android:fillColor="@color/asphalt" android:fillType="evenOdd"
         android:pathData="M140.35,102.43l-40.35,-50.88l-40.35,50.88l21.96,0l0,46.02l36.78,0l0,-46.02l21.96,0z"
-        android:strokeColor="#FFFFFF" android:strokeLineCap="round"
+        android:strokeColor="@color/fog" android:strokeLineCap="round"
         android:strokeLineJoin="round" android:strokeWidth="10"/>
 </vector>

--- a/app/src/main/res/drawable/ic_icon_keyboard_shift_on.xml
+++ b/app/src/main/res/drawable/ic_icon_keyboard_shift_on.xml
@@ -1,7 +1,7 @@
 <vector android:height="24dp" android:viewportHeight="200"
     android:viewportWidth="200" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FFFFFF" android:fillType="evenOdd"
+    <path android:fillColor="@color/fog" android:fillType="evenOdd"
         android:pathData="M140.35,102.43l-40.35,-50.88l-40.35,50.88l21.96,0l0,46.02l36.78,0l0,-46.02l21.96,0z"
-        android:strokeColor="#FFFFFF" android:strokeLineCap="round"
+        android:strokeColor="@color/fog" android:strokeLineCap="round"
         android:strokeLineJoin="round" android:strokeWidth="10"/>
 </vector>


### PR DESCRIPTION
Fixes #288 Make shift become caps lock when double clicked or long pressed.

![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/837184/43784370-438d6fae-9a64-11e8-8dd0-912bf55f1c19.gif)
