### PR TITLE
Improve widget depth sorting

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -21,6 +21,8 @@ typedef std::shared_ptr<BrowserWorld> BrowserWorldPtr;
 typedef std::weak_ptr<BrowserWorld> BrowserWorldWeakPtr;
 class WidgetPlacement;
 typedef std::shared_ptr<WidgetPlacement> WidgetPlacementPtr;
+class Widget;
+typedef std::shared_ptr<Widget> WidgetPtr;
 
 class BrowserWorld {
 public:
@@ -64,6 +66,8 @@ protected:
   void LoadSkybox(const vrb::TransformPtr transform, const std::string& basePath);
   void CreateFloor();
   float DistanceToNode(const vrb::NodePtr& aNode, const vrb::Vector& aPosition) const;
+  WidgetPtr GetWidgetFromNode(const vrb::NodePtr& aNode) const;
+  float DistanceToPlane(const WidgetPtr& aNode, const vrb::Vector& aPosition, const vrb::Vector& aDirection) const;
 private:
   State& m;
   BrowserWorld() = delete;

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -288,6 +288,11 @@ Widget::GetRoot() const {
   return m.root;
 }
 
+QuadPtr
+Widget::GetQuad() const {
+  return m.quad;
+}
+
 vrb::TransformPtr
 Widget::GetTransformNode() const {
   return m.transform;

--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -17,6 +17,9 @@
 
 namespace crow {
 
+class Quad;
+typedef std::shared_ptr<Quad> QuadPtr;
+
 class Widget;
 typedef std::shared_ptr<Widget> WidgetPtr;
 
@@ -44,6 +47,7 @@ public:
   void TogglePointer(const bool aEnabled);
   bool IsVisible() const;
   vrb::NodePtr GetRoot() const;
+  QuadPtr GetQuad() const;
   vrb::TransformPtr GetTransformNode() const;
   vrb::NodePtr GetPointerGeometry() const;
   void SetPointerGeometry(vrb::NodePtr& aNode);


### PR DESCRIPTION
The depth sorting we are using for the widgets fails in some situations for the video mode UI (e.g. a widget on the right side vs one in the center but farther in z plane). This PR improves the depth sorting using distance to plane instead of distance to node position.


