### PR TITLE
Fix error message

### DIFF
--- a/geckoview-local/build.gradle
+++ b/geckoview-local/build.gradle
@@ -32,7 +32,7 @@ def addArtifact(path) {
     if (aar.exists()) {
         artifacts.add('default', aar)
     } else {
-        throw new GradleException('Failed to find GeckoView AAR at: ' + gradle.geckoViewLocal)
+        throw new GradleException('Failed to find GeckoView AAR at: ' + path)
     }
 }
 


### PR DESCRIPTION
Without this, if we use the wrong path in user.properties, we would get this error:

```
Could not get unknown property 'geckoViewLocal' for build 'FirefoxReality' of type org.gradle.invocation.DefaultGradle.
```