### PR TITLE
Making Wave support 6DOF controllers.

### DIFF
--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -187,7 +187,8 @@ struct DeviceDelegateWaveVR::State {
         delegate->SetCapabilityFlags(index, device::Orientation);
       }
 
-      const bool bumperPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Digital_Trigger);
+      const bool bumperPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Digital_Trigger)
+                                || WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Trigger);
       const bool touchpadPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Touchpad);
       const bool touchpadTouched = WVR_GetInputTouchState(controller.type, WVR_InputId_Alias1_Touchpad);
       const bool menuPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Menu);
@@ -395,6 +396,9 @@ DeviceDelegateWaveVR::ProcessEvents() {
         break;
       case WVR_EventType_RecenterSuccess: {
         VRB_DEBUG("WVR_EventType_RecenterSuccess");
+        WVR_InAppRecenter(WVR_RecenterType_YawAndPosition);
+        m.recentered = !m.ignoreNextRecenter;
+        m.ignoreNextRecenter = false;
       }
         break;
       case WVR_EventType_RecenterFail: {
@@ -497,7 +501,7 @@ DeviceDelegateWaveVR::StartFrame() {
       continue;
     }
     vrb::Matrix controllerTransform = vrb::Matrix::FromRowMajor(pose.poseMatrix.m);
-    if (m.elbow) {
+    if (m.elbow && !pose.is6DoFPose) {
       ElbowModel::HandEnum hand = ElbowModel::HandEnum::Right;
       if (m.devicePairs[id].type == WVR_DeviceType_Controller_Left) {
         hand = ElbowModel::HandEnum::Left;


### PR DESCRIPTION
Doing some adjustments to make 6DOF controllers work on Wave devices. Currently, the 6DOF recenter function doesn't work from this new device, but it makes sense to add the same code as we did for 3DOF controllers. Besides, on this 6DOF controller, it uses `WVR_InputId_Alias1_Trigger` instead of `WVR_InputId_Alias1_Digital_Trigger` for trigger btn, we have to support both for different controllers. Furthermore, we haven't given a new 3D model for this new controller, we would give a todo list for this art work.
