### PR TITLE
Keyboard refinements

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/AutoCompletionView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/AutoCompletionView.java
@@ -32,13 +32,14 @@ public class AutoCompletionView extends FrameLayout {
     private int mLineHeight;
     private UIButton mExtendButton;
     private int mExtendedHeight;
-    private final int kMaxItemsPerLine = 12;
+    private final int kMaxItemsPerLine = 15;
     private ArrayList<Words> mExtraItems = new ArrayList<>();
     private boolean mIsExtended;
     private Delegate mDelegate;
 
     public interface Delegate {
         void onAutoCompletionItemClick(Words aItem);
+        void onAutoCompletionExtendedChanged();
     }
 
     public AutoCompletionView(Context aContext) {
@@ -71,8 +72,7 @@ public class AutoCompletionView extends FrameLayout {
                 enterExtend();
             }
         });
-        mKeyWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.keyboard_key_width);
-        mKeyHeight = WidgetPlacement.pixelDimension(getContext(), R.dimen.keyboard_key_height);
+        mKeyWidth = mKeyHeight = WidgetPlacement.pixelDimension(getContext(), R.dimen.autocompletion_widget_button_size);
         mLineHeight = WidgetPlacement.pixelDimension(getContext(), R.dimen.autocompletion_widget_line_height);
         mExtendedHeight = mLineHeight * 6;
         setFocusable(false);
@@ -90,7 +90,6 @@ public class AutoCompletionView extends FrameLayout {
         UITextButton key = new UITextButton(getContext());
         key.setTintColorList(R.drawable.main_button_icon_color);
         key.setBackground(getContext().getDrawable(R.drawable.keyboard_key_background));
-        //key.setBackgroundColor(Color.RED);
         if (aHandler != null) {
             key.setOnClickListener(aHandler);
         }
@@ -137,6 +136,10 @@ public class AutoCompletionView extends FrameLayout {
         mExtendButton.setVisibility(n >= kMaxItemsPerLine ? View.VISIBLE : View.GONE);
     }
 
+    public boolean isExtended() {
+        return mIsExtended;
+    }
+
     private OnClickListener clickHandler = v -> {
         UITextButton button = (UITextButton) v;
         if (mIsExtended) {
@@ -178,6 +181,9 @@ public class AutoCompletionView extends FrameLayout {
         RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) getLayoutParams();
         params.height = mExtendedHeight;
         setLayoutParams(params);
+        if (mDelegate != null) {
+            mDelegate.onAutoCompletionExtendedChanged();
+        }
     }
 
     private void exitExtend() {
@@ -190,5 +196,8 @@ public class AutoCompletionView extends FrameLayout {
         RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) getLayoutParams();
         params.height = WidgetPlacement.pixelDimension(getContext(), R.dimen.autocompletion_widget_line_height);
         setLayoutParams(params);
+        if (mDelegate != null) {
+            mDelegate.onAutoCompletionExtendedChanged();
+        }
     }
 }

--- a/app/src/main/res/layout/keyboard.xml
+++ b/app/src/main/res/layout/keyboard.xml
@@ -9,6 +9,7 @@
             android:id="@+id/keyboardContainer"
             android:layout_width="match_parent"
             android:layout_height="@dimen/keyboard_height"
+            android:layout_marginTop="@dimen/autocompletion_widget_line_height"
             android:orientation="horizontal">
             <RelativeLayout
                 android:layout_width="@dimen/keyboard_alphabetic_width"
@@ -16,7 +17,7 @@
 
                 <org.mozilla.vrbrowser.ui.views.CustomKeyboardView
                     android:id="@+id/keyboard"
-                    android:padding="20dp"
+                    android:padding="15dp"
                     android:background="@drawable/keyboard_background"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
@@ -31,11 +32,10 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_gravity="center"
-                    android:layout_margin="20dp"
+                    android:layout_margin="15dp"
                     android:background="@color/asphalt"
                     android:alpha="0.5"
                     android:visibility="visible"/>
-
 
                 <org.mozilla.vrbrowser.ui.views.CustomKeyboardView
                     android:id="@+id/popupKeyboard"
@@ -58,7 +58,7 @@
                 android:id="@+id/keyboardNumeric"
                 android:layout_width="@dimen/keyboard_numeric_width"
                 android:layout_height="match_parent"
-                android:padding="20dp"
+                android:padding="15dp"
                 android:background="@drawable/keyboard_background"
                 android:keyBackground="@drawable/keyboard_key_background"
                 android:shadowColor="@android:color/transparent"
@@ -69,22 +69,21 @@
 
         <org.mozilla.vrbrowser.ui.views.AutoCompletionView
             android:id="@+id/autoCompletionView"
-            android:layout_width="@dimen/keyboard_alphabetic_width"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/autocompletion_widget_line_height"
+            android:layout_marginStart="38dp"
             android:visibility="gone">
 
         </org.mozilla.vrbrowser.ui.views.AutoCompletionView>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/keyboardCloseButton"
-            android:visibility="gone"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
+            android:layout_width="@dimen/autocompletion_widget_line_height"
+            android:layout_height="@dimen/autocompletion_widget_line_height"
             app:tintColorList="@drawable/url_button_icon_color"
             android:padding="10dp"
             android:src="@drawable/ic_icon_exit"
             android:scaleType="fitCenter"
-            android:layout_marginLeft="240dp"
             android:background="@drawable/keyboard_key_background"/>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/keyboard.xml
+++ b/app/src/main/res/layout/keyboard.xml
@@ -9,7 +9,7 @@
             android:id="@+id/keyboardContainer"
             android:layout_width="match_parent"
             android:layout_height="@dimen/keyboard_height"
-            android:layout_marginTop="@dimen/autocompletion_widget_line_height"
+            android:layout_marginTop="37dp"
             android:orientation="horizontal">
             <RelativeLayout
                 android:layout_width="@dimen/keyboard_alphabetic_width"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -23,7 +23,7 @@
     <dimen name="keyboard_width">674dp</dimen>
     <dimen name="keyboard_height">188dp</dimen>
     <dimen name="keyboard_alphabetic_width">526dp</dimen>
-    <dimen name="keyboard_numeric_width">148dp</dimen>
+    <dimen name="keyboard_numeric_width">144dp</dimen>
     <dimen name="keyboard_horizontal_gap">4dp</dimen>
     <dimen name="keyboard_vertical_gap">4dp</dimen>
     <dimen name="keyboard_key_width">36dp</dimen>
@@ -38,7 +38,7 @@
     <dimen name="keyboard_key_longtext_size">12dp</dimen>
     <dimen name="keyboard_key_hovered_padding">0dp</dimen>
     <dimen name="keyboard_key_pressed_padding">0dp</dimen>
-    <dimen name="keyboard_autocompletion_padding">3dp</dimen>
+    <dimen name="keyboard_autocompletion_padding">4dp</dimen>
     <!-- Permission PromptWidget -->
     <item name="permission_world_width" format="float" type="dimen">1.6</item>
     <dimen name="permission_width">320dp</dimen>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -20,14 +20,14 @@
     <item name="keyboard_y_distance_from_browser" format="float" type="dimen">-0.18</item>
     <item name="keyboard_z_distance_from_browser" format="float" type="dimen">2.0</item>
     <item name="keyboard_world_rotation" format="float" type="dimen">-35.0</item>
-    <dimen name="keyboard_width">672dp</dimen>
-    <dimen name="keyboard_height">190dp</dimen>
-    <dimen name="keyboard_alphabetic_width">516dp</dimen>
-    <dimen name="keyboard_numeric_width">156dp</dimen>
+    <dimen name="keyboard_width">674dp</dimen>
+    <dimen name="keyboard_height">188dp</dimen>
+    <dimen name="keyboard_alphabetic_width">526dp</dimen>
+    <dimen name="keyboard_numeric_width">148dp</dimen>
     <dimen name="keyboard_horizontal_gap">4dp</dimen>
     <dimen name="keyboard_vertical_gap">4dp</dimen>
-    <dimen name="keyboard_key_width">34dp</dimen>
-    <dimen name="keyboard_key_height">34dp</dimen>
+    <dimen name="keyboard_key_width">36dp</dimen>
+    <dimen name="keyboard_key_height">36dp</dimen>
     <dimen name="keyboard_key_rounded_corner">18dp</dimen>
     <dimen name="keyboard_key_space_width">186dp</dimen>
     <dimen name="keyboard_key_backspace_width">50dp</dimen>
@@ -95,10 +95,10 @@
     <dimen name="no_internet_z_distance" format="float" type="dimen">2.5</dimen>
 
     <!-- Autocompletion Widget -->
-    <dimen name="autocompletion_widget_default_width">40dp</dimen>
-    <dimen name="autocompletion_widget_line_height">40dp</dimen>
+    <dimen name="autocompletion_widget_line_height">36dp</dimen>
     <dimen name="autocompletion_widget_extended_height">160dp</dimen>
-    <dimen name="autocompletion_widget_margin">35dp</dimen>
+    <dimen name="autocompletion_widget_margin">4dp</dimen>
+    <dimen name="autocompletion_widget_button_size">34dp</dimen>
 
     <!-- Tray -->
     <item name="tray_world_y" format="float" type="dimen">0.1</item>

--- a/app/src/main/res/xml/keyboard_numeric.xml
+++ b/app/src/main/res/xml/keyboard_numeric.xml
@@ -5,23 +5,23 @@
     android:keyWidth="@dimen/keyboard_key_width"
     android:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="49" android:keyLabel="1"/>
+        <Key android:codes="49" android:keyLabel="1"  android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
         <Key android:codes="50" android:keyLabel="2"/>
         <Key android:codes="51" android:keyLabel="3"/>
 
     </Row>
     <Row>
-        <Key android:codes="52" android:keyLabel="4"/>
+        <Key android:codes="52" android:keyLabel="4" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
         <Key android:codes="53" android:keyLabel="5"/>
         <Key android:codes="54" android:keyLabel="6"/>
     </Row>
     <Row>
-        <Key android:codes="55" android:keyLabel="7"/>
+        <Key android:codes="55" android:keyLabel="7" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
         <Key android:codes="56" android:keyLabel="8"/>
         <Key android:codes="57" android:keyLabel="9"/>
     </Row>
     <Row>
-        <Key android:codes="35" android:keyLabel="#"/>
+        <Key android:codes="35" android:keyLabel="#" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
         <Key android:codes="48" android:keyLabel="0"/>
         <Key android:codes="42" android:keyIcon="@drawable/ic_keyboard_asterisk"/>
     </Row>


### PR DESCRIPTION
Includes some keyboard refinements from the latest spec published in https://github.com/MozillaReality/FirefoxReality/issues/636

- Improved margins
- Added close button
- Autocompletion view only visible when there are candidates
- Keyboard top margin is the same on all languages whether there is auto completion or not

Note: This PR still doesn't change the keyboard world size, position or angle. I prefer to move that to other PR