### PR TITLE
Switch from local test signing to Mozilla signing

### DIFF
--- a/tools/taskcluster/sign.sh
+++ b/tools/taskcluster/sign.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-python tools/taskcluster/fetch_secret.py -s project/firefoxreality/preview-keystore -d -o keystore.jks -n store
-python tools/taskcluster/fetch_secret.py -s project/firefoxreality/keystore-password -o keystore_password -n password
-python tools/taskcluster/fetch_secret.py -s project/firefoxreality/key-password -o key_password -n password
-python tools/taskcluster/sign_apk.py -s keystore.jks -p keystore_password -k key_password -a FirefoxRealityTestKey
+python tools/taskcluster/fetch_secret.py -s project/firefoxreality/autograph_token -o token -n password
+python tools/taskcluster/sign_apk.py -t token
 python tools/taskcluster/archive_debug_apk.py

--- a/tools/taskcluster/sign_apk.py
+++ b/tools/taskcluster/sign_apk.py
@@ -12,27 +12,18 @@ import subprocess
 import sys
 
 def main(name, argv):
-   store = ''
-   store_password = ''
-   key_password = ''
-   alias_name = '';
+   token = ''
    try:
-      opts, args = getopt.getopt(argv,"hs:p:k:a:")
+      opts, args = getopt.getopt(argv,"ht:")
    except getopt.GetoptError:
-      print name + '-s <key store file> -p <key store password file> -k <key password file> -a <key alias>'
+      print name + '-t <token>'
       sys.exit(2)
    for opt, arg in opts:
       if opt == '-h':
-         print name + '-s <key store file> -p <key store password file> -k <key password file> -a <key alias>'
+         print name + '-t <token>'
          sys.exit()
-      elif opt in ("-s"):
-         store = arg
-      elif opt in ("-p"):
-         store_password = arg
-      elif opt in ("-k"):
-         key_password = arg
-      elif opt in ("-a"):
-         alias_name = arg
+      elif opt in ("-t"):
+         token = arg
 
    build_output_path = './app/build/outputs/apk'
 
@@ -45,16 +36,11 @@ def main(name, argv):
    for apk in glob.glob(build_output_path + "/*/*/*-aligned.apk"):
       print "Signing", apk
       print subprocess.check_output([
-           "apksigner", "sign",
-           "--v1-signing-enabled", "true",
-           "--v2-signing-enabled", "false",
-           "--ks", store,
-           "--ks-key-alias", alias_name,
-           "--ks-pass", "file:" + store_password,
-           "--key-pass", "file:" + key_password,
-           "-v",
-           "--out", apk.replace('unsigned', 'signed'),
-           apk])
+           "curl",
+           "-F", "input=@" + apk,
+           "-o", apk.replace('unsigned', 'signed'),
+           "-H", "Authorization: " + token,
+           "https://autograph-edge.prod.mozaws.net/sign"])
 
    # Create folder for saving build artifacts
    artifacts_path = './builds'


### PR DESCRIPTION
Fixes #408

Before landing this, I'll need to get the official production `AUTOGRAPH_EDGE_TOKEN` into the taskcluster secrets. This works locally and produces a build that passes signing and installs & runs cleanly on the Go.

I'd still love any suggestions for fixups!

This uses the default recommended CI method ("just use `curl`") the webops team recommended to me, linked from:
https://mozilla.github.io/application-services/docs/applications/signing-android-apps.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozillareality/firefoxreality/468)
<!-- Reviewable:end -->
