### PR TITLE
Update APK names generated on taskcluster

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,6 @@ def getGitHash = { ->
 }
 
 android {
-    project.archivesBaseName = "FirefoxReality"
     compileSdkVersion 27
     defaultConfig {
         applicationId "org.mozilla.vrbrowser"
@@ -32,6 +31,11 @@ android {
                 arguments "-DANDROID_STL=c++_shared"
             }
         }
+    }
+    if (gradle.hasProperty('taskclusterBuild')) {
+        project.archivesBaseName = "FirefoxReality-$defaultConfig.versionName-$generatedVersionCode"
+    } else {
+        project.archivesBaseName = "FirefoxReality"
     }
     buildTypes {
         release {

--- a/tools/taskcluster/sign_apk.py
+++ b/tools/taskcluster/sign_apk.py
@@ -14,19 +14,21 @@ import sys
 def main(name, argv):
    token = ''
    sign_url = 'https://autograph-edge.stage.mozaws.net/sign'
+   release = False
    try:
       opts, args = getopt.getopt(argv,"ht:r")
    except getopt.GetoptError:
-      print name + '-s <key store file> -p <key store password file> -k <key password file> -a <key alias>'
+      print name + '-t <token file name> -r'
       sys.exit(2)
    for opt, arg in opts:
       if opt == '-h':
-         print name + '-t <token file name>'
+         print name + '-t <token file name> -r'
          sys.exit()
       elif opt in ("-t"):
          token = arg
       elif opt in ('-r'):
          sign_url = 'https://autograph-edge.prod.mozaws.net/sign'
+         release = True
 
    build_output_path = './app/build/outputs/apk'
 
@@ -38,6 +40,8 @@ def main(name, argv):
    # Sign APKs
    for apk in glob.glob(build_output_path + "/*/*/*-aligned.apk"):
       print "Signing", apk
+      if not release:
+         apk = apk.replace('release', 'staging')
       print subprocess.check_output([
            "curl",
             "-F", "input=@" + apk,


### PR DESCRIPTION
APK file names should now contain version name and version code and staging builds should
now have staging in the name instead of release.