### PR TITLE
Fix spinner during link traversal

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -165,7 +165,7 @@ struct ExternalVR::State {
     memcpy(&browser, &data.browserState, sizeof(mozilla::gfx::VRBrowserState));
 
 
-    if (!wasPresenting && IsPresenting()) {
+    if ((!wasPresenting && IsPresenting()) || browser.navigationTransitionActive) {
       firstPresentingFrame = true;
     }
     if (wasPresenting && !IsPresenting()) {


### PR DESCRIPTION
This PR fixes the spinner during link traversal and for the first frame after link traversal.

We need to land this to make link traversal work reliably: https://phabricator.services.mozilla.com/D6921 but this PR is not blocked by that GV patch

I use this sample for testing: https://webvr.info/samples/test-vr-links.html