### PR TITLE
Check for a null URI in the TelemertryWrapper when page is stopped.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -207,6 +207,9 @@ public class TelemetryWrapper {
             return;
         }
 
+        if (uri == null)
+            return;
+
         URI uriLink = URI.create(uri);
         if (uriLink.getHost() == null) {
             return;


### PR DESCRIPTION
Fixes #589 Added URI null check to TelemetryWrapper for uploadPageLoadToHistogram

STR:
- Open any page that triggers a new session creation i.e. window.open
- When the new session is opened the app shouldn't crash anymore