### PR TITLE
Add deadzone when clicking so that buttons are easier to activate

### DIFF
--- a/app/src/main/cpp/Controller.cpp
+++ b/app/src/main/cpp/Controller.cpp
@@ -52,6 +52,7 @@ Controller::operator=(const Controller& aController) {
   memcpy(immersiveAxes, aController.immersiveAxes, sizeof(immersiveAxes));
   numAxes = aController.numAxes;
   leftHanded = aController.leftHanded;
+  inDeadZone = aController.inDeadZone;
   return *this;
 }
 
@@ -78,6 +79,7 @@ Controller::Reset() {
   memset(immersiveAxes, 0, sizeof(immersiveAxes));
   numAxes = 0;
   leftHanded = false;
+  inDeadZone = true;
 }
 
 } // namespace crow

--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -41,6 +41,7 @@ struct Controller {
   float immersiveAxes[kControllerMaxAxes];
   uint32_t numAxes;
   bool leftHanded;
+  bool inDeadZone;
 
   Controller();
   Controller(const Controller& aController);


### PR DESCRIPTION
Clicking a button on controllers can cause them to move enough to cancel button presses. Add a deadzone when clicking to make button and link activation easier.