### PR TITLE
Update telemetry app name to be FLAVOR_platform.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -86,7 +86,7 @@ public class TelemetryWrapper {
             final boolean telemetryEnabled = SettingsStore.getInstance(aContext).isTelemetryEnabled();
             final TelemetryConfiguration configuration = new TelemetryConfiguration(aContext)
                     .setServerEndpoint("https://incoming.telemetry.mozilla.org")
-                    .setAppName(APP_NAME + "_" + BuildConfig.FLAVOR)
+                    .setAppName(APP_NAME + "_" + BuildConfig.FLAVOR_platform)
                     .setUpdateChannel(BuildConfig.BUILD_TYPE)
                     .setPreferencesImportantForTelemetry(resources.getString(R.string.settings_key_locale))
                     .setCollectionEnabled(telemetryEnabled)


### PR DESCRIPTION
We changed the behavior of BuildConfig.FLAVOR recently. We should update our telemetry app name to be FLAVOR_platform.