### PR TITLE
fixes 1034, minor adjustments to l10n.toml for android-l10n

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -2,14 +2,20 @@
 basepath = "."
 
 locales = [
-"de",
-"es",
-"fr",
-"it",
-"ja",
-"ko",
-"zh-CN",
-"zh-TW",
+  "de",
+  "es",
+  "fr",
+  "it",
+  "ja",
+  "ko",
+  "zh-CN",
+  "zh-TW",
+]
+
+# Expose the following branches to localization
+# Changes to this list should be announced to the l10n team ahead of time.
+branches = [
+    "master",
 ]
 
 [env]


### PR DESCRIPTION
Sorry for the delay here, I did a small reformat on the locale list, and added the branch data we need for android-l10n.

Philip, are you a good person to rubber-stamp this?

CC @Delphine 