### PR TITLE
Fixes a crash hiding the suggestions bar

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
@@ -19,6 +19,7 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 
@@ -74,7 +75,7 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
 
             @Override
             public void onAnimationEnd(Animation animation) {
-                SuggestionsWidget.super.hide();
+                ThreadUtils.postToUiThread(() -> SuggestionsWidget.super.hide());
             }
 
             @Override


### PR DESCRIPTION
Fixes a crash when animating the suggestions bar if it' already removed from the view tree.

STRs:
- Click on the URL bar
- Go to file:///sdcard/

Expected result:
- Permission dialog shows

Result:
- App crashes