### PR TITLE
Enable custom elements preference

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/SessionStore.java
@@ -563,6 +563,7 @@ public class SessionStore implements GeckoSession.NavigationDelegate, GeckoSessi
             out.write("pref(\"dom.vr.external.enabled\", true);\n".getBytes());
             out.write("pref(\"webgl.enable-surface-texture\", true);\n".getBytes());
             out.write("pref(\"apz.allow_double_tap_zooming\", false);\n".getBytes());
+            out.write("pref(\"dom.webcomponents.customelements.enabled\", false);\n".getBytes());
         } catch (FileNotFoundException e) {
             Log.e(LOGTAG, "Unable to create file: '" + prefFileName + "' got exception: " + e.toString());
         } catch (IOException e) {


### PR DESCRIPTION
Enabling this may help aframe persomance. A-frame uses a polyfill is custom elements is not availabe, which adds overhead in a lot of calls.

