### PR TITLE
Avoid Infinite restart loop in the CrashReporterService

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -159,8 +159,16 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        // Fix for infinite restart on startup crashes.
+        long lastRestartTime = SettingsStore.getInstance(getBaseContext()).getLatestCrashRestartTime();
+        boolean cancelRestart = lastRestartTime > 0 && (System.currentTimeMillis() - lastRestartTime) < CrashReporterService.MIN_RESTART_INTERVAL_MS;
+        if (cancelRestart) {
+            finish();
+            return;
+        }
+
         // Set a global exception handler as soon as possible
-        GlobalExceptionHandler.register();
+        GlobalExceptionHandler.register(this.getApplicationContext());
 
         if (BuildConfig.FLAVOR_platform == "oculusvr") {
             workaroundGeckoSigAction();

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -440,5 +440,15 @@ public class SettingsStore {
         }
         return Locale.forLanguageTag(value);
     }
+
+    public long getLatestCrashRestartTime() {
+        return mPrefs.getLong(mContext.getString(R.string.settings_key_latest_crash_restart_time), -1);
+    }
+
+    public void setLatestCrashRestartTime(long aTimeStamp) {
+        SharedPreferences.Editor editor = mPrefs.edit();
+        editor.putLong(mContext.getString(R.string.settings_key_latest_crash_restart_time), aTimeStamp);
+        editor.commit();
+    }
 }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
@@ -28,7 +28,7 @@ public class CrashReporterService extends JobIntentService {
     private static final int JOB_ID = 1000;
     // Threshold used to fix Infinite restart loop on startup crashes.
     // See https://github.com/MozillaReality/FirefoxReality/issues/651
-    private static final long MIN_RESTART_INTERVAL_MS = 3000;
+    public static final long MIN_RESTART_INTERVAL_MS = 3000;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -53,7 +53,7 @@ public class CrashReporterService extends JobIntentService {
             }
 
             if (fatal) {
-                Log.d(LOGTAG, "======> NATIVE CRASH PARENT" + intent);
+                Log.d(LOGTAG, "======> NATIVE CRASH PARENT " + intent);
                 final int pid = Process.myPid();
                 final ActivityManager activityManager = (ActivityManager) this.getSystemService(Context.ACTIVITY_SERVICE);
                 if (activityManager == null) {
@@ -71,6 +71,7 @@ public class CrashReporterService extends JobIntentService {
                     }
 
                     if (!otherProcessesFound) {
+                        SettingsStore.getInstance(getBaseContext()).setLatestCrashRestartTime(System.currentTimeMillis());
                         intent.setClass(CrashReporterService.this, VRBrowserActivity.class);
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(intent);

--- a/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
@@ -5,12 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Process;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import org.mozilla.geckoview.GeckoRuntime;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserActivity;
+import org.mozilla.vrbrowser.browser.SettingsStore;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
@@ -24,6 +26,9 @@ public class CrashReporterService extends JobIntentService {
 
     private static final int PID_CHECK_INTERVAL = 100;
     private static final int JOB_ID = 1000;
+    // Threshold used to fix Infinite restart loop on startup crashes.
+    // See https://github.com/MozillaReality/FirefoxReality/issues/651
+    private static final long MIN_RESTART_INTERVAL_MS = 3000;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -41,8 +46,13 @@ public class CrashReporterService extends JobIntentService {
         if (GeckoRuntime.ACTION_CRASHED.equals(action)) {
             boolean fatal = intent.getBooleanExtra(GeckoRuntime.EXTRA_CRASH_FATAL, false);
 
+            long lastRestartTime = SettingsStore.getInstance(getBaseContext()).getLatestCrashRestartTime();
+            boolean cancelRestart = lastRestartTime > 0 && (System.currentTimeMillis() - lastRestartTime) < MIN_RESTART_INTERVAL_MS;
+            if (cancelRestart || BuildConfig.DISABLE_CRASH_RESTART) {
+                return;
+            }
 
-            if (fatal && !BuildConfig.DISABLE_CRASH_RESTART) {
+            if (fatal) {
                 Log.d(LOGTAG, "======> NATIVE CRASH PARENT" + intent);
                 final int pid = Process.myPid();
                 final ActivityManager activityManager = (ActivityManager) this.getSystemService(Context.ACTIVITY_SERVICE);

--- a/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/GlobalExceptionHandler.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.mozilla.vrbrowser.crashreporting;
 
+import android.content.Context;
 import android.util.Log;
 
 import org.mozilla.gecko.CrashHandler;
@@ -13,10 +14,10 @@ public class GlobalExceptionHandler {
     private static GlobalExceptionHandler mInstance;
 
     public static synchronized @NonNull
-    GlobalExceptionHandler register() {
+    GlobalExceptionHandler register(Context aContext) {
         if (mInstance == null) {
             mInstance = new GlobalExceptionHandler();
-            mInstance.mCrashHandler = new CrashHandler(CrashReporterService.class);
+            mInstance.mCrashHandler = new CrashHandler(aContext, CrashReporterService.class);
             Log.d(LOGTAG, "======> GlobalExceptionHandler registered");
         }
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -31,6 +31,7 @@
     <string name="settings_key_foveated_app" translatable="false">settings_foveated_app</string>
     <string name="settings_key_foveated_webvr" translatable="false">settings_foveated_webvr</string>
     <string name="settings_key_keyboard_locale" translatable="false">settings_key_keyboard_locale</string>
+    <string name="settings_key_latest_crash_restart_time" translatable="false">settings_key_latest_crash_restart_time</string>
     <string name="private_browsing_support_url" translatable="false">https://support.mozilla.org/kb/private-mode-firefox-reality</string>
     <string name="settings_key_browser_world_width" translatable="false">settings_browser_world_width</string>
     <string name="settings_key_browser_world_height" translatable="false">settings_browser_world_height</string>


### PR DESCRIPTION
See #651

@bluemarvin I can still reproduce a case of infinite restart but the restart is not originated from our CrashReporterService. Has some Gecko behavior changed or does it attempt to restart?