### PR TITLE
Bump GeckoView to 68.0.20190509033505

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/InternalPages.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/InternalPages.java
@@ -6,8 +6,7 @@ import android.util.Base64;
 import org.mozilla.vrbrowser.R;
 
 import org.mozilla.geckoview.WebRequestError;
-import org.mozilla.geckoview.WebRequestError.ErrorCategory;
-import org.mozilla.geckoview.WebRequestError.Error;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -17,7 +16,7 @@ import mozilla.components.browser.errorpages.ErrorType;
 
 public class InternalPages {
 
-    private static ErrorType fromGeckoErrorToErrorType(@ErrorCategory int category, @Error int error) {
+    private static ErrorType fromGeckoErrorToErrorType(int category, int error) {
         switch(category) {
             case WebRequestError.ERROR_CATEGORY_UNKNOWN: {
                 return ErrorType.UNKNOWN;
@@ -143,8 +142,8 @@ public class InternalPages {
 
     public static String createErrorPage(Context context,
                                          String uri,
-                                         @ErrorCategory int errorCategory,
-                                         @Error int errorType) {
+                                         int errorCategory,
+                                         int errorType) {
         // TODO: browser-error pages component needs to accept a uri parameter
         String html = ErrorPages.INSTANCE.createErrorPage(
                 context,

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "68.0.20190422094240"
+versions.gecko_view = "68.0.20190509033505"
 versions.android_components = "0.31.0"
 versions.mozilla_speech = "1.0.6"
 versions.google_vr = "1.190.0"


### PR DESCRIPTION
Contains the fix for the Java CrashHandler.

https://bugzilla.mozilla.org/show_bug.cgi?id=1550185