### PR TITLE
Support intent preferences for benchmarks

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -80,7 +80,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             workaroundGeckoSigAction();
         }
         mUiThread = Thread.currentThread();
-        SessionStore.get().setContext(this);
+
+        Bundle extras = getIntent() != null ? getIntent().getExtras() : null;
+        SessionStore.get().setContext(this, extras);
 
         mLastGesture = NoGesture;
         super.onCreate(savedInstanceState);
@@ -229,7 +231,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     void loadFromIntent(final Intent intent) {
-        final Uri uri = intent.getData();
+        Uri uri = intent.getData();
+        if (uri == null && intent.getExtras() != null && intent.getExtras().containsKey("url")) {
+            uri = Uri.parse(intent.getExtras().getString("url"));
+        }
         if (SessionStore.get().getCurrentSession() == null) {
             String url = (uri != null ? uri.toString() : null);
             int id = SessionStore.get().createSession();


### PR DESCRIPTION
Usage:

Ensure that the app is killed (GeckoView doesn't support changing preferences at runtime yet)
`adb shell am force-stop org.mozilla.vrbrowser`

Launch intent with the desided preference values. We have only exposed vr-user gesture and timer precision for now.

`adb shell am start -n  org.mozilla.vrbrowser/.VRBrowserActivity --es url "https://aframe.io" --ez dom.vr.require-gesture false --ez privacy.reduceTimerPrecision false`


Note, extra parameters don't work when using the android.intent.action.VIEW. That's why I added the optional `url` parameter.

`adb shell am start -a android.intent.action.VIEW -d "https://aframe.io" org.mozilla.vrbrowser/.VRBrowserActivity`
