### PR TITLE
Use lockHardwareCanvas on UI rendering

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UISurfaceTextureRenderer.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UISurfaceTextureRenderer.java
@@ -53,7 +53,7 @@ class UISurfaceTextureRenderer {
         mSurfaceCanvas = null;
         if (mSurface != null) {
             try {
-                mSurfaceCanvas = mSurface.lockCanvas(null);
+                mSurfaceCanvas = mSurface.lockHardwareCanvas();
                 mSurfaceCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
             }
             catch (Exception e){


### PR DESCRIPTION
It seems that `lockCanvas()` doesn't return a hardware accelerated canvas.

`lockHardwareCanvas()` returns a canvas that uses hardware acceleration instead. It requires a full clean on each layout update but we were already doing that. 