### PR TITLE
Remove keyboards back handler when it's dismissed

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/KeyboardWidget.java
@@ -241,6 +241,8 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
        mWidgetPlacement.visible = false;
        mWidgetManager.updateWidget(this);
 
+       mWidgetManager.popBackHandler(mBackHandler);
+
        mIsCapsLock = false;
        mIsLongPress = false;
        handleShift(false);


### PR DESCRIPTION
Fixes #530 Remove the keyboard back handler when it's dismissed. We were only removing the back handler if there was a focus change.