### PR TITLE
Only show the servo button for few websites

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -28,6 +28,7 @@ import org.mozilla.vrbrowser.ui.views.CustomUIButton;
 import org.mozilla.vrbrowser.ui.views.NavigationURLBar;
 import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.views.UITextButton;
+import org.mozilla.vrbrowser.utils.ServoUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -390,7 +391,19 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     public void updateServoButton() {
-        if (SettingsStore.getInstance(mAppContext).isServoEnabled()) {
+        // We show the Servo button if:
+        // 1. the current session is using Servo. No matter what, we need the toggle button to go back to Gecko.
+        // 2. Or, if the pref is enabled and the current url is white listed.
+        boolean show = false;
+        GeckoSession currentSession = SessionStore.get().getCurrentSession();
+        if (currentSession != null) {
+            String currentUri = SessionStore.get().getCurrentUri();
+            boolean isPrefEnabled = SettingsStore.getInstance(mAppContext).isServoEnabled();
+            boolean isServoSession = ServoUtils.isInstanceOfServoSession(currentSession);
+            boolean isUrlWhiteListed = ServoUtils.isUrlInServoWhiteList(mAppContext, currentUri);
+            show = isServoSession || (isPrefEnabled && isUrlWhiteListed);
+        }
+        if (show) {
             mServoButton.setVisibility(View.VISIBLE);
         } else {
             mServoButton.setVisibility(View.GONE);
@@ -419,6 +432,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             mURLBar.setURL(url);
             mReloadButton.setEnabled(true);
         }
+        updateServoButton();
     }
 
     @Override

--- a/servo/src/main/java/org/mozilla/servo/ServoWhiteList.java
+++ b/servo/src/main/java/org/mozilla/servo/ServoWhiteList.java
@@ -1,0 +1,23 @@
+package org.mozilla.servo;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class ServoWhiteList {
+    private final Pattern[] mRules;
+
+    public ServoWhiteList(Context context) {
+        Resources res = context.getResources();
+        Stream<String> rules = Stream.of(res.getStringArray(R.array.servo_white_list));
+        mRules = rules.map(Pattern::compile).toArray(Pattern[]::new);
+    }
+
+    public boolean isAllowed(String url) {
+        return url != null && Stream.of(mRules).anyMatch(r -> r.matcher(url).matches());
+    }
+}

--- a/servo/src/main/res/values/servo_white_list.xml
+++ b/servo/src/main/res/values/servo_white_list.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="servo_white_list">
+        <!--
+        Matches:
+            https://servo.org
+            https://download.servo.org
+            https://download.servo.org
+            https://servo.org/
+            https://servo.org/ddd
+        Doesn't match:
+            https://.servo.org/ddd
+            https://servo.orgd
+            http://servo.org
+        -->
+        <item>https:\/\/(.+\.)?servo\.org(\/.*)?$</item>
+        <!-- All examples hosted under threejs.org/examples/ -->
+        <item>https:\/\/threejs\.org\/examples\/.*</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
This is for after #498. We only want to show the button for some urls.
I moved the button to the right of the url bar to prevent the UI to "move" too much as the user navigates.

@jdm can you look at the list and tell me if there's anything else you want to add in there?