### PR TITLE
Remove android speech dependency from GV using Proguard.

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,6 +30,23 @@
     public static int d(...);
 }
 
+
+# --------------------------------------------------------------------
+# REMOVE android speech dependency from GV
+# --------------------------------------------------------------------
+-assumenosideeffects class org.mozilla.gecko.SpeechSynthesisService {
+    private static void initSynthInternal();
+    private static void stopInternal();
+    private static void speakInternal(java.lang.String, java.lang.String, float, float, float, java.lang.String, java.util.concurrent.atomic.AtomicBoolean);
+    private static void setUtteranceListener();
+    private static void stopInternal();
+}
+
+-assumenosideeffects class org.mozilla.gecko.util.InputOptionsUtils {
+    public static boolean supportsVoiceRecognizer(android.content.Context, java.lang.String);
+    public static android.content.Intent createVoiceRecognizerIntent(java.lang.String);
+}
+
 -dontwarn **
 -target 1.7
 -dontusemixedcaseclassnames
@@ -37,8 +54,7 @@
 -dontpreverify
 -verbose
 -optimizations !code/simplification/arithmetic,!code/allocation/variable
--keep class **
--keepclassmembers class *{*;}
 -keepattributes *
-
+-keep class !org.mozilla.gecko.Speech* { *; }
+-keepclassmembers class !org.mozilla.gecko.Speech*, ** { *; }
 -printconfiguration "build/outputs/mapping/configuration.txt"

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
@@ -749,6 +749,7 @@ public class SessionStore implements ContentBlocking.Delegate, GeckoSession.Navi
             out.write("pref(\"apz.allow_double_tap_zooming\", false);\n".getBytes());
             out.write("pref(\"dom.webcomponents.customelements.enabled\", true);\n".getBytes());
             out.write("pref(\"javascript.options.ion\", true);\n".getBytes());
+            out.write("pref(\"media.webspeech.synth.enabled\", false);\n".getBytes());
             // Prevent autozoom when giving a form field focus.
             out.write("pref(\"formhelper.autozoom\", false);\n".getBytes());
             // Uncomment this to enable WebRender. WARNING NOT READY FOR USAGE.


### PR DESCRIPTION
Fixes #1077

Depends on: https://bugzilla.mozilla.org/show_bug.cgi?id=1544584