### PR TITLE
Added a Java global exception handler

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/GlobalExceptionHandler.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.mozilla.vrbrowser;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import org.mozilla.gecko.CrashHandler;
+
+public class GlobalExceptionHandler {
+
+    private static final String LOGTAG = "VRB";
+
+    private static GlobalExceptionHandler mInstance;
+
+    public static synchronized @NonNull
+    GlobalExceptionHandler register() {
+        if (mInstance == null) {
+            mInstance = new GlobalExceptionHandler();
+            mInstance.mCrashHandler = new CrashHandler(CrashReporterService.class);
+            Log.d(LOGTAG, "======> GlobalExceptionHandler registered");
+        }
+
+        return mInstance;
+    }
+
+    private CrashHandler mCrashHandler;
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -95,6 +95,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Set a global exception handler as soon as possible
+        GlobalExceptionHandler.register();
+
         if (BuildConfig.FLAVOR_platform == "oculusvr") {
             workaroundGeckoSigAction();
         }


### PR DESCRIPTION
Fixes #592 Set a global Java exception handler using Gecko's CrashHandler implementation. Should catch any exception including OOMs happening in any thread from the current process. 

Regarding @cvan's comment on #592 the CrashHandler seems to be sending reports to **https://crash-reports.mozilla.com/**, not sure if that's the right place for it or we should  extend that to use another endpoint (he mentioned Sentry).