### PR TITLE
User dynamic clock levels on Oculus

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -68,6 +68,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 
+import androidx.annotation.IntDef;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
@@ -775,7 +776,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     // VideoAvailabilityListener
     @Override
     public void onVideoAvailabilityChanged(boolean aVideosAvailable) {
-        queueRunnable(() -> setCPULevelNative(aVideosAvailable));
+        queueRunnable(() -> setCPULevelNative(aVideosAvailable ? CPU_LEVEL_HIGH : CPU_LEVEL_NORMAL));
     }
 
     // WidgetManagerDelegate
@@ -1051,7 +1052,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void setControllersVisibleNative(boolean aVisible);
     private native void runCallbackNative(long aCallback);
     private native void setCylinderDensityNative(float aDensity);
-    private native void setCPULevelNative(boolean aHighLevel);
+    private native void setCPULevelNative(@CPULevelFlags int aCPULevel);
     private native void setIsServo(boolean aIsServo);
     private native void updateFoveatedLevelNative(int appLevel, int webVRLevel);
+
+    @IntDef(value = { CPU_LEVEL_NORMAL, CPU_LEVEL_HIGH})
+    private @interface CPULevelFlags {}
+    private static final int CPU_LEVEL_NORMAL = 0;
+    private static final int CPU_LEVEL_HIGH = 1;
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -71,7 +71,7 @@ import java.util.LinkedList;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 
-public class VRBrowserActivity extends PlatformActivity implements WidgetManagerDelegate {
+public class VRBrowserActivity extends PlatformActivity implements WidgetManagerDelegate, SessionStore.VideoAvailabilityListener {
 
     private BroadcastReceiver mCrashReceiver = new BroadcastReceiver() {
         @Override
@@ -148,6 +148,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         Bundle extras = getIntent() != null ? getIntent().getExtras() : null;
         SessionStore.get().setContext(this, extras);
         SessionStore.get().registerListeners();
+        SessionStore.get().addVideoAvailabilityListener(this);
 
         // Create broadcast receiver for getting crash messages from crash process
         IntentFilter intentFilter = new IntentFilter();
@@ -305,6 +306,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         // Remove all widget listeners
         mTray.removeAllListeners();
         mBookmarksView.removeAllListeners();
+        SessionStore.get().removeVideoAvailabilityListener(this);
 
         SessionStore.get().unregisterListeners();
         super.onDestroy();
@@ -770,6 +772,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         });
     }
 
+    // VideoAvailabilityListener
+    @Override
+    public void onVideoAvailabilityChanged(boolean aVideosAvailable) {
+        queueRunnable(() -> setCPULevelNative(aVideosAvailable));
+    }
+
     // WidgetManagerDelegate
     @Override
     public void addWidget(final Widget aWidget) {
@@ -1043,6 +1051,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void setControllersVisibleNative(boolean aVisible);
     private native void runCallbackNative(long aCallback);
     private native void setCylinderDensityNative(float aDensity);
+    private native void setCPULevelNative(boolean aHighLevel);
     private native void setIsServo(boolean aIsServo);
     private native void updateFoveatedLevelNative(int appLevel, int webVRLevel);
 }

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -959,6 +959,11 @@ BrowserWorld::SetCylinderDensity(const float aDensity) {
 }
 
 void
+BrowserWorld::SetCPULevel(const bool aHighLevel) {
+  m.device->SetCPULevel(aHighLevel ? device::CPULevel::High : device::CPULevel::Normal);
+}
+
+void
 BrowserWorld::SetIsServo(const bool aIsServo) {
   m.externalVR->SetSourceBrowser(aIsServo ? ExternalVR::VRBrowserType::Servo : ExternalVR::VRBrowserType::Gecko);
 }
@@ -1345,6 +1350,11 @@ JNI_METHOD(void, runCallbackNative)
     (*func)();
     delete func;
   }
+}
+
+JNI_METHOD(void, setCPULevelNative)
+(JNIEnv* aEnv, jobject, jboolean aHighLevel) {
+  crow::BrowserWorld::Instance().SetCPULevel(aHighLevel);
 }
 
 JNI_METHOD(void, setIsServo)

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -959,8 +959,8 @@ BrowserWorld::SetCylinderDensity(const float aDensity) {
 }
 
 void
-BrowserWorld::SetCPULevel(const bool aHighLevel) {
-  m.device->SetCPULevel(aHighLevel ? device::CPULevel::High : device::CPULevel::Normal);
+BrowserWorld::SetCPULevel(const device::CPULevel aLevel) {
+  m.device->SetCPULevel(aLevel);
 }
 
 void
@@ -1353,8 +1353,8 @@ JNI_METHOD(void, runCallbackNative)
 }
 
 JNI_METHOD(void, setCPULevelNative)
-(JNIEnv* aEnv, jobject, jboolean aHighLevel) {
-  crow::BrowserWorld::Instance().SetCPULevel(aHighLevel);
+(JNIEnv* aEnv, jobject, int aCPULevel) {
+  crow::BrowserWorld::Instance().SetCPULevel(static_cast<crow::device::CPULevel>(aCPULevel));
 }
 
 JNI_METHOD(void, setIsServo)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -58,6 +58,7 @@ public:
   void ResetUIYaw();
   void SetCylinderDensity(const float aDensity);
   void SetIsServo(const bool aIsServo);
+  void SetCPULevel(const bool aHighLevel);
   JNIEnv* GetJNIEnv() const;
 protected:
   struct State;

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -58,7 +58,7 @@ public:
   void ResetUIYaw();
   void SetCylinderDensity(const float aDensity);
   void SetIsServo(const bool aIsServo);
-  void SetCPULevel(const bool aHighLevel);
+  void SetCPULevel(const device::CPULevel aLevel);
   JNIEnv* GetJNIEnv() const;
 protected:
   struct State;

--- a/app/src/main/cpp/Device.h
+++ b/app/src/main/cpp/Device.h
@@ -19,7 +19,7 @@ const CapabilityFlags MountDetection = 1 << 8;
 const CapabilityFlags PositionEmulated = 1 << 9;
 enum class Eye { Left, Right };
 enum class RenderMode { StandAlone, Immersive };
-enum class CPULevel { Normal, High };
+enum class CPULevel { Normal = 0, High };
 const int32_t EyeCount = 2;
 inline int32_t EyeIndex(const Eye aEye) { return aEye == Eye::Left ? 0 : 1; }
 

--- a/app/src/main/cpp/Device.h
+++ b/app/src/main/cpp/Device.h
@@ -19,6 +19,7 @@ const CapabilityFlags MountDetection = 1 << 8;
 const CapabilityFlags PositionEmulated = 1 << 9;
 enum class Eye { Left, Right };
 enum class RenderMode { StandAlone, Immersive };
+enum class CPULevel { Normal, High };
 const int32_t EyeCount = 2;
 inline int32_t EyeIndex(const Eye aEye) { return aEye == Eye::Left ? 0 : 1; }
 

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -60,6 +60,7 @@ public:
   virtual void ReleaseControllerDelegate() = 0;
   virtual int32_t GetControllerModelCount() const = 0;
   virtual const std::string GetControllerModelName(const int32_t aModelIndex) const = 0;
+  virtual void SetCPULevel(const device::CPULevel aLevel) {};
   virtual void ProcessEvents() = 0;
   virtual void StartFrame() = 0;
   virtual void BindEye(const device::Eye aWhich) = 0;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -38,6 +38,7 @@ public:
   void SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
+  void SetCPULevel(const device::CPULevel aLevel) override;
   void ProcessEvents() override;
   void StartFrame() override;
   void BindEye(const device::Eye aWhich) override;


### PR DESCRIPTION
According to the Oculus docs the clock levels are a baseline, so even setting them to 2 the system can decide to increase them. However, we think something with their throttler is just wrong since with video perf we saw better performance at 4 than 2. If it were dynamic that should not be the case. On #947 some tests performed faster with cpu levels set to 4 than 2.

This PR sets the clock levels to 2 by default, and switches to 4 during WebVR and video playback. The benefit should be saving battery when we are not in WebVR and playing videos. Oculus browser does the same thing (dynamic levels while browsing but max levels in WebVR). My concern is if it affects WebGL while not in WebVR.

Thoughts? Should we use dynamic or fixed clock levels to 4?

Note: We can use the same code in this PR to enable 72Hz in Oculus Go and setting it back to 60Hz during WebVR and video playback. I'm contacting Oculus to fix a bug. I'll update the PR when we get the solution (it seems a problem in their end according to the contact)