### PR TITLE
Add Youtube webcompat webextension

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
@@ -26,6 +26,7 @@ import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.geckoview.GeckoSession.SessionState;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.geckoview.MediaElement;
+import org.mozilla.geckoview.WebExtension;
 import org.mozilla.geckoview.WebRequestError;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
@@ -72,6 +73,7 @@ public class SessionStore implements ContentBlocking.Delegate, GeckoSession.Navi
     // You can test a local file using: "resource://android/assets/webvr/index.html"
     public static final String PRIVATE_BROWSING_URI = "about:privatebrowsing";
     public static final int NO_SESSION_ID = -1;
+    private static final String[] WEB_EXTENSIONS = new String[] {"youtube_webcompat"};
 
     private LinkedList<GeckoSession.NavigationDelegate> mNavigationListeners;
     private LinkedList<GeckoSession.ProgressDelegate> mProgressListeners;
@@ -179,6 +181,10 @@ public class SessionStore implements ContentBlocking.Delegate, GeckoSession.Navi
             }
 
             mRuntime = GeckoRuntime.create(aContext, runtimeSettingsBuilder.build());
+            for (String extension: WEB_EXTENSIONS) {
+                String path = "resource://android/assets/web_extensions/" + extension + "/";
+                mRuntime.registerWebExtension(new WebExtension(path));
+            }
 
         } else {
             mRuntime.attachTo(aContext);

--- a/app/src/main/assets/web_extensions/youtube_webcompat/main.css
+++ b/app/src/main/assets/web_extensions/youtube_webcompat/main.css
@@ -1,0 +1,3 @@
+div.alert-with-button-renderer {
+	display:none;
+}

--- a/app/src/main/assets/web_extensions/youtube_webcompat/main.js
+++ b/app/src/main/assets/web_extensions/youtube_webcompat/main.js
@@ -1,0 +1,8 @@
+// Add meta-viewport
+let viewport = document.head.querySelector("meta[name='viewport']");
+if (!viewport) {
+    viewport = document.createElement("meta");
+    viewport.name = "viewport";
+    viewport.content = "width=user-width, initial-scale=1";
+    document.head.appendChild(viewport);
+}

--- a/app/src/main/assets/web_extensions/youtube_webcompat/manifest.json
+++ b/app/src/main/assets/web_extensions/youtube_webcompat/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 2,
+  "name": "YoutubeWebCompat",
+  "version": "1.0",
+  "description": "Youtube web compat fixes for Firefox Reality",
+  "content_scripts": [
+    {
+      "matches": ["*://*.youtube.com/*"],
+      "css": ["main.css"],
+      "js": ["main.js"],
+      "run_at": "document_end"
+    }
+  ]
+}


### PR DESCRIPTION
- Fixes #862 
- Fixes #1019

Note: When https://bugzilla.mozilla.org/show_bug.cgi?id=1511177 lands we probably can remove the viewport change injection. That should also avoid the layout change.
