### PR TITLE
Implement dynamic switch between flat and curved display

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -989,6 +989,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         queueRunnable(this::resetUIYawNative);
     }
 
+    @Override
     public void setCylinderDensity(final float aDensity) {
         queueRunnable(() -> setCylinderDensityNative(aDensity));
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
@@ -45,6 +45,7 @@ public interface WidgetManagerDelegate {
     void showVRVideo(int aWindowHandle, @VideoProjectionMenuWidget.VideoProjectionFlags int aVideoProjection);
     void hideVRVideo();
     void resetUIYaw();
+    void setCylinderDensity(float aDensity);
     void addFocusChangeListener(@NonNull FocusChangeListener aListener);
     void removeFocusChangeListener(@NonNull FocusChangeListener aListener);
     void addPermissionListener(PermissionListener aListener);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/options/DisplayOptionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/options/DisplayOptionsWidget.java
@@ -82,8 +82,9 @@ public class DisplayOptionsWidget extends UIWidget implements
         mCurvedDisplaySwitch = findViewById(R.id.curved_display_switch);
         mCurvedDisplaySwitch.setChecked(SettingsStore.getInstance(getContext()).getCylinderDensity() > 0.0f);
         mCurvedDisplaySwitch.setOnCheckedChangeListener((compoundButton, enabled, apply) -> {
-            SettingsStore.getInstance(getContext()).setCylinderDensity(enabled ? SettingsStore.CYLINDER_DENSITY_ENABLED_DEFAULT : 0.0f);
-            showRestartDialog();
+            float density = enabled ? SettingsStore.CYLINDER_DENSITY_ENABLED_DEFAULT : 0.0f;
+            SettingsStore.getInstance(getContext()).setCylinderDensity(density);
+            mWidgetManager.setCylinderDensity(density);
         });
 
         int uaMode = SettingsStore.getInstance(getContext()).getUaMode();

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -933,7 +933,21 @@ void
 BrowserWorld::SetCylinderDensity(const float aDensity) {
   m.cylinderDensity = aDensity;
   for (WidgetPtr& widget: m.widgets) {
-    widget->SetCylinderDensity(aDensity);
+    const bool useCylinder = m.cylinderDensity > 0 && widget->GetPlacement()->cylinder;
+    if (useCylinder && widget->GetCylinder()) {
+      widget->SetCylinderDensity(aDensity);
+    } else if (useCylinder && !widget->GetCylinder()) {
+      VRLayerCylinderPtr layer = m.device->CreateLayerCylinder(widget->GetLayer());
+      CylinderPtr cylinder = Cylinder::Create(m.create, layer);
+      widget->SetCylinder(cylinder);
+      widget->SetCylinderDensity(aDensity);
+    } else if (widget->GetCylinder()) {
+      float w = 0, h = 0;
+      widget->GetWorldSize(w, h);
+      VRLayerQuadPtr layer = m.device->CreateLayerQuad(widget->GetLayer());
+      QuadPtr quad = Quad::Create(m.create, w, h, layer);
+      widget->SetQuad(quad);
+    }
   }
 }
 

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -64,8 +64,10 @@ public:
   virtual void EndFrame(bool aDiscard = false) = 0;
   virtual VRLayerQuadPtr CreateLayerQuad(int32_t aWidth, int32_t aHeight,
                                          VRLayerSurface::SurfaceType aSurfaceType) { return nullptr; }
+  virtual VRLayerQuadPtr CreateLayerQuad(const VRLayerSurfacePtr& aMoveLayer) { return nullptr; }
   virtual VRLayerCylinderPtr CreateLayerCylinder(int32_t aWidth, int32_t aHeight,
                                                 VRLayerSurface::SurfaceType aSurfaceType) { return nullptr; }
+  virtual VRLayerCylinderPtr CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer) { return nullptr; }
   virtual VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) { return nullptr; }
   virtual VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) { return nullptr; }
   virtual void DeleteLayer(const VRLayerPtr& aLayer) {};

--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -58,6 +58,8 @@ public:
   vrb::NodePtr GetRoot() const;
   QuadPtr GetQuad() const;
   CylinderPtr GetCylinder() const;
+  void SetQuad(const QuadPtr& aQuad) const;
+  void SetCylinder(const CylinderPtr& aCylinder) const;
   VRLayerSurfacePtr GetLayer() const;
   vrb::TransformPtr GetTransformNode() const;
   const WidgetPlacementPtr& GetPlacement() const;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -43,8 +43,10 @@ public:
   void EndFrame(const bool aDiscard) override;
   VRLayerQuadPtr CreateLayerQuad(int32_t aWidth, int32_t aHeight,
                                  VRLayerSurface::SurfaceType aSurfaceType) override;
+  VRLayerQuadPtr CreateLayerQuad(const VRLayerSurfacePtr& aMoveLayer) override;
   VRLayerCylinderPtr CreateLayerCylinder(int32_t aWidth, int32_t aHeight,
                                          VRLayerSurface::SurfaceType aSurfaceType) override;
+  VRLayerCylinderPtr CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer) override;
   VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) override;
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;


### PR DESCRIPTION
This PR allows to switch between flat and curved display without a restart.

With Oculus Layers it reuses the swapChain so no surfaces are created during the switch.
With GL geometries it reuses the SurfaceTexture.