### PR TITLE
Show correct enter key label based on input IME options

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/BaseKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/BaseKeyboard.java
@@ -34,6 +34,11 @@ public abstract class BaseKeyboard implements KeyboardInterface {
     }
 
     @Override
+    public String getSpaceKeyText(String aComposingText) {
+        return StringUtils.getStringByLocale(mContext, R.string.keyboard_space_label, getLocale()).toUpperCase();
+    }
+
+    @Override
     public String getComposingText(String aComposing, String aCode) {
         return aComposing.replaceFirst(Pattern.quote(aCode), "");
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/KeyboardInterface.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/KeyboardInterface.java
@@ -37,7 +37,7 @@ public interface KeyboardInterface {
     String getComposingText(String aComposing, String aCode);
     String getKeyboardTitle();
     Locale getLocale();
-    default String getSpaceKeyText(String aComposingText) { return ""; }
+    String getSpaceKeyText(String aComposingText);
     String getEnterKeyText(int aIMEOptions, String aComposingText);
     String getModeChangeKeyText();
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -113,7 +113,8 @@ public class NavigationURLBar extends FrameLayout {
         mURL = findViewById(R.id.urlEditText);
         mURL.setShowSoftInputOnFocus(false);
         mURL.setOnEditorActionListener((aTextView, actionId, event) -> {
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
+            if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_SEARCH
+                    || actionId == EditorInfo.IME_ACTION_GO || actionId == EditorInfo.IME_ACTION_SEND) {
                 handleURLEdit(aTextView.getText().toString());
                 return true;
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -275,6 +275,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         }
 
         updateCandidates();
+        updateSpecialKeyLabels();
     }
 
     public void dismiss() {

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -31,7 +31,7 @@
             android:fadingEdgeLength="20dp"
             android:gravity="center_vertical"
             android:hint="@string/search_placeholder"
-            android:imeOptions="actionDone"
+            android:imeOptions="actionGo"
             android:inputType="textUri"
             android:paddingStart="20dp"
             android:paddingEnd="80dp"


### PR DESCRIPTION
- Most of the implementation already landed in #1116 but we were missing a update call when the keyboard is changed (in addition to autocompletion candidate changes)
- I changed the URL bar action to `go`.
- Test page to try `search` action: https://developer.mozilla.org/es/docs/Web/HTML/Elemento/input/search

It seems that GV reports action `go` for Amazon and Google searches. iPhone browser reports `search`for both pages. May that be another GV bug @bluemarvin @cvan ?