### PR TITLE
Add support for resizing alphabetic keyboard with based on language

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -166,6 +166,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             workaroundGeckoSigAction();
         }
         mUiThread = Thread.currentThread();
+        mUiThread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                e.printStackTrace();
+            }
+        });
 
         Bundle extras = getIntent() != null ? getIntent().getExtras() : null;
         SessionStore.get().setContext(this, extras);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/BaseKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/BaseKeyboard.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.view.inputmethod.EditorInfo;
 
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.utils.StringUtils;
 
 import java.util.Locale;
@@ -40,5 +41,9 @@ public abstract class BaseKeyboard implements KeyboardInterface {
     @Override
     public String getModeChangeKeyText() {
         return mContext.getString(R.string.keyboard_mode_change);
+    }
+
+    public float getAlphabeticKeyboardWidth() {
+        return WidgetPlacement.dpDimension(mContext, R.dimen.keyboard_alphabetic_width);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/KeyboardInterface.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/KeyboardInterface.java
@@ -29,6 +29,7 @@ public interface KeyboardInterface {
         public String composing;
     }
     @NonNull CustomKeyboard getAlphabeticKeyboard();
+    float getAlphabeticKeyboardWidth();
     default @Nullable CandidatesResult getCandidates(String aComposingText) { return null; }
     default boolean supportsAutoCompletion() { return false; }
     default boolean usesComposingText() { return false; }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
@@ -116,11 +116,10 @@ public class WidgetPlacement {
         return unitFromMeters(floatDimension(aContext, aDimensionId));
     }
 
-    public static float convertDpToPixel(Context aContext, float dp){
+    public static int convertDpToPixel(Context aContext, float dp){
         Resources resources = aContext.getResources();
         DisplayMetrics metrics = resources.getDisplayMetrics();
-        float px = dp * ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT);
-        return px;
+        return (int) Math.ceil(dp * ((float)metrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT));
     }
 
     public static float convertPixelsToDp(Context aContext, float px){

--- a/app/src/main/res/layout/keyboard.xml
+++ b/app/src/main/res/layout/keyboard.xml
@@ -6,12 +6,12 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
         <LinearLayout
-            android:id="@+id/keyboardContainer"
             android:layout_width="match_parent"
             android:layout_height="@dimen/keyboard_height"
             android:layout_marginTop="37dp"
             android:orientation="horizontal">
             <RelativeLayout
+                android:id="@+id/keyboardContainer"
                 android:layout_width="@dimen/keyboard_alphabetic_width"
                 android:layout_height="match_parent">
 

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -20,7 +20,6 @@
     <item name="keyboard_y_distance_from_browser" format="float" type="dimen">-0.18</item>
     <item name="keyboard_z_distance_from_browser" format="float" type="dimen">2.0</item>
     <item name="keyboard_world_rotation" format="float" type="dimen">-35.0</item>
-    <dimen name="keyboard_width">674dp</dimen>
     <dimen name="keyboard_height">188dp</dimen>
     <dimen name="keyboard_alphabetic_width">526dp</dimen>
     <dimen name="keyboard_numeric_width">144dp</dimen>


### PR DESCRIPTION
While implementing the german keyboard I had some width space problems (they have a extra letter in the same line as `enter`). I tried this as a solution but then I switched to making keys a bit smaller.

I believe @daoshengmu also needs this feature for Zhuyin keybord. It may be required for russian too. 