### PR TITLE
Use Mozilla Android Components 0.26.0 from maven.mozilla.org.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -223,7 +223,7 @@ dependencies {
     svrImplementation fileTree(dir: "${project.rootDir}/third_party/svr/", include: ['*.jar'])
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.google.vr:sdk-audio:1.170.0'
-    implementation "org.mozilla.components:telemetry:0.23"
+    implementation "org.mozilla.components:service-telemetry:0.26.0"
     implementation "com.github.mozilla:mozillaspeechlibrary:1.0.4"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,10 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-
         maven {
             url 'https://maven.mozilla.org/maven2'
         }
+        jcenter()
     }
 }
 


### PR DESCRIPTION
* Updates the version used to 0.26.0
* Updates the artifacts to use the new names

During the migration phase from JCenter to maven.mozilla.org (artifacts get published on both) maven.mozilla.org needs to be listed before JCenter to avoid dependency resolution conflicts.