### PR TITLE
Add support for UI texture scaling

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -474,8 +474,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
             widget.setSurfaceTexture(aTexture, aWidth, aHeight);
             // Add widget to a virtual display for invalidation
-            if (((View)widget).getParent() == null) {
-                mWidgetContainer.addView((View) widget, new FrameLayout.LayoutParams(aWidth, aHeight));
+            View view = (View) widget;
+            if (view.getParent() == null) {
+                float scale = widget.getPlacement().textureScale;
+                mWidgetContainer.addView(view, new FrameLayout.LayoutParams((int) Math.ceil(aWidth / scale), (int) Math.ceil(aHeight / scale)));
             }
         });
     }
@@ -506,7 +508,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             View view = (View) widget;
             // Add widget to a virtual display for invalidation
             if (aSurface != null && view.getParent() == null) {
-                mWidgetContainer.addView(view, new FrameLayout.LayoutParams(aWidth, aHeight));
+                float scale = widget.getPlacement().textureScale;
+                mWidgetContainer.addView(view, new FrameLayout.LayoutParams((int) Math.ceil(aWidth / scale), (int) Math.ceil(aHeight / scale)));
             } else if (aSurface == null && view.getParent() != null) {
                 mWidgetContainer.removeView(view);
             }
@@ -519,13 +522,17 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     void handleMotionEvent(final int aHandle, final int aDevice, final boolean aPressed, final float aX, final float aY) {
         runOnUiThread(() -> {
             Widget widget = mWidgets.get(aHandle);
+            float scale = widget != null ? widget.getPlacement().textureScale : 1.0f;
+            final float x = aX / scale;
+            final float y = aY / scale;
+
             if (widget == null) {
-                MotionEventGenerator.dispatch(mRootWidget, aDevice, aPressed, aX, aY);
+                MotionEventGenerator.dispatch(mRootWidget, aDevice, aPressed, x, y);
             } else if (widget == mWindowWidget && mWindowWidget.getBorderWidth() > 0) {
                 final int border = mWindowWidget.getBorderWidth();
-                MotionEventGenerator.dispatch(widget, aDevice, aPressed, aX - border, aY - border);
+                MotionEventGenerator.dispatch(widget, aDevice, aPressed, x - border, y - border);
             } else {
-                MotionEventGenerator.dispatch(widget, aDevice, aPressed, aX, aY);
+                MotionEventGenerator.dispatch(widget, aDevice, aPressed, x, y);
             }
         });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -203,6 +203,7 @@ public class TrayWidget extends UIWidget implements SessionStore.SessionChangeLi
         aPlacement.rotation = (float)Math.toRadians(-45);
         aPlacement.opaque = false;
         aPlacement.cylinder = false;
+        aPlacement.textureScale = 1.0f;
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
@@ -40,6 +40,7 @@ public class WidgetPlacement {
     public boolean firstDraw = false;
     public boolean layer = true;
     public boolean cylinder = true;
+    public float textureScale = 0.7f;
 
     public WidgetPlacement clone() {
         WidgetPlacement w = new WidgetPlacement();
@@ -70,6 +71,7 @@ public class WidgetPlacement {
         this.firstDraw = w.firstDraw;
         this.layer = w.layer;
         this.cylinder = w.cylinder;
+        this.textureScale = w.textureScale;
     }
 
     public int textureWidth() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -96,6 +96,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         aPlacement.anchorY = 0.0f;
         aPlacement.visible = true;
         aPlacement.cylinder = true;
+        aPlacement.textureScale = 1.0f;
     }
 
     @Override

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -707,8 +707,8 @@ BrowserWorld::AddWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement) {
     worldWidth = aPlacement->width * kWorldDPIRatio;
   }
 
-  int32_t textureWidth = (int32_t)(ceilf(aPlacement->width * aPlacement->density));
-  int32_t textureHeight = (int32_t)(ceilf(aPlacement->height * aPlacement->density));
+  const int32_t textureWidth = aPlacement->GetTextureWidth();
+  const int32_t textureHeight = aPlacement->GetTextureHeight();
 
   const float aspect = (float)textureWidth / (float)textureHeight;
   const float worldHeight = worldWidth / aspect;
@@ -759,8 +759,7 @@ BrowserWorld::UpdateWidget(int32_t aHandle, const WidgetPlacementPtr& aPlacement
   widget->SetPlacement(aPlacement);
   widget->SetCylinderDensity(m.cylinderDensity);
   widget->ToggleWidget(aPlacement->visible);
-  widget->SetSurfaceTextureSize((int32_t)(ceilf(aPlacement->width * aPlacement->density)),
-                                (int32_t)(ceilf(aPlacement->height * aPlacement->density)));
+  widget->SetSurfaceTextureSize(aPlacement->GetTextureWidth(), aPlacement->GetTextureHeight());
 
   float worldWidth = 0.0f, worldHeight = 0.0f;
   widget->GetWorldSize(worldWidth, worldHeight);

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -130,8 +130,8 @@ struct Widget::State {
     cylinder->GetTextureSize(textureWidth, textureHeight);
 
     const float radius = cylinder->GetCylinderRadius();
-    const float surfaceWidth = (float)textureWidth / placement->density;
-    const float surfaceHeight = (float)textureHeight / placement->density;
+    const float surfaceWidth = (float)textureWidth / placement->density * placement->textureScale;
+    const float surfaceHeight = (float)textureHeight / placement->density * placement->textureScale;
     // Cylinder density measures the pixels for a 360 cylinder
     // Oculus recommends 4680px density, which is 13 pixels per degree.
     const float theta = (float)M_PI * surfaceWidth / (cylinderDensity * 0.5f);

--- a/app/src/main/cpp/WidgetPlacement.cpp
+++ b/app/src/main/cpp/WidgetPlacement.cpp
@@ -54,8 +54,19 @@ WidgetPlacement::FromJava(JNIEnv* aEnv, jobject& aObject) {
   GET_BOOLEAN_FIELD(firstDraw);
   GET_BOOLEAN_FIELD(layer);
   GET_BOOLEAN_FIELD(cylinder);
+  GET_FLOAT_FIELD(textureScale, "textureScale");
 
   return result;
+}
+
+int32_t
+WidgetPlacement::GetTextureWidth() const{
+  return (int32_t)ceilf(width * density * textureScale);
+}
+
+int32_t
+WidgetPlacement::GetTextureHeight() const {
+  return (int32_t)ceilf(height * density * textureScale);
 }
 
 }

--- a/app/src/main/cpp/WidgetPlacement.h
+++ b/app/src/main/cpp/WidgetPlacement.h
@@ -32,6 +32,10 @@ struct WidgetPlacement {
   bool firstDraw;
   bool layer;
   bool cylinder;
+  float textureScale;
+
+  int32_t GetTextureWidth() const;
+  int32_t GetTextureHeight() const;
 
   static WidgetPlacementPtr FromJava(JNIEnv* aEnv, jobject& aObject);
 private:


### PR DESCRIPTION
We are using pretty big textures now for UI due to the Android screen density. VR doesn't have the same density so we may be using more than needed. This PR allows to set a specific texture scaling per widget. The "big" scaling is done on the UI renderer only after each render due to layout changes instead of every frame on the GPU

I set a default value of 0.75f. There may be some better formula taking z into account but it's a starting point. I saw some improvements on the aliasing of the navigation bar on Oculus with Layers enabled (In addition to reduced texture sizes). It should have a similar aliasing effects to creating mipmaps if we are able to set the right value here.

I'd like some more testing on all the platforms. Thoughts?
