### PR TITLE
Bump OpenGLES version for Oculus

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.mozilla.vrbrowser">
+    <uses-feature android:glEsVersion="0x00030001"/>
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">


### PR DESCRIPTION
Required for oculus store. Tested on Go.