### PR TITLE
Enable Daydream WebVR swapchain

### DIFF
--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -155,8 +155,7 @@ struct DeviceDelegateGoogleVR::State {
   SetRenderMode(const device::RenderMode aMode) {
     if (aMode != renderMode) {
       renderMode = aMode;
-      // Fixme: GL_INVALID_OPERATION using a specific SurfaceTexture when we create a new SwapChain
-      // CreateSwapChain();
+      CreateSwapChain();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/MozillaReality/FirefoxReality/issues/121

Is not a problem anymore thanks to using a different  GLScreenBuffer for WebVR and not deatching our SurfaceTextures everyframe