### PR TITLE
Compile fix for new onLoadError() GV API

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/SessionStore.java
@@ -697,12 +697,13 @@ public class SessionStore implements GeckoSession.NavigationDelegate, GeckoSessi
     }
 
     @Override
-    public void onLoadError(GeckoSession session, String uri, int category, int error) {
+    public GeckoResult<String> onLoadError(GeckoSession session, String uri, int category, int error) {
         Log.d(LOGTAG, "SessionStore onLoadError: " + uri);
 
         mLastUri = uri;
         InternalPages.PageResources pageResources = errorPageResourcesForCategory(category);
         session.loadData(InternalPages.createErrorPage(mContext, uri, pageResources, category, error), "text/html");
+        return null;
     }
 
     // Progress Listener

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
@@ -411,8 +411,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     @Override
-    public void onLoadError(GeckoSession session, String uri, int category, int error) {
-
+    public GeckoResult<String> onLoadError(GeckoSession session, String uri, int category, int error) {
+        return null;
     }
 
     public void release() {


### PR DESCRIPTION
The new GeckoView API has landed in nightly so update FxR so it will continue to compile on task cluster.