### PR TITLE
Hide Wave controller if input is captured by system

### DIFF
--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -174,7 +174,7 @@ struct DeviceDelegateWaveVR::State {
 
     for (int index = 0; index < kMaxControllerCount; index++) {
       Controller& controller = controllers[index];
-      if(!WVR_IsDeviceConnected(controller.type)) {
+      if (WVR_IsInputFocusCapturedBySystem() || !WVR_IsDeviceConnected(controller.type)) {
         if (controller.enabled) {
           delegate->SetEnabled(index, false);
           controller.enabled = false;


### PR DESCRIPTION
App controller should be hidden when system has focus.