### PR TITLE
keep keyboard open upon pressing Clear icon in URL bar (fixes issue #742)

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -419,7 +419,6 @@ public class NavigationURLBar extends FrameLayout {
             mAudio.playSound(AudioEngine.Sound.CLICK);
         }
 
-        view.requestFocusFromTouch();
         mURL.getText().clear();
     };
 


### PR DESCRIPTION
so I can better understand how my fix fixes the bug, can you share the context of PR #609?

specifically, in the `mMicrophoneListener` method, what does the `view.requestFocusFromTouch()` call do?

the reason I ask: on `master`, I was able to reproduce the same bug randomly twice (but I still cannot find reliable STR): I pressed the Voice Search icon in the URL bar, my Voice Search was processed and completed, but then the keyboard opened (even though I was not previously interacting with the keyboard, and the keyboard was closed). ideas? if it was a bug/oversight from PR #609, I can address this in this PR. otherwise, I'll be filing an issue.