### PR TITLE
Only add launcher category intent for debug builds. 

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.mozilla.vrbrowser">
+
+    <application android:name=".VRBrowserApplication">
+        <activity android:name=".VRBrowserActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>
+                <category android:name="android.intent.category.APP_BROWSER" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.INFO" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/googlevr/AndroidManifest.xml
+++ b/app/src/googlevr/AndroidManifest.xml
@@ -13,12 +13,7 @@
     <application>
         <activity android:name=".VRBrowserActivity"
             android:screenOrientation="landscape"
-            android:enableVrMode="@string/gvr_vr_mode_component"
-            android:resizeableActivity="false"
-            android:launchMode="singleInstance"
-            android:windowSoftInputMode="stateAlwaysHidden"
-            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|navigation"
-            tools:node="replace">
+            android:enableVrMode="@string/gvr_vr_mode_component">
             <meta-data android:name="com.google.android.vr.icon"
                 android:resource="@drawable/ffgvr_foreground" />
             <meta-data android:name="com.google.android.vr.icon_background"
@@ -27,7 +22,6 @@
             <!-- Intent filter that enables this app to be launched from the Daydream Home menu. -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="com.google.intent.category.DAYDREAM"/>
             </intent-filter>
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,23 +18,13 @@
         <activity
             android:name=".VRBrowserActivity"
             android:launchMode="singleInstance"
-            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|navigation"
+            android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode"
             android:windowSoftInputMode="stateAlwaysHidden"
             >
-
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-                <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>
-                <category android:name="android.intent.category.APP_BROWSER" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.INFO" />
-            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <category android:name="android.intent.category.LAUNCHER" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>


### PR DESCRIPTION
This prevents FxR icon from being shown in 2D icon list in Daydream phones

It also fixes duplicated daydream activity issues when launched from 2D :)