### PR TITLE
Do not call anything after session.close()

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
@@ -357,13 +357,13 @@ public class SessionStore implements GeckoSession.NavigationDelegate, GeckoSessi
             session.setPromptDelegate(null);
             session.setPermissionDelegate(null);
             session.setTrackingProtectionDelegate(null);
-            session.close();
             mSessions.remove(aSessionId);
             for (SessionChangeListener listener: mSessionChangeListeners) {
                 listener.onRemoveSession(session, aSessionId);
             }
             session.setActive(false);
             session.stop();
+            session.close();
         }
     }
 


### PR DESCRIPTION
This is a problem with servo sessions. `stop` and `setActive` can't work after `close` is called.