### PR TITLE
Improve border aliasing. Enable transparent border on all platforms.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
@@ -167,7 +167,7 @@ public class SessionStore implements GeckoSession.NavigationDelegate, GeckoSessi
             runtimeSettingsBuilder.displayDpiOverride(SettingsStore.getInstance(aContext).getDisplayDpi());
             runtimeSettingsBuilder.screenSizeOverride(SettingsStore.getInstance(aContext).getMaxWindowWidth(),
                     SettingsStore.getInstance(aContext).getMaxWindowHeight());
-            if (SettingsStore.getInstance(aContext).getLayersEnabled()) {
+            if (SettingsStore.getInstance(aContext).getTransparentBorderWidth() > 0) {
                 runtimeSettingsBuilder.useMaxScreenDepth(true);
             }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -321,6 +321,10 @@ public class SettingsStore {
         return false;
     }
 
+    public int getTransparentBorderWidth() {
+        return 1;
+    }
+
     public boolean isAudioEnabled() {
         return mPrefs.getBoolean(mContext.getString(R.string.settings_key_audio), AUDIO_ENABLED);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/BrowserWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/BrowserWidget.java
@@ -53,7 +53,7 @@ public class BrowserWidget extends UIWidget implements SessionStore.SessionChang
         super(aContext);
         mSessionId = aSessionId;
         mWidgetManager = (WidgetManagerDelegate) aContext;
-        mBorderWidth = SettingsStore.getInstance(aContext).getLayersEnabled() ? 1 : 0;
+        mBorderWidth = SettingsStore.getInstance(aContext).getTransparentBorderWidth();
         SessionStore.get().addSessionChangeListener(this);
         SessionStore.get().addPromptListener(this);
         SessionStore.get().addContentListener(this);
@@ -152,7 +152,7 @@ public class BrowserWidget extends UIWidget implements SessionStore.SessionChang
             return;
         }
         mIsInVRVideoMode = false;
-        int border = SettingsStore.getInstance(getContext()).getLayersEnabled() ? 1 : 0;
+        int border = SettingsStore.getInstance(getContext()).getTransparentBorderWidth();
         if (mWidthBackup == mWidth && mHeightBackup == mHeight && border == mBorderWidth) {
             return;
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
@@ -18,6 +18,7 @@ import android.view.ViewParent;
 import android.widget.FrameLayout;
 
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.browser.SettingsStore;
 
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ public abstract class UIWidget extends FrameLayout implements Widget {
     protected Runnable mBackHandler;
     protected HashMap<Integer, UIWidget> mChildren;
     protected Delegate mDelegate;
-    protected int mBorderWidth = 1;
+    protected int mBorderWidth;
     private Runnable mFirstDrawCallback;
 
     public UIWidget(Context aContext) {
@@ -63,6 +64,7 @@ public abstract class UIWidget extends FrameLayout implements Widget {
     }
 
     private void initialize() {
+        mBorderWidth = SettingsStore.getInstance(getContext()).getTransparentBorderWidth();
         mWidgetManager = (WidgetManagerDelegate) getContext();
         mWidgetPlacement = new WidgetPlacement(getContext());
         mHandle = mWidgetManager.newWidgetHandle();


### PR DESCRIPTION
Transparent border helps a bit with aliased borders on the browser window when not using layers (e.g. Wave)