### PR TITLE
Replace Gamepad id from "Gear VR Controller" to Oculus Go/HTC HTC Vive Focus controllers

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -769,7 +769,7 @@ struct DeviceDelegateOculusVR::State {
           controller->SetButtonCount(count, 6);
         } else {
           // Oculus Go only has one kind of controller model.
-          controller->CreateController(count, 0, "Gear VR Controller");
+          controller->CreateController(count, 0, "Oculus Go Controller");
           controller->SetButtonCount(count, 2);
         }
 

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -299,7 +299,7 @@ DeviceDelegateWaveVR::SetControllerDelegate(ControllerDelegatePtr& aController) 
     return;
   }
   for (int32_t index = 0; index < kMaxControllerCount; index++) {
-    m.delegate->CreateController(index, 0, "Gear VR Controller");
+    m.delegate->CreateController(index, 0, "HTC Vive Focus Controller");
   }
 }
 


### PR DESCRIPTION
Per #812, we should use the same gamepad id, `Oculus Go Controller`, as other browsers when running in Oculus Go display.