### PR TITLE
add command for updating `third_party`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ This repo is only available to Mozilla employees. If you have access to the rele
  - `third_party/svr/` for Snapdragon (should contain a `libs` folder, among other things)
  - `third_party/wavesdk/` for Vive (should contain a `build` folder, among other things)
 
+The [repo in `third_party`](`https://github.com/MozillaReality/FirefoxReality-android-third-party`) can be updated like so:
+
+```bash
+pushd third_party && git checkout master && git pull && popd
+```
 
 *Fetch Git submodules.*
 


### PR DESCRIPTION
compilation errors are thrown if the developer's checkout of the third-party repo (in their `third_party` directory) is not up to date. this command fixes that.