### PR TITLE
Add snakeyaml to deps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -289,6 +289,7 @@ dependencies {
     implementation deps.support.app_compat
     implementation deps.support.annotations
     implementation deps.constraint_layout
+    implementation deps.snakeyaml
 
     // Android Components
     implementation deps.mozilla_speech

--- a/versions.gradle
+++ b/versions.gradle
@@ -38,6 +38,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.espresso = "3.1.0-alpha4"
 versions.android_gradle_plugin = "3.2.0"
 versions.kotlin = "1.2.71"
+versions.snakeyaml = "1.24"
 def deps = [:]
 
 def gecko_view = [:]
@@ -107,6 +108,8 @@ deps.constraint_layout = "androidx.constraintlayout:constraintlayout:$versions.c
 deps.junit = "junit:junit:$versions.junit"
 
 deps.android_gradle_plugin = "com.android.tools.build:gradle:$versions.android_gradle_plugin"
+
+deps.snakeyaml = "org.yaml:snakeyaml:$versions.snakeyaml:android"
 
 ext.deps = deps
 


### PR DESCRIPTION
GeckoView uses snakeyaml now, and it is included as a dependency in
the Maven POM, but that doesn't help when we're using a local
GeckoView build.