### PR TITLE
Fix pixelated (cubemap) background

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1044,8 +1044,8 @@ BrowserWorld::LoadSkybox(const vrb::TransformPtr transform, const std::string &b
 
     RenderStatePtr state = RenderState::Create(aContext);
     TextureCubeMapPtr cubemap = vrb::TextureCubeMap::Create(aContext);
-    cubemap->SetTextureParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    cubemap->SetTextureParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    cubemap->SetTextureParameter(GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    cubemap->SetTextureParameter(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     cubemap->SetTextureParameter(GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     cubemap->SetTextureParameter(GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     cubemap->SetTextureParameter(GL_TEXTURE_WRAP_R, GL_CLAMP_TO_EDGE);


### PR DESCRIPTION
The background (cubemap) environment was looking pixelated due to being sampled with a box filter (GL_NEAREST).  Changing this to GL_LINEAR fixes it.  At the particular resolution of the environments, it's not necessary to create mipmaps or use GL_LINEAR_MIPMAP_LINEAR sampling, as the lower mips would only have a minor effect in the extreme corners of the cube.  If we later support a wider range of resolutions, or sample from this environment map for reflections, then we should generate mips.  Ideally, the environment would be pre-compressed with pre-generated mips, but simply using GL_LINEAR helps a lot for now.