### PR TITLE
Fixes a noapi crash when going back from fullscreen

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -429,7 +429,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
         // We need to add a delay for the exitFullScreen() call to solve some viewport scaling issues,
         // See https://github.com/MozillaReality/FirefoxReality/issues/833 for more info.
-        getHandler().postDelayed(() -> {
+        postDelayed(() -> {
             if (SessionStore.get().isInFullScreen()) {
                 SessionStore.get().exitFullScreen();
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/RestartDialogWidget.java
@@ -52,7 +52,7 @@ public class RestartDialogWidget extends UIWidget {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
 
-            getHandler().postDelayed(() -> handleRestartApp(), 500);
+            postDelayed(() -> handleRestartApp(), 500);
         });
         cancelButton.setOnClickListener(view -> {
             if (mAudio != null) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ChoicePromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ChoicePromptWidget.java
@@ -75,7 +75,7 @@ public class ChoicePromptWidget extends PromptWidget {
 
             mAdapter.notifyDataSetChanged();
 
-            handler.postDelayed(() -> {
+            postDelayed(() -> {
                 ChoiceWrapper selectedItem = mListItems[position];
                 if (mList.getChoiceMode() == ListView.CHOICE_MODE_SINGLE) {
                     if (mCallback != null) {


### PR DESCRIPTION
Fixes a noapi crash that happens when a handler is accessed while the view is not attached. Use postDelayed directly so the right handler is used internally. The view life cycle must be slightly different in noapi and at some point the view gets unattached right after the back button is pressed.