### PR TITLE
Set correct Oculus WebVR device name

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -988,7 +988,11 @@ DeviceDelegateOculusVR::RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) {
     return;
   }
 
-  m.immersiveDisplay->SetDeviceName("Oculus");
+  if (m.IsOculusQuest()) {
+    m.immersiveDisplay->SetDeviceName("Oculus Quest");
+  } else {
+    m.immersiveDisplay->SetDeviceName("Oculus Go");
+  }
   uint32_t width, height;
   m.GetImmersiveRenderSize(width, height);
   m.immersiveDisplay->SetEyeResolution(width, height);


### PR DESCRIPTION
We are using "Oculus" instead of "Oculus Go" for the WebVR device name.

I found that this affects Sketchfab performance (with "Oculus Go" it uses a lower quality model/shader). Could this affect other engines @fernandojsg, @cvan?

@daoshengmu Please review the correct name for Quest

