### PR TITLE
Improve resize UI quality

### DIFF
--- a/app/src/main/cpp/Cylinder.h
+++ b/app/src/main/cpp/Cylinder.h
@@ -27,6 +27,7 @@ typedef std::shared_ptr<Cylinder> CylinderPtr;
 class Cylinder {
 public:
   static CylinderPtr Create(vrb::CreationContextPtr aContext, const float aRadius, const float aHeight, const VRLayerCylinderPtr& aLayer = nullptr);
+  static CylinderPtr Create(vrb::CreationContextPtr aContext, const float aRadius, const float aHeight, const vrb::Color& aSolidColor, const float kBorder, const vrb::Color& aBorderColor);
   static CylinderPtr Create(vrb::CreationContextPtr aContext, const VRLayerCylinderPtr& aLayer = nullptr);
   void GetTextureSize(int32_t& aWidth, int32_t& aHeight) const;
   void SetTextureSize(int32_t aWidth, int32_t aHeight);


### PR DESCRIPTION
See #959

Depends on https://github.com/MozillaReality/vrb/pull/60

This PR improves resize UI quality on Vive. I finally decided to switch to vertex colors instead of using a texture sample. It was more work but it provides better quality and allows for more flexibility (we can set different values per platform, e.g. disabled in Oculus) 