### PR TITLE
Added multiprocess switch to Developer Panel

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/SettingsStore.java
@@ -33,6 +33,7 @@ public class SettingsStore {
     public final static boolean REMOTE_DEBUGGING_DEFAULT = false;
     public final static boolean CONSOLE_LOGS_DEFAULT = false;
     public final static boolean ENV_OVERRIDE_DEFAULT = false;
+    public final static boolean MULTIPROCESS_DEFAULT = false;
     public final static DeveloperOptionsWidget.UaMode UA_MODE_DEFAULT = DeveloperOptionsWidget.UaMode.VR;
     public final static DeveloperOptionsWidget.InputMode INPUT_MODE_DEFAULT = DeveloperOptionsWidget.InputMode.TOUCH;
     public final static float DISPLAY_DENSITY_DEFAULT = 1.0f;
@@ -127,6 +128,17 @@ public class SettingsStore {
     public void setEnvironmentOverrideEnabled(boolean isEnabled) {
         SharedPreferences.Editor editor = mPrefs.edit();
         editor.putBoolean(mContext.getString(R.string.settings_key_environment_override), isEnabled);
+        editor.commit();
+    }
+
+    public boolean isMultiprocessEnabled() {
+        return mPrefs.getBoolean(
+                mContext.getString(R.string.settings_key_multiprocess), MULTIPROCESS_DEFAULT);
+    }
+
+    public void setMultiprocessEnabled(boolean isEnabled) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putBoolean(mContext.getString(R.string.settings_key_multiprocess), isEnabled);
         editor.commit();
     }
 

--- a/app/src/main/res/layout/developer_options.xml
+++ b/app/src/main/res/layout/developer_options.xml
@@ -122,6 +122,33 @@
                     <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:text="@string/developer_options_multiprocess"
+                            android:textSize="14sp"
+                            android:textColor="@color/fog"
+                            android:layout_alignParentStart="true"
+                            android:layout_toStartOf="@id/developer_options_multiprocess_switch"/>
+                    <Switch
+                            android:id="@+id/developer_options_multiprocess_switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:switchMinWidth="0dp"
+                            android:textOff=""
+                            android:textOn=""
+                            android:track="@drawable/switch_track"
+                            android:thumb="@drawable/switch_thumb"
+                            android:layout_alignParentEnd="true"/>
+                </RelativeLayout>
+                <View
+                        android:layout_width="match_parent"
+                        android:layout_height="0.5dp"
+                        android:background="@color/fog"/>
+                <RelativeLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="60dp"
+                        android:gravity="center_vertical">
+                    <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
                             android:text="@string/developer_options_ua_mode"
                             android:textSize="14sp"
                             android:textColor="@color/fog"

--- a/app/src/main/res/values/non_I10n.xml
+++ b/app/src/main/res/values/non_I10n.xml
@@ -7,6 +7,7 @@
     <string name="settings_key_remote_debugging">settings_remote_debugging</string>
     <string name="settings_key_console_logs">settings_console_logs</string>
     <string name="settings_key_environment_override">settings_environment_override</string>
+    <string name="settings_key_multiprocess">settings_environment_multiprocess</string>
     <string name="settings_key_desktop_version">settings_desktop_version</string>
     <string name="settings_key_input_mode">settings_touch_mode</string>
     <string name="settings_key_display_density">settings_display_density</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="developer_options_remote_debugging">Enable Remote Debugging</string>
     <string name="developer_options_show_console">Redirect Console to Logcat</string>
     <string name="developer_options_env_override">Enable Environment Override</string>
+    <string name="developer_options_multiprocess">Enable Multiprocess</string>
     <string name="developer_options_ua_mode">User Agent Mode</string>
     <string name="developer_options_events">Input Events</string>
     <string name="developer_options_display_density">Display Density:</string>


### PR DESCRIPTION
Fixes #419 Added multiprocess dev panel switch. 

Wanted to avoid the session swapping and reuse the current session but I was always getting a crash due to underlying structs being null after reopening the session after a close.