### PR TITLE
Change UA settings storage key

### DIFF
--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -10,7 +10,7 @@
     <string name="settings_key_environment_override" translatable="false">settings_environment_override</string>
     <string name="settings_key_multiprocess" translatable="false">settings_environment_multiprocess</string>
     <string name="settings_key_servo">settings_environment_servo</string>
-    <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version</string>
+    <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version_v2</string>
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>
     <string name="settings_key_display_density" translatable="false">settings_display_density</string>
     <string name="settings_key_window_width" translatable="false">settings_window_width</string>


### PR DESCRIPTION
Changed the key name so users who update the app without uninstalling it get the VR UA by default.