### PR TITLE
Implement history and expose it to content feed

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/History.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/History.java
@@ -1,0 +1,210 @@
+package org.mozilla.vrbrowser;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Base64;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.GeckoSessionSettings;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+
+public class History implements GeckoSession.ProgressDelegate {
+    private HashMap<String, Item> mItems;
+    private static final int MAX_ITEMS = 30;
+    private static final String LOGTAG = "VRB";
+    private static final String FILENAME = "history.json";
+
+    private Context mContext;
+
+    public static class Item {
+        String url;
+        String title;
+        long timestamp;
+
+        Item() {
+            timestamp = System.currentTimeMillis();
+        }
+
+        Item(JSONObject aObject) {
+            url = aObject.optString("u", "");
+            title = aObject.optString("n", "");
+            timestamp = aObject.optLong("t", System.currentTimeMillis());
+        }
+
+        JSONObject toJSON() {
+            JSONObject obj = new JSONObject();
+            try {
+                obj.put("u", url);
+                obj.put("n", title);
+                obj.put("t", timestamp);
+            }
+            catch (JSONException ex) {
+            }
+            return obj;
+        }
+    }
+
+    public History(Context aContext) {
+        mContext = aContext;
+        mItems = new HashMap<>();
+        SessionStore.get().addProgressListener(this);
+        restore();
+    }
+
+    public void updateContext(Context aContext) {
+        mContext = aContext;
+    }
+
+    public void release() {
+        SessionStore.get().removeProgressListener(this);
+    }
+
+    public String encodedJSON() {
+        String value = getJSONString();
+        String base64 = Base64.encodeToString(value.getBytes(), 0);
+        return Uri.encode(base64);
+    }
+
+    public void clear() {
+        mItems.clear();
+        save();
+    }
+
+    private void save() {
+        JSONArray array = new JSONArray();
+        for (Item item: mItems.values()) {
+            array.put(item.toJSON());
+        }
+
+        try (FileWriter file = new FileWriter(mContext.getFilesDir().getAbsolutePath() + "/" + FILENAME)) {
+            file.write(getJSONString());
+        }
+        catch (Exception ex) {
+            Log.e(LOGTAG, "Error saving history", ex);
+        }
+    }
+
+    private void restore() {
+        try (BufferedReader reader = new BufferedReader(new FileReader(mContext.getFilesDir().getAbsolutePath() + "/" + FILENAME))) {
+            StringBuilder sb = new StringBuilder();
+            String line = reader.readLine();
+
+            while (line != null) {
+                sb.append(line);
+                sb.append("\n");
+                line = reader.readLine();
+            }
+            try {
+                JSONArray array = new JSONArray(sb.toString());
+                mItems.clear();
+                for (int i = 0; i < array.length(); ++i) {
+                    Item item = new Item(array.getJSONObject(i));
+                    if (item.url != null && item.url.length() > 0) {
+                        mItems.put(key(item.url), item);
+                    }
+                }
+
+            } catch (JSONException e) {
+                Log.e(LOGTAG, "Error parsing history", e);
+            }
+        }
+        catch (Exception ex) {
+            Log.e(LOGTAG, "Error reading history", ex);
+        }
+    }
+
+    private String getJSONString() {
+        JSONArray array = new JSONArray();
+        for (Item item: mItems.values()) {
+            array.put(item.toJSON());
+        }
+        return array.toString();
+    }
+
+    private String key(String aUri) {
+        String result = aUri.toLowerCase();
+        int index = result.indexOf('#');
+        if (index >= 0) {
+            result = result.substring(0, index);
+        }
+        return result;
+    }
+
+    private void checkMaxSize() {
+        if (mItems.size() <= MAX_ITEMS) {
+            return;
+        }
+
+        ArrayList<Item> list = new ArrayList<>(mItems.values());
+        list.sort(new Comparator<Item>() {
+            @Override
+            public int compare(Item o1, Item o2) {
+                return (int)(o1.timestamp - o2.timestamp);
+            }
+        });
+
+        for (Item item: list) {
+            mItems.remove(key(item.url));
+            if (mItems.size() >= MAX_ITEMS) {
+                return;
+            }
+        }
+    }
+
+    // GeckoSession.ProgressDelegate
+
+    @Override
+    public void onPageStart(GeckoSession geckoSession, String s) {
+
+    }
+
+    @Override
+    public void onPageStop(GeckoSession geckoSession, boolean b) {
+        String uri = SessionStore.get().getUriFromSession(geckoSession);
+        if (uri == null || uri.length() == 0) {
+            return;
+        }
+        if (SessionStore.get().isHomeUri(uri)) {
+            return;
+        }
+        if (geckoSession.getSettings().getBoolean(GeckoSessionSettings.USE_PRIVATE_MODE)) {
+            // Do not store private mode history
+            return;
+        }
+
+        Item item = mItems.get(key(uri));
+        if (item == null) {
+            item = new Item();
+            item.url = uri;
+            mItems.put(key(uri), item);
+            checkMaxSize();
+        }
+
+        item.url = uri;
+        item.title = SessionStore.get().getTitleFromSession(geckoSession);
+        item.timestamp = System.currentTimeMillis();
+        save();
+    }
+
+    @Override
+    public void onProgressChange(GeckoSession geckoSession, int i) {
+
+    }
+
+    @Override
+    public void onSecurityChange(GeckoSession geckoSession, SecurityInformation securityInformation) {
+
+    }
+
+
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -263,7 +263,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             mPermissionDelegate.release();
         }
 
-        SessionStore.get().clearListeners();
+        SessionStore.get().onDestroy();
         super.onDestroy();
     }
 


### PR DESCRIPTION
Example URL
`https://webxr.today/?history=W3sidSI6ImFib3V0OmJsYW5rIiwibiI6IiIsInQiOjE1MzU3Mjc1ODE5NDR9LHsidSI6Imh0dHBz%0AOlwvXC9hZnJhbWUuaW9cLyIsIm4iOiJBLUZyYW1lIOKAkyBNYWtlIFdlYlZSIiwidCI6MTUzNTcy%0ANzQxODc5OX0seyJ1IjoiaHR0cHM6XC9cL3dlYnZyLmluZm9cL3NhbXBsZXNcLyIsIm4iOiJXZWJW%0AUiAtIFNhbXBsZXMiLCJ0IjoxNTM1NzI3NDU5NjQ0fSx7InUiOiJodHRwczpcL1wvYWZyYW1lLmlv%0AXC9leGFtcGxlc1wvIiwibiI6IkhlbGxvIFdlYlZSIOKAkyBBLUZyYW1lIiwidCI6MTUzNTcyNzQy%0AMjQ3Nn0seyJ1IjoiaHR0cHM6XC9cL3d3dy5nb29nbGUuY29tXC9zZWFyY2g%2FcT13ZWJ2ciUyMHNh%0AbXBsZXMmaWU9dXRmLTgmb2U9dXRmLTgma2V5d29yZD1maXJlZm94LWItYWImc2VhcmNoYmFyPWZp%0AcmVmb3gtYiIsIm4iOiJ3ZWJ2ciBzYW1wbGVzIC0gQnVzY2FyIGNvbiBHb29nbGUiLCJ0IjoxNTM1%0ANzI3NDUwNDEzfV0%3D%0A`

If we decode history parameter from urlEncoded base64

`[{"u":"about:blank","n":"","t":1535727581944},{"u":"https:\/\/aframe.io\/","n":"A-Frame – Make WebVR","t":1535727418799},{"u":"https:\/\/webvr.info\/samples\/","n":"WebVR - Samples","t":1535727459644},{"u":"https:\/\/aframe.io\/examples\/","n":"Hello WebVR – A-Frame","t":1535727422476},{"u":"https:\/\/www.google.com\/search?q=webvr%20samples&ie=utf-8&oe=utf-8&keyword=firefox-b-ab&searchbar=firefox-b","n":"webvr samples - Buscar con Google","t":1535727450413}]`

Fixes https://github.com/MozillaReality/FirefoxReality/issues/443

Notes: To clear the history the content feed can filter based on timestamps


