### PR TITLE
fix shift key (fixes issue #1188)

### DIFF
--- a/app/src/main/res/drawable/ic_icon_keyboard_caps.xml
+++ b/app/src/main/res/drawable/ic_icon_keyboard_caps.xml
@@ -1,22 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="30dp"
-        android:height="30dp"
-        android:viewportWidth="200"
-        android:viewportHeight="200">
-
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
     <path
-            android:fillColor="@color/fog"
-            android:strokeColor="@color/fog"
-            android:strokeWidth="5.67"
-            android:strokeLineJoin="round"
-            android:strokeLineCap="round"
-            android:pathData="M 81.6 141.4 H 118.4 V 148.5 H 81.6 V 141.4 Z" />
-    <path
-            android:fillColor="@color/fog"
-            android:strokeColor="@color/fog"
-            android:strokeWidth="5.67"
-            android:strokeLineJoin="round"
-            android:strokeLineCap="round"
-            android:pathData="M 81.6 131.6 L 118.4 131.6 L 118.4 102.4 L 140.4 102.4 L 100 51.5 L 59.7 102.4 L 81.6 102.4 Z" />
+        android:fillColor="@color/fog"
+        android:pathData="M77.175,149.377a4.506,4.506 0,0 0,4.505 4.504h37.164a4.503,4.503 0,0 0,4.505 -4.504v-1.467a4.504,4.504 0,0 0,-4.505 -4.505H81.68a4.504,4.504 0,0 0,-4.505 4.505v1.467zM144.556,100.08l-40.765,-51.379a4.514,4.514 0,0 0,-5.488 -1.254,4.511 4.511,0 0,0 -1.57,1.254L55.967,100.08a4.505,4.505 0,0 0,0 5.579,4.72 4.72,0 0,0 3.752,1.722h17.292a0.163,0.163 0,0 1,0.164 0.163v20.88a4.506,4.506 0,0 0,4.505 4.505h37.164a4.503,4.503 0,0 0,4.505 -4.505v-20.88a0.164,0.164 0,0 1,0.163 -0.163h17.345a4.722,4.722 0,0 0,3.752 -1.722,4.509 4.509,0 0,0 -0.053,-5.579z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_icon_keyboard_shift_off.xml
+++ b/app/src/main/res/drawable/ic_icon_keyboard_shift_off.xml
@@ -1,7 +1,14 @@
-<vector android:height="30dp" android:viewportHeight="200"
-    android:viewportWidth="200" android:width="30dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@color/asphalt" android:fillType="evenOdd"
-        android:pathData="M140.35,102.43l-40.35,-50.88l-40.35,50.88l21.96,0l0,46.02l36.78,0l0,-46.02l21.96,0z"
-        android:strokeColor="@color/fog" android:strokeLineCap="round"
-        android:strokeLineJoin="round" android:strokeWidth="10"/>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="@color/asphalt"
+        android:pathData="M100.282,52.297L134.234,95.089H134.197L140.012,102.391H123.366H118.366V107.391V148.9H82.185V107.391V102.391H77.185H60.536L100.282,52.297ZM59.499,102.391C59.5,102.391 59.501,102.391 59.503,102.391L59.499,102.391Z"
+        android:strokeColor="@color/fog"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="10"/>
 </vector>

--- a/app/src/main/res/drawable/ic_icon_keyboard_shift_on.xml
+++ b/app/src/main/res/drawable/ic_icon_keyboard_shift_on.xml
@@ -1,7 +1,10 @@
-<vector android:height="24dp" android:viewportHeight="200"
-    android:viewportWidth="200" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@color/fog" android:fillType="evenOdd"
-        android:pathData="M140.35,102.43l-40.35,-50.88l-40.35,50.88l21.96,0l0,46.02l36.78,0l0,-46.02l21.96,0z"
-        android:strokeColor="@color/fog" android:strokeLineCap="round"
-        android:strokeLineJoin="round" android:strokeWidth="10"/>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="200"
+    android:viewportHeight="200">
+    <path
+        android:fillColor="@color/fog"
+        android:pathData="M144.584,100.089l-40.772,-51.387a4.517,4.517 0,0 0,-5.49 -1.254,4.51 4.51,0 0,0 -1.57,1.254L55.98,100.089a4.503,4.503 0,0 0,-0.533 4.758,4.497 4.497,0 0,0 4.056,2.544h17.681v42.003a4.506,4.506 0,0 0,4.506 4.506h37.171a4.505,4.505 0,0 0,4.505 -4.506v-42.003h17.682a4.494,4.494 0,0 0,4.056 -2.544,4.503 4.503,0 0,0 -0.533,-4.758h0.013z"/>
 </vector>


### PR DESCRIPTION
- fixes issue #1188, including modified shape per new icons provided in issue #1107 and fixed the Shift On and Caps Lock sizes so they don't get smaller and larger, respectively (as it did previously w/ the old icon)
- this properly fixes the keys so we can revert the revert in PR #1192 (thanks, @MortimerGoro)
- verified there are no visual regressions by checking side by side against this branch vs. f0c5f45a (the commit before the regression in c9d06ba, PR #1107)
