### PR TITLE
Enable Oculus Fixed Foveated Rendering

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -587,6 +587,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         return SettingsStore.getInstance(this).getPointerColor();
     }
 
+    @Keep
+    @SuppressWarnings("unused")
+    public int getFoveatedLevel() {
+        return SettingsStore.getInstance(this).getFoveatedLevel();
+    }
+
     void createOffscreenDisplay() {
         int[] ids = new int[1];
         GLES20.glGenTextures(1, ids, 0);
@@ -816,6 +822,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public void updateFoveatedLevel() {
+        queueRunnable(() -> updateFoveatedLevelNative());
+    }
+
+    @Override
     public void updatePointerColor() {
         queueRunnable(() -> updatePointerColorNative());
     }
@@ -854,4 +865,5 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void workaroundGeckoSigAction();
     private native void updateEnvironmentNative();
     private native void updatePointerColorNative();
+    private native void updateFoveatedLevelNative();
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -50,6 +50,7 @@ public class SettingsStore {
     public final static float BROWSER_WORLD_WIDTH_DEFAULT = 4.0f;
     public final static float BROWSER_WORLD_HEIGHT_DEFAULT = 2.25f;
     public final static int MSAA_DEFAULT_LEVEL = 1;
+    public final static int FOVEATED_DEFAULT_LEVEL = 2;
 
     // Enable telemetry by default (opt-out).
     private final static boolean enableCrashReportingByDefault = false;
@@ -304,4 +305,14 @@ public class SettingsStore {
         editor.commit();
     }
 
+    public int getFoveatedLevel() {
+        return mPrefs.getInt(
+                mContext.getString(R.string.settings_key_foveated), FOVEATED_DEFAULT_LEVEL);
+    }
+
+    public void setFoveatedLevel(int level) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putInt(mContext.getString(R.string.settings_key_foveated), level);
+        editor.commit();
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/DeveloperOptionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/DeveloperOptionsWidget.java
@@ -14,6 +14,7 @@ import android.widget.RadioGroup;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.SessionStore;
 import org.mozilla.vrbrowser.browser.SettingsStore;
+import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.settings.ButtonSetting;
@@ -41,6 +42,7 @@ public class DeveloperOptionsWidget extends UIWidget {
     private RadioGroupSetting mPointerColorRadio;
     private RadioGroupSetting mUaModeRadio;
     private RadioGroupSetting mMSAARadio;
+    private RadioGroupSetting mFoveatedRadio;
 
     private SingleEditSetting mDensityEdit;
     private SingleEditSetting mDpiEdit;
@@ -126,6 +128,15 @@ public class DeveloperOptionsWidget extends UIWidget {
         mMSAARadio = findViewById(R.id.msaa_radio);
         mMSAARadio.setOnCheckedChangeListener(mMSSAChangeListener);
         setMSAAMode(mMSAARadio.getIdForValue(msaaLevel), false);
+
+        mFoveatedRadio = findViewById(R.id.foveated_radio);
+        if (BuildConfig.FLAVOR_platform == "oculusvr") {
+            int foveatedLevel = SettingsStore.getInstance(getContext()).getFoveatedLevel();
+            mFoveatedRadio.setOnCheckedChangeListener(mFoveatedChangeListener);
+            setFoveatedLevel(mFoveatedRadio.getIdForValue(foveatedLevel), false);
+        } else {
+            mFoveatedRadio.setVisibility(View.GONE);
+        }
 
         mDensityEdit = findViewById(R.id.density_edit);
         mDensityEdit.setFirstText(Float.toString(SettingsStore.getInstance(getContext()).getDisplayDensity()));
@@ -242,6 +253,13 @@ public class DeveloperOptionsWidget extends UIWidget {
         @Override
         public void onCheckedChanged(RadioGroup radioGroup, int checkedId, boolean doApply) {
             setMSAAMode(checkedId, true);
+        }
+    };
+
+    private RadioGroupSetting.OnCheckedChangeListener mFoveatedChangeListener = new RadioGroupSetting.OnCheckedChangeListener() {
+        @Override
+        public void onCheckedChanged(RadioGroup radioGroup, int checkedId, boolean doApply) {
+            setFoveatedLevel(checkedId, true);
         }
     };
 
@@ -411,6 +429,18 @@ public class DeveloperOptionsWidget extends UIWidget {
         if (doApply) {
             SettingsStore.getInstance(getContext()).setMSAALevel((Integer)mMSAARadio.getValueForId(checkedId));
             showRestartDialog();
+        }
+    }
+
+    private void setFoveatedLevel(int checkedId, boolean doApply) {
+        mFoveatedRadio.setOnCheckedChangeListener(null);
+        mFoveatedRadio.setChecked(checkedId, doApply);
+        mFoveatedRadio.setOnCheckedChangeListener(mFoveatedChangeListener);
+
+        SettingsStore.getInstance(getContext()).setFoveatedLevel((Integer)mFoveatedRadio.getValueForId(checkedId));
+
+        if (doApply) {
+            mWidgetManager.updateFoveatedLevel();
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
@@ -38,6 +38,7 @@ public interface WidgetManagerDelegate {
     void setBrowserSize(float targetWidth, float targetHeight);
     void keyboardDismissed();
     void updateEnvironment();
+    void updateFoveatedLevel();
     void updatePointerColor();
     void addFocusChangeListener(@NonNull FocusChangeListener aListener);
     void removeFocusChangeListener(@NonNull FocusChangeListener aListener);

--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -441,6 +441,11 @@ DeviceDelegateGoogleVR::SetControllerDelegate(ControllerDelegatePtr& aController
 }
 
 void
+DeviceDelegateGoogleVR::SetFoveatedLevel(const uint32_t aLevel) {
+  // Not Supported
+}
+
+void
 DeviceDelegateGoogleVR::ReleaseControllerDelegate() {
   m.controllerDelegate = nullptr;
 }

--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.h
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.h
@@ -31,6 +31,7 @@ public:
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
+  void SetFoveatedLevel(const uint32_t aLevel) override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   void ProcessEvents() override;

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -40,6 +40,7 @@ public:
   void Draw();
   void SetTemporaryFilePath(const std::string& aPath);
   void UpdateEnvironment();
+  void UpdateFoveatedLevel();
   void UpdatePointerColor();
   void SetSurfaceTexture(const std::string& aName, jobject& aSurface);
   void AddWidget(int32_t aHandle, const WidgetPlacementPtr& placement);

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -48,6 +48,7 @@ public:
   virtual void SetClearColor(const vrb::Color& aColor) = 0;
   virtual void SetClipPlanes(const float aNear, const float aFar) = 0;
   virtual void SetControllerDelegate(ControllerDelegatePtr& aController) = 0;
+  virtual void SetFoveatedLevel(const uint32_t aLevel) = 0;
   virtual void ReleaseControllerDelegate() = 0;
   virtual int32_t GetControllerModelCount() const = 0;
   virtual const std::string GetControllerModelName(const int32_t aModelIndex) const = 0;

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -38,7 +38,8 @@ static const char* kGetActiveEnvironment = "getActiveEnvironment";
 static const char* kGetActiveEnvironmentSignature = "()Ljava/lang/String;";
 static const char* kGetPointerColor = "getPointerColor";
 static const char* kGetPointerColorSignature = "()I";
-
+static const char* kGetFoveatedLevel = "getFoveatedLevel";
+static const char* kGetFoveatedLevelSignature = "()I";
 static JNIEnv* sEnv;
 static jobject sActivity;
 static jmethodID sDispatchCreateWidget;
@@ -55,6 +56,7 @@ static jmethodID sGetStorageAbsolutePath;
 static jmethodID sIsOverrideEnvPathEnabled;
 static jmethodID sGetActiveEnvironment;
 static jmethodID sGetPointerColor;
+static jmethodID sGetFoveatedLevel;
 }
 
 namespace crow {
@@ -88,6 +90,7 @@ VRBrowser::InitializeJava(JNIEnv* aEnv, jobject aActivity) {
   sIsOverrideEnvPathEnabled = FindJNIMethodID(sEnv, browserClass, kIsOverrideEnvPathEnabledName, kIsOverrideEnvPathEnabledSignature);
   sGetActiveEnvironment = FindJNIMethodID(sEnv, browserClass, kGetActiveEnvironment, kGetActiveEnvironmentSignature);
   sGetPointerColor = FindJNIMethodID(sEnv, browserClass, kGetPointerColor, kGetPointerColorSignature);
+  sGetFoveatedLevel = FindJNIMethodID(sEnv, browserClass, kGetFoveatedLevel, kGetFoveatedLevelSignature);
 }
 
 void
@@ -235,6 +238,15 @@ VRBrowser::GetPointerColor() {
   CheckJNIException(sEnv, __FUNCTION__);
 
   return (int32_t )jHexColor;
+}
+
+int32_t
+VRBrowser::GetFoveatedLevel() {
+  if (!ValidateMethodID(sEnv, sActivity, sGetFoveatedLevel, __FUNCTION__)) { return 16777215; }
+  jint jFoveatedLevel = (jint) sEnv->CallIntMethod(sActivity, sGetFoveatedLevel);
+  CheckJNIException(sEnv, __FUNCTION__);
+
+  return (int32_t )jFoveatedLevel;
 }
 
 } // namespace crow

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -31,6 +31,7 @@ std::string GetStorageAbsolutePath(const std::string& aRelativePath);
 bool isOverrideEnvPathEnabled();
 std::string GetActiveEnvironment();
 int32_t GetPointerColor();
+int32_t GetFoveatedLevel();
 } // namespace VRBrowser;
 
 } // namespace crow

--- a/app/src/main/res/layout/developer_options.xml
+++ b/app/src/main/res/layout/developer_options.xml
@@ -97,6 +97,14 @@
                     app:options="@array/developer_options_msaa_options"
                     app:values="@array/developer_options_ua_mode_values"/>
 
+                <org.mozilla.vrbrowser.ui.settings.RadioGroupSetting
+                    android:id="@+id/foveated_radio"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    app:description="@string/developer_options_foveated"
+                    app:options="@array/developer_options_foveated_options"
+                    app:values="@array/developer_options_ua_mode_values"/>
+
                 <org.mozilla.vrbrowser.ui.settings.SingleEditSetting
                     android:id="@+id/density_edit"
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -21,6 +21,7 @@
     <string name="settings_key_env" translatable="false">settings_env</string>
     <string name="settings_key_pointer_color" translatable="false">settings_pointer_color</string>
     <string name="settings_key_msaa" translatable="false">settings_msaa</string>
+    <string name="settings_key_foveated" translatable="false">settings_foveated</string>
     <string name="private_browsing_support_url" translatable="false">https://support.mozilla.org/kb/private-mode-firefox-reality</string>
     <string name="settings_key_browser_world_width" translatable="false">settings_browser_world_width</string>
     <string name="settings_key_browser_world_height" translatable="false">settings_browser_world_height</string>
@@ -71,5 +72,11 @@
         <item>@string/developer_options_msaa_disabled</item>
         <item>@string/developer_options_msaa_2</item>
         <item>@string/developer_options_msaa_4</item>
+    </string-array>
+    <string-array name="developer_options_foveated_options" translatable="false">
+        <item>@string/developer_options_foveated_disabled</item>
+        <item>@string/developer_options_foveated_1</item>
+        <item>@string/developer_options_foveated_2</item>
+        <item>@string/developer_options_foveated_3</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/settings_values.xml
+++ b/app/src/main/res/values/settings_values.xml
@@ -13,5 +13,6 @@
         <item>0</item>
         <item>1</item>
         <item>2</item>
+        <item>3</item>
     </integer-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,21 @@
     <string name="developer_options_msaa_2">2x</string>
     <!-- This string is used to label the MSAA radio button that enables four times MSAA in immersive mode. -->
     <string name="developer_options_msaa_4">4x</string>
+    <!-- This string is used to label radio buttons for setting fixed-foveated-rendering (FFR) level.
+         Higher values of this option result in larger parts of the peripheral vision being rendered
+         at lower resolutions than the content in the center of the view.  These higher values reduce
+         quality to increase performance.  The Oculus implementation of fixed-foveated-rendering is
+         described in more detail here:
+         https://developer.oculus.com/blog/optimizing-oculus-go-for-performance/-->
+    <string name="developer_options_foveated">Foveation Level</string>
+    <!-- This string is used to label the Foveated radio button that disables fixed-foveated-rendering in immersive mode. -->
+    <string name="developer_options_foveated_disabled">Disabled</string>
+    <!-- This string is used to label the Foveated radio button that enables low-level fixed-foveated-rendering. -->
+    <string name="developer_options_foveated_1">1</string>
+    <!-- This string is used to label the Foveated radio button that enables medium-level fixed-foveated-rendering. -->
+    <string name="developer_options_foveated_2">2</string>
+    <!-- This string is used to label the Foveated radio button that enables high-level fixed-foveated-rendering. -->
+    <string name="developer_options_foveated_3">3</string>
     <!-- This string is used to label a set of radio buttons that allow the user to
      change the user-agent (UA) string of the browser. -->
     <string name="developer_options_ua_mode">User-Agent Mode</string>

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.cpp
@@ -154,6 +154,11 @@ DeviceDelegateNoAPI::ReleaseControllerDelegate() {
     m.controller = nullptr;
 }
 
+void
+DeviceDelegateNoAPI::SetFoveatedLevel(const uint32_t aLevel) {
+  // Not Supported
+}
+
 int32_t
 DeviceDelegateNoAPI::GetControllerModelCount() const {
   return 0;

--- a/app/src/noapi/cpp/DeviceDelegateNoAPI.h
+++ b/app/src/noapi/cpp/DeviceDelegateNoAPI.h
@@ -31,6 +31,7 @@ public:
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
+  void SetFoveatedLevel(const uint32_t aLevel) override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   void ProcessEvents() override;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -386,6 +386,12 @@ DeviceDelegateOculusVR::ReleaseControllerDelegate() {
   m.controller = nullptr;
 }
 
+void
+DeviceDelegateOculusVR::SetFoveatedLevel(const uint32_t aLevel) {
+  // Enable fixed-foveated rendering level.
+  vrapi_SetPropertyInt(&m.java, VRAPI_FOVEATION_LEVEL, aLevel);
+}
+
 int32_t
 DeviceDelegateOculusVR::GetControllerModelCount() const {
   return 1;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -34,6 +34,7 @@ public:
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
+  void SetFoveatedLevel(const uint32_t aLevel) override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   void ProcessEvents() override;

--- a/app/src/svr/cpp/DeviceDelegateSVR.cpp
+++ b/app/src/svr/cpp/DeviceDelegateSVR.cpp
@@ -383,6 +383,11 @@ DeviceDelegateSVR::SetControllerDelegate(ControllerDelegatePtr& aController) {
 }
 
 void
+DeviceDelegateSVR::SetFoveatedLevel(const uint32_t aLevel) {
+  // Not supported
+}
+
+void
 DeviceDelegateSVR::ReleaseControllerDelegate() {
   m.controller = nullptr;
 }

--- a/app/src/svr/cpp/DeviceDelegateSVR.h
+++ b/app/src/svr/cpp/DeviceDelegateSVR.h
@@ -34,6 +34,7 @@ public:
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
+  void SetFoveatedLevel(const uint32_t aLevel) override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   void ProcessEvents() override;

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -298,6 +298,11 @@ DeviceDelegateWaveVR::SetControllerDelegate(ControllerDelegatePtr& aController) 
 }
 
 void
+DeviceDelegateWaveVR::SetFoveatedLevel(const uint32_t aLevel) {
+  // Not Supported
+}
+
+void
 DeviceDelegateWaveVR::ReleaseControllerDelegate() {
   m.delegate = nullptr;
 }

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -25,6 +25,7 @@ public:
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
+  void SetFoveatedLevel(const uint32_t aLevel) override;
   void ReleaseControllerDelegate() override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;


### PR DESCRIPTION
A value of 2 was selected through experimentation on the Oculus Go. (0 = none, 3 = max).

Ideally, this would be a user-select-able value; however, a default of 2 seems reasonable as I could not notice any artifacts in the peripheral vision.