### PR TITLE
Fix WebVR remote controller names

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -361,7 +361,7 @@ DeviceDelegateOculusVR::SetClipPlanes(const float aNear, const float aFar) {
 void
 DeviceDelegateOculusVR::SetControllerDelegate(ControllerDelegatePtr& aController) {
   m.controller = aController;
-  m.controller->CreateController(0, 0, "Gear VR Remote Controller");
+  m.controller->CreateController(0, 0, "Gear VR Controller");
   m.controller->SetButtonCount(0, 2);
 }
 

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -280,7 +280,7 @@ DeviceDelegateWaveVR::SetControllerDelegate(ControllerDelegatePtr& aController) 
     return;
   }
   for (int32_t index = 0; index < kMaxControllerCount; index++) {
-    m.delegate->CreateController(index, 0, "HTC Vive Focus Controller");
+    m.delegate->CreateController(index, 0, "Gear VR Controller");
   }
 }
 


### PR DESCRIPTION
`Gear VR Controller` is used in Oculus and Vive Focus
`Daydream Controller` is used in Daydream

Fixes  #434