### PR TITLE
Support added for loading local files through file:// handler (loadUri/reload)

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/PermissionDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/PermissionDelegate.java
@@ -1,8 +1,11 @@
 package org.mozilla.vrbrowser;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 import org.mozilla.geckoview.GeckoSession;
@@ -54,7 +57,7 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
         }
     }
 
-    private void handleContentPermission(final String aUri, final PermissionWidget.PermissionType aType, final Callback aCallback) {
+    public void handlePermission(final String aUri, final PermissionWidget.PermissionType aType, final Callback aCallback) {
         if (mPermissionWidget == null) {
             mPermissionWidget = new PermissionWidget(mContext);
             mPermissionWidget.getPlacement().parentHandle = mParentWidgetHandle;
@@ -122,7 +125,7 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
             return;
         }
 
-        handleContentPermission(aUri, type, callback);
+        handlePermission(aUri, type, callback);
     }
 
     @Override
@@ -155,6 +158,51 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
             }
         };
 
-        handleContentPermission(aUri, type, callback);
+        handlePermission(aUri, type, callback);
+    }
+
+    public boolean isPermissionGranted(@NonNull String permission) {
+        return ContextCompat.checkSelfPermission(mContext, permission) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    // Handle app permissions that Gecko doesn't handle itself yet
+    public void onAppPermissionRequest(final GeckoSession aSession, String aUri, final String permission, final Callback callback) {
+        Log.d(LOGTAG, "onAppPermissionRequest: " + aUri);
+
+        // If the permission is already granted we just grant
+        if (ContextCompat.checkSelfPermission(mContext, permission) != PackageManager.PERMISSION_GRANTED) {
+
+            // Check if we support a rationale for that permission
+            PermissionWidget.PermissionType type = null;
+            if (permission.equals(Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                type = PermissionWidget.PermissionType.ReadExternalStorage;
+            }
+
+            if (type != null) {
+                // Show rationale
+                handlePermission(aUri, type, new Callback() {
+                    @Override
+                    public void grant() {
+                        onAndroidPermissionsRequest(aSession, new String[]{permission}, callback);
+                    }
+
+                    @Override
+                    public void reject() {
+                        if (callback != null) {
+                            callback.reject();
+                        }
+                    }
+                });
+
+            } else {
+                // Let Android handle the permission request
+                onAndroidPermissionsRequest(aSession, new String[]{permission}, callback);
+            }
+
+        } else {
+            if (callback != null) {
+                callback.grant();
+            }
+        }
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -22,6 +22,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
+
 import org.mozilla.gecko.GeckoVRManager;
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.geckoview.CrashReporter;
@@ -30,7 +31,13 @@ import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.audio.VRAudioTheme;
 import org.mozilla.vrbrowser.search.SearchEngine;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
-import org.mozilla.vrbrowser.ui.*;
+import org.mozilla.vrbrowser.ui.BrowserWidget;
+import org.mozilla.vrbrowser.ui.CrashDialogWidget;
+import org.mozilla.vrbrowser.ui.KeyboardWidget;
+import org.mozilla.vrbrowser.ui.NavigationBarWidget;
+import org.mozilla.vrbrowser.ui.OffscreenDisplay;
+import org.mozilla.vrbrowser.ui.TopBarWidget;
+import org.mozilla.vrbrowser.ui.TrayWidget;
 
 import java.io.IOException;
 import java.net.URISyntaxException;

--- a/app/src/common/shared/org/mozilla/vrbrowser/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/WidgetManagerDelegate.java
@@ -1,7 +1,5 @@
 package org.mozilla.vrbrowser;
 
-import android.support.annotation.Nullable;
-
 public interface WidgetManagerDelegate {
     interface Listener {
         void onWidgetUpdate(Widget aWidget);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.ui;
 
 import android.content.Context;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -399,7 +400,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             Log.d(LOGTAG, "Got onLoadUri");
             mURLBar.setURL(aUri);
         }
-        return null;
+
+        return GeckoResult.fromValue(true);
     }
 
     // Progress Listener

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/PermissionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/PermissionWidget.java
@@ -41,7 +41,8 @@ public class PermissionWidget extends UIWidget {
         Microphone,
         CameraAndMicrophone,
         Location,
-        Notification
+        Notification,
+        ReadExternalStorage
     }
 
     public PermissionWidget(Context aContext) {
@@ -127,6 +128,10 @@ public class PermissionWidget extends UIWidget {
                 break;
             case Notification:
                 messageId = R.string.permission_notification;
+                iconId = R.drawable.ic_icon_dialog_notification;
+                break;
+            case ReadExternalStorage:
+                messageId = R.string.permission_read_external_storage;
                 iconId = R.drawable.ic_icon_dialog_notification;
                 break;
             default:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,11 +6,11 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-
-    <permission android:name="org.mozilla.vrbrowser.CRASH_RECEIVER_PERMISSION"
-                android:protectionLevel="signature">
-    </permission>
     <uses-permission android:name="org.mozilla.vrbrowser.CRASH_RECEIVER_PERMISSION"/>
+
+    <permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <permission android:name="org.mozilla.vrbrowser.CRASH_RECEIVER_PERMISSION"
+                android:protectionLevel="signature"/>
 
     <application
         android:name=".VRBrowserApplication"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
     <string name="permission_location">Will you allow %1$s to access your location?</string>
     <!-- Parameter will be replaced with the app name -->
     <string name="permission_notification">Will you allow %1$s to send notifications?</string>
+    <!-- Parameter will be replaced with the app name -->
+    <string name="permission_read_external_storage">Will you allow %1$s to read you external storage?</string>
     <string name="speak_now">Speak now</string>
     <string name="settings_version">version %1$s</string>
     <string name="settings_crash_reporting">Crash Reporting</string>


### PR DESCRIPTION
Fixes #594 Added support for general app permissions (outside Gecko) handling and support for loading content from external storage upon loadUri/reload.

See https://github.com/MozillaReality/FirefoxReality/issues/594#issuecomment-427354841