### PR TITLE
Recalculating WaveVR hand change before entering the immersive mode.

### DIFF
--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -309,6 +309,11 @@ DeviceDelegateWaveVR::SetRenderMode(const device::RenderMode aMode) {
   if (aMode == m.renderMode) {
     return;
   }
+  // To make sure assigning correct hands before entering immersive mode.
+  if (aMode == device::RenderMode::Immersive) {
+    m.handsCalculated = false;
+  }
+
   m.renderMode = aMode;
   m.reorientMatrix = vrb::Matrix::Identity();
 }


### PR DESCRIPTION
In WaveVR, we can't get the correct hand info from its runtime, so we have to calculate it by our own. We were using reorient action to trigger the recalculate function, but we can't make sure users do this way before entering the immersive mode. Therefore, I think we should help users do it once when they are going to in the immersive mode.

Fixes #1241. We should recalculate hands before entering the immersive mode in WaveVR.