### PR TITLE
Make WebVR work with multiprocess enabled

### DIFF
--- a/app/src/main/cpp/ExternalBlitter.cpp
+++ b/app/src/main/cpp/ExternalBlitter.cpp
@@ -81,10 +81,6 @@ ExternalBlitter::Create(vrb::CreationContextPtr& aContext) {
 void
 ExternalBlitter::StartFrame(const int32_t aSurfaceHandle, const device::EyeRect& aLeftEye,
                             const device::EyeRect& aRightEye) {
-  if (m.surface) {
-    m.surface->ReleaseTexImage();
-    m.surface = nullptr;
-  }
   std::map<const int32_t, GeckoSurfaceTexturePtr>::iterator iter = m.surfaceMap.find(aSurfaceHandle);
 
   if (iter == m.surfaceMap.end()) {
@@ -139,9 +135,10 @@ ExternalBlitter::Draw(const device::Eye aEye) {
 
 void
 ExternalBlitter::EndFrame() {
-  if (m.surface && m.surface->IsAttachedToGLContext(eglGetCurrentContext())) {
+  if (m.surface) {
     // We need to detach the SurfaceTexture to prevent the Gecko WebGL compositor from getting blocked.
-    m.surface->DetachFromGLContext();
+    m.surface->ReleaseTexImage();
+    m.surface = nullptr;
   }
 }
 

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -373,7 +373,7 @@ ExternalVR::WaitFrameResult() {
   while (true) {
     if (!IsPresenting() || m.browser.layerState[0].layer_stereo_immersive.mFrameId != m.lastFrameId) {
       m.firstPresentingFrame = false;
-      m.system.displayState.mLastSubmittedFrameSuccessful = m.browser.layerState[0].layer_stereo_immersive.mFrameId != 0;
+      m.system.displayState.mLastSubmittedFrameSuccessful = true;
       m.system.displayState.mLastSubmittedFrameId = m.browser.layerState[0].layer_stereo_immersive.mFrameId;
       // VRB_LOG("RequestFrame BREAK %llu",  m.browser.layerState[0].layer_stereo_immersive.mFrameId);
       break;


### PR DESCRIPTION
The big patch is here: https://bugzilla.mozilla.org/show_bug.cgi?id=1482613

Do not merge this until that patch lands.

The patch also has some benefits for non-multiprocess:

- Custom SurfaceTexture sets are used for WebVR, no more conflicts with the compositor SurfaceTextures. We can even enable the compositor and WebVR works. This will be useful for link traversal (we may need to enable the compositor in the transition)
- We no longed need to dettach SurfaceTextures at the end of the VR frame. 
- It might help with #121 (didn't try yet)

I tested the implementation with multiprocess and non-multiprocess on Oculus Go, Vive and Pixel 1.
