### PR TITLE
Add a user property to disable app relaunch on crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ geckoViewLocalX86=/path/to/your/build/geckoview-nightly-x86-64.0.20180924100359.
 - When using the native debugger you can ignore the first SIGSEGV: address access protected stop in GV thread. It's not a crash; you can click *Resume* to continue debugging.
 - On some platforms such as Oculus Go the native debugger stops on each input event. You can set this LLDB post-attach command in Android Studio to fix the problem: `pro hand -p true -s false SIGILL`
 - You can use `adb shell am start -a android.intent.action.VIEW -d "https://aframe.io" org.mozilla.vrbrowser/org.mozilla.vrbrowser.VRBrowserActivity` to load a URL from the command line
-- You can use `adb shell setprop debug.oculus.enableVideoCapture 1`to record videos on the Oculus Go. Remember to disable it when your video is ready.
+- You can use `adb shell setprop debug.oculus.enableVideoCapture 1` to record videos on the Oculus Go. Remember to disable it when your video is ready.
+- You can set `disableCrashRestart=true` in the gradle `user.properties` to disable app relaunch on crash.
 
 
 ## Experimental Servo support

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,13 @@ def getGitHash = { ->
     return stdout.toString().trim()
 }
 
+def getCrashRestartDisabled = { ->
+    if (gradle.hasProperty("disableCrashRestart")) {
+        return gradle.disableCrashRestart
+    }
+    return "false"
+}
+
 android {
     compileSdkVersion 27
     defaultConfig {
@@ -19,6 +26,7 @@ android {
         versionCode 1
         versionName "1.0.1"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
+        buildConfigField "Boolean", "DISABLE_CRASH_RESTART", getCrashRestartDisabled()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {

--- a/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
@@ -10,6 +10,7 @@ import android.support.v4.app.JobIntentService;
 import android.util.Log;
 
 import org.mozilla.geckoview.GeckoRuntime;
+import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserActivity;
 
@@ -39,7 +40,8 @@ public class CrashReporterService extends JobIntentService {
         if (GeckoRuntime.ACTION_CRASHED.equals(action)) {
             boolean fatal = intent.getBooleanExtra(GeckoRuntime.EXTRA_CRASH_FATAL, false);
 
-            if (fatal) {
+
+            if (fatal && !BuildConfig.DISABLE_CRASH_RESTART) {
                 Log.d(LOGTAG, "======> NATIVE CRASH PARENT" + intent);
                 final int pid = Process.myPid();
                 final ActivityManager activityManager = (ActivityManager) this.getSystemService(Context.ACTIVITY_SERVICE);


### PR DESCRIPTION
I find the restart annoying while developing because the logs/stacktraces get back on the log history and may be lost.

Related issue: https://github.com/MozillaReality/FirefoxReality/issues/651