### PR TITLE
add "Desktop" User-Agent Overrides for U-NEXT (fixes issue #914)

### DIFF
--- a/app/src/main/assets/userAgentOverride.json
+++ b/app/src/main/assets/userAgentOverride.json
@@ -62,5 +62,6 @@
   "edac8d1b694780928622a66901f21487a96323a0b1a3b01ef9042dc0103ae1aab0f1b230d11fbd7869989b3551b4dcf09a91956422167b2932fc4df18a06196d": "Mozilla/5.0 (X11; Linux x86_64; rv:66.0) Gecko/20100101 Firefox VR/65.0 OculusBrowser/5.4.9.132217727 SamsungBrowser/4.0",
   "f2e907dbfe6c8d4b92b94452ce31424e4f4a1daede60d41ab5545bf9ec51cb1928f0376c0c6b1006658c22b7f1f8666d56b64f9b88fd05b3e09921921bc1aec8": "Mozilla/5.0 (X11; Linux x86_64; rv:66.0) Gecko/20100101 Firefox VR/65.0 OculusBrowser/5.4.9.132217727 SamsungBrowser/4.0",
   "f8f9049dbf5adc3ce575bcfa5b2d386131fd57439817b18c68d9dc10ab17d08ceb7dbb091a2ff5b9b89756fb42b189c11cce01a7e8a95e13efc1c705961f34c9": "Mozilla/5.0 (X11; Linux x86_64; rv:66.0) Gecko/20100101 Firefox VR/65.0 OculusBrowser/5.4.9.132217727 SamsungBrowser/4.0",
-  "fbda302f46e7847ec8a9df2443a07eae94bc49ba91ea6cf08fa0fa21298457d61f3ab0f4a8c04de06738be6ae43aa90744bb79b943929572963c9c8c6cd28c15": "Mozilla/5.0 (X11; Linux x86_64; rv:66.0) Gecko/20100101 Firefox VR/65.0 OculusBrowser/5.4.9.132217727 SamsungBrowser/4.0"
+  "fbda302f46e7847ec8a9df2443a07eae94bc49ba91ea6cf08fa0fa21298457d61f3ab0f4a8c04de06738be6ae43aa90744bb79b943929572963c9c8c6cd28c15": "Mozilla/5.0 (X11; Linux x86_64; rv:66.0) Gecko/20100101 Firefox VR/65.0 OculusBrowser/5.4.9.132217727 SamsungBrowser/4.0",
+  "926a9e590713086535d2ee399eeef76fda5577a9a5a3caef39df03c0ebb5e8bf21e1d0f1867ba7b8ed16ebfd690a5e8aabf79ab46096151146c8f21346672052": "Mozilla/5.0 (X11; Linux x86_64; rv:66.0) Gecko/20100101 Firefox VR/65.0 OculusBrowser/5.4.9.132217727 SamsungBrowser/4.0"
 }


### PR DESCRIPTION
fixes issue #914, handling `unext.jp` (which covers `www.unext.jp`, `video.unext.jp`, etc. too)

example:
https://video.unext.jp/genre/foreigntvseries
