### PR TITLE
Improved focus handling

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -421,7 +421,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             @Override
             public void run() {
                 Widget widget = mWidgets.get(aHandle);
-                MotionEventGenerator.dispatch(widget, aDevice, aPressed, aX, aY);
+                if (widget == null) {
+                    for (FocusChangeListener listener: mFocusChangeListeners) {
+                        listener.onGlobalFocusChanged(null, null);
+                    }
+
+                } else {
+                    MotionEventGenerator.dispatch(widget, aDevice, aPressed, aX, aY);
+                }
             }
         });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/WidgetManagerDelegate.java
@@ -1,24 +1,28 @@
 package org.mozilla.vrbrowser;
 
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
+import android.view.View;
 
 public interface WidgetManagerDelegate {
-    interface Listener {
+    interface UpdateListener {
         void onWidgetUpdate(Widget aWidget);
     }
     interface PermissionListener {
         void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
     }
+    interface FocusChangeListener {
+        void onGlobalFocusChanged(View oldFocus, View newFocus);
+    }
     int newWidgetHandle();
-    void addWidget(Widget aWidget);
-    void updateWidget(Widget aWidget);
-    void removeWidget(Widget aWidget);
-    void startWidgetResize(Widget aWidget);
-    void finishWidgetResize(Widget aWidget);
-    void addListener(WidgetManagerDelegate.Listener aListener);
-    void removeListener(WidgetManagerDelegate.Listener aListener);
-    void pushBackHandler(Runnable aRunnable);
-    void popBackHandler(Runnable aRunnable);
+    void addWidget(@NonNull Widget aWidget);
+    void updateWidget(@NonNull Widget aWidget);
+    void removeWidget(@NonNull Widget aWidget);
+    void startWidgetResize(@NonNull Widget aWidget);
+    void finishWidgetResize(@NonNull Widget aWidget);
+    void addUpdateListener(@NonNull UpdateListener aUpdateListener);
+    void removeUpdateListener(@NonNull UpdateListener aUpdateListener);
+    void pushBackHandler(@NonNull Runnable aRunnable);
+    void popBackHandler(@NonNull Runnable aRunnable);
     void fadeOutWorld();
     void fadeInWorld();
     void setTrayVisible(boolean visible);
@@ -26,6 +30,8 @@ public interface WidgetManagerDelegate {
     void keyboardDismissed();
     void updateEnvironment();
     void updatePointerColor();
-    void addPermissionListener(PermissionListener aListener);
-    void removePermissionListener(PermissionListener aListener);
+    void addPermissionListener(@NonNull PermissionListener aListener);
+    void removePermissionListener(@NonNull PermissionListener aListener);
+    void addFocusChangeListener(@NonNull FocusChangeListener aListener);
+    void removeFocusChangeListener(@NonNull FocusChangeListener aListener);
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/DeveloperOptionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/DeveloperOptionsWidget.java
@@ -332,6 +332,8 @@ public class DeveloperOptionsWidget extends UIWidget {
     }
 
     private void showRestartDialog() {
+        hide();
+
         UIWidget widget = getChild(mRestartDialogHandle);
         if (widget == null) {
             widget = createChild(RestartDialogWidget.class, false);
@@ -339,8 +341,6 @@ public class DeveloperOptionsWidget extends UIWidget {
         }
 
         widget.show();
-
-        hide();
     }
 
     private CompoundButton.OnCheckedChangeListener mRemoteDebuggingListener = new CompoundButton.OnCheckedChangeListener() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/KeyboardWidget.java
@@ -27,11 +27,14 @@ import android.widget.RelativeLayout;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.SessionStore;
+import org.mozilla.vrbrowser.Widget;
+import org.mozilla.vrbrowser.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.WidgetPlacement;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 
 
-public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKeyboardActionListener, GeckoSession.TextInputDelegate {
+public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKeyboardActionListener,
+        GeckoSession.TextInputDelegate, WidgetManagerDelegate.FocusChangeListener {
 
     private static final String LOGTAG = "VRB";
 
@@ -79,6 +82,8 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     private void initialize(Context aContext) {
         inflate(aContext, R.layout.keyboard, this);
+
+        mWidgetManager.addFocusChangeListener(this);
 
         mKeyboardview = findViewById(R.id.keyboard);
         mPopupKeyboardview = findViewById(R.id.popupKeyboard);
@@ -177,6 +182,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     @Override
     public void releaseWidget() {
+        mWidgetManager.removeFocusChangeListener(this);
         SessionStore.get().removeTextInputListener(this);
         mBrowserWidget = null;
         super.releaseWidget();
@@ -598,5 +604,12 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     @Override
     public void notifyAutoFill(GeckoSession session, int notification, int virtualId) {
 
+    }
+
+    // FocusChangeListener
+
+    @Override
+    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+        updateFocusedView(newFocus);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationBarWidget.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 
 public class NavigationBarWidget extends UIWidget implements GeckoSession.NavigationDelegate,
         GeckoSession.ProgressDelegate, GeckoSession.ContentDelegate,
-        WidgetManagerDelegate.Listener, SessionStore.SessionChangeListener,
+        WidgetManagerDelegate.UpdateListener, SessionStore.SessionChangeListener,
         NavigationURLBar.NavigationURLBarDelegate, VoiceSearchWidget.VoiceSearchDelegate {
 
     private static final String LOGTAG = "VRB";
@@ -90,6 +90,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mBackButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+                requestFocusFromTouch();
                 if (SessionStore.get().canGoBack())
                     SessionStore.get().goBack();
                 else if (SessionStore.get().canUnstackSession())
@@ -104,6 +105,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mForwardButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+                requestFocusFromTouch();
                 SessionStore.get().goForward();
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -114,6 +116,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mReloadButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+                requestFocusFromTouch();
                 if (mIsLoading) {
                     SessionStore.get().stop();
                 } else {
@@ -128,6 +131,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mHomeButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
+                requestFocusFromTouch();
                 SessionStore.get().loadUri(SessionStore.get().getHomeUri());
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -145,6 +149,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mResizeEnterButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 enterResizeMode();
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -155,6 +160,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mResizeExitButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 exitResizeMode(true);
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -165,6 +171,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mPreset0.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 setResizePreset(0.5f);
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -175,6 +182,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mPreset1.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 setResizePreset(1.0f);
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -185,6 +193,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mPreset2.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 setResizePreset(2.0f);
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -195,6 +204,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mPreset3.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 setResizePreset(3.0f);
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -212,7 +222,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         SessionStore.get().addNavigationListener(this);
         SessionStore.get().addProgressListener(this);
         SessionStore.get().addContentListener(this);
-        mWidgetManager.addListener(this);
+        mWidgetManager.addUpdateListener(this);
 
         mVoiceSearchWidget = createChild(VoiceSearchWidget.class, false);
         mVoiceSearchWidget.setDelegate(this);
@@ -222,7 +232,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void releaseWidget() {
-        mWidgetManager.removeListener(this);
+        mWidgetManager.removeUpdateListener(this);
         SessionStore.get().removeNavigationListener(this);
         SessionStore.get().removeProgressListener(this);
         SessionStore.get().removeContentListener(this);
@@ -491,7 +501,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     }
 
-    // WidgetManagerDelegate.Listener
+    // WidgetManagerDelegate.UpdateListener
     @Override
     public void onWidgetUpdate(Widget aWidget) {
         if (aWidget != mBrowserWidget || mIsResizing) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/NavigationURLBar.java
@@ -108,7 +108,6 @@ public class NavigationURLBar extends FrameLayout {
         mURLWebsiteColor = typedValue.data;
 
         // Prevent the URL TextEdit to get focus when user touches something outside of it
-        setFocusable(true);
         setFocusableInTouchMode(true);
         setClickable(true);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsButton.java
@@ -40,7 +40,6 @@ public class SettingsButton extends LinearLayout {
         inflate(aContext, R.layout.settings_btn, this);
 
         setClickable(true);
-        setFocusable(true);
 
         mIcon = findViewById(R.id.settings_button_icon);
         if (mIcon != null)

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/SettingsWidget.java
@@ -29,6 +29,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 public class SettingsWidget extends UIWidget {
+
     private static final String LOGTAG = "VRB";
 
     private AudioEngine mAudio;
@@ -187,6 +188,11 @@ public class SettingsWidget extends UIWidget {
     }
 
     @Override
+    public void releaseWidget() {
+        super.releaseWidget();
+    }
+
+    @Override
     protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
         aPlacement.visible = false;
         aPlacement.width =  WidgetPlacement.dpDimension(getContext(), R.dimen.settings_width);
@@ -252,8 +258,6 @@ public class SettingsWidget extends UIWidget {
 
     private void onDeveloperOptionsClick() {
         showDeveloperOptionsDialog();
-
-        hide();
     }
 
     /**
@@ -306,6 +310,8 @@ public class SettingsWidget extends UIWidget {
     }
 
     private void showDeveloperOptionsDialog() {
+        hide();
+
         UIWidget widget = getChild(mDeveloperOptionsDialogHandle);
         if (widget == null) {
             widget = createChild(DeveloperOptionsWidget.class, false);
@@ -313,20 +319,13 @@ public class SettingsWidget extends UIWidget {
         }
 
         widget.show();
-
-        hide();
     }
 
     @Override
     public void toggle() {
-        for (UIWidget child : mChildren.values()) {
-            if (child.getPlacement().visible)
-                return;
-        }
-
         super.toggle();
 
-        if (!mWidgetPlacement.visible)
+        if (!isVisible())
             mWidgetManager.fadeInWorld();
         else
             mWidgetManager.fadeOutWorld();
@@ -338,4 +337,5 @@ public class SettingsWidget extends UIWidget {
 
         mWidgetManager.fadeInWorld();
     }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/TopBarWidget.java
@@ -18,7 +18,7 @@ import org.mozilla.vrbrowser.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.WidgetPlacement;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 
-public class TopBarWidget extends UIWidget implements SessionStore.SessionChangeListener, WidgetManagerDelegate.Listener {
+public class TopBarWidget extends UIWidget implements SessionStore.SessionChangeListener, WidgetManagerDelegate.UpdateListener {
     private static final String LOGTAG = "VRB";
 
     private UIButton mCloseButton;
@@ -47,6 +47,7 @@ public class TopBarWidget extends UIWidget implements SessionStore.SessionChange
         mCloseButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                requestFocusFromTouch();
                 if (mAudio != null) {
                     mAudio.playSound(AudioEngine.Sound.CLICK);
                 }
@@ -58,7 +59,7 @@ public class TopBarWidget extends UIWidget implements SessionStore.SessionChange
         mAudio = AudioEngine.fromContext(aContext);
 
         SessionStore.get().addSessionChangeListener(this);
-        mWidgetManager.addListener(this);
+        mWidgetManager.addUpdateListener(this);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class TopBarWidget extends UIWidget implements SessionStore.SessionChange
     @Override
     public void releaseWidget() {
         SessionStore.get().removeSessionChangeListener(this);
-        mWidgetManager.removeListener(this);
+        mWidgetManager.removeUpdateListener(this);
 
         super.releaseWidget();
     }
@@ -119,7 +120,7 @@ public class TopBarWidget extends UIWidget implements SessionStore.SessionChange
             mWidgetManager.removeWidget(this);
     }
 
-    // WidgetManagerDelegate.Listener
+    // WidgetManagerDelegate.UpdateListener
     @Override
     public void onWidgetUpdate(Widget aWidget) {
         if (aWidget != mBrowserWidget) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/UIButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/UIButton.java
@@ -11,6 +11,7 @@ import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.support.v7.widget.AppCompatImageButton;
+import android.view.View;
 
 import org.mozilla.vrbrowser.R;
 
@@ -88,4 +89,5 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
             }
         }
     }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/VoiceSearchWidget.java
@@ -28,7 +28,8 @@ import org.mozilla.vrbrowser.WidgetPlacement;
 
 import static org.mozilla.gecko.GeckoAppShell.getApplicationContext;
 
-public class VoiceSearchWidget extends UIWidget implements WidgetManagerDelegate.PermissionListener, Application.ActivityLifecycleCallbacks {
+public class VoiceSearchWidget extends UIWidget implements WidgetManagerDelegate.PermissionListener,
+        Application.ActivityLifecycleCallbacks, WidgetManagerDelegate.FocusChangeListener {
 
     private static final String LOGTAG = "VRB";
     private static final int VOICESEARCH_AUDIO_REQUEST_CODE = 7455;
@@ -77,6 +78,7 @@ public class VoiceSearchWidget extends UIWidget implements WidgetManagerDelegate
     private void initialize(Context aContext) {
         inflate(aContext, R.layout.voice_search_dialog, this);
 
+        mWidgetManager.addFocusChangeListener(this);
         mWidgetManager.addPermissionListener(this);
 
         mMozillaSpeechService = MozillaSpeechService.getInstance();
@@ -102,7 +104,7 @@ public class VoiceSearchWidget extends UIWidget implements WidgetManagerDelegate
         mSearchingAnimation.setRepeatCount(Animation.INFINITE);
         mVoiceSearchSearching = findViewById(R.id.voiceSearchSearching);
 
-        mCloseButton = createChild(CloseButtonWidget.class, true);
+        mCloseButton = createChild(CloseButtonWidget.class);
         mCloseButton.setDelegate(new CloseButtonWidget.CloseButtonDelegate() {
             @Override
             public void OnClick() {
@@ -119,6 +121,7 @@ public class VoiceSearchWidget extends UIWidget implements WidgetManagerDelegate
 
     @Override
     public void releaseWidget() {
+        mWidgetManager.removeFocusChangeListener(this);
         mWidgetManager.removePermissionListener(this);
         mMozillaSpeechService.removeListener(mVoiceSearchListener);
         ((Application)getApplicationContext()).unregisterActivityLifecycleCallbacks(this);
@@ -350,6 +353,14 @@ public class VoiceSearchWidget extends UIWidget implements WidgetManagerDelegate
     @Override
     public void onActivityDestroyed(Activity activity) {
 
+    }
+
+    // WidgetManagerDelegate.FocusChangeListener
+    @Override
+    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+        if (oldFocus == this) {
+            hide();
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #600 Improved focus handling to solve some inconsistencies of the current implementation. Now every focus change closes the current opened dialog.

Some inconsistencies:
- The Keyboard gets closed when the browser window is focused
- Keyboard doesn't get closed when you focus any other UI element
- Clicking on the browser widget closes the keyboard but doens't close any other widgets (ie. Settings dialog)
- A Choices prompt dialog doens't get closed inmediatly when you focus on any UI element including navigation buttons. We are currently handling it with navigation callbacks so it takes some time and feels lagged.
- When any dialog is visible it's never closed unless you explicitly close it so you can end up with dialogs on top of dialogs not all of them using the correct Z. Ie. Open settings, go to URL bar and open baidu.com (geolocation permission dialog should show behing Settings)
- There are dialogs that open other dialogs which is really bad UX ie. Settings -> Developer options.