### PR TITLE
Switch WaveVR controller touchpad and trigger button order

### DIFF
--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -192,8 +192,8 @@ struct DeviceDelegateWaveVR::State {
       const bool menuPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Menu);
 
       delegate->SetButtonCount(index, 2); // For immersive mode
-      delegate->SetButtonState(index, ControllerDelegate::BUTTON_TRIGGER, 0, bumperPressed, bumperPressed);
-      delegate->SetButtonState(index, ControllerDelegate::BUTTON_TOUCHPAD, 1, touchpadPressed, touchpadTouched);
+      delegate->SetButtonState(index, ControllerDelegate::BUTTON_TOUCHPAD, 0, touchpadPressed, touchpadTouched);
+      delegate->SetButtonState(index, ControllerDelegate::BUTTON_TRIGGER, 1, bumperPressed, bumperPressed);
       delegate->SetButtonState(index, ControllerDelegate::BUTTON_APP, -1, menuPressed, menuPressed);
 
       const int32_t kNumAxes = 2;


### PR DESCRIPTION
We have checked Oculus Go browser and FxR in Oculus Go, even Firefox desktop, all of them are put touchpad button at index 0, and trigger at index 1. We should make WaveVR to be consistent with other devices.