### PR TITLE
Enable Wave VR foveated rendering in App. (Fixes #1228)

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
@@ -73,10 +73,11 @@ class DisplayOptionsView extends SettingsView {
 
         mFoveatedAppRadio = findViewById(R.id.foveated_app_radio);
         mFoveatedWebVRRadio = findViewById(R.id.foveated_webvr_radio);
-        if (BuildConfig.FLAVOR_platform == "oculusvr") {
+        if (BuildConfig.FLAVOR_platform == "oculusvr" ||
+            BuildConfig.FLAVOR_platform == "wavevr") {
             mFoveatedAppRadio.setVisibility(View.VISIBLE);
             // Uncomment this when Foveated Rendering for WebVR makes more sense
-            //mFoveatedWebVRRadio.setVisibility(View.VISIBLE);
+            // mFoveatedWebVRRadio.setVisibility(View.VISIBLE);
             int level = SettingsStore.getInstance(getContext()).getFoveatedLevelApp();
             setFoveatedLevel(mFoveatedAppRadio, mFoveatedAppRadio.getIdForValue(level), false);
             mFoveatedAppRadio.setOnCheckedChangeListener((compoundButton, checkedId, apply) -> setFoveatedLevel(mFoveatedAppRadio, checkedId, apply));
@@ -244,7 +245,8 @@ class DisplayOptionsView extends SettingsView {
         if (!mMSAARadio.getValueForId(mMSAARadio.getCheckedRadioButtonId()).equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mMSAARadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
         }
-        if (BuildConfig.FLAVOR_platform == "oculusvr") {
+        if (BuildConfig.FLAVOR_platform == "oculusvr" ||
+            BuildConfig.FLAVOR_platform == "wavevr") {
             if (!mFoveatedAppRadio.getValueForId(mFoveatedAppRadio.getCheckedRadioButtonId()).equals(SettingsStore.FOVEATED_APP_DEFAULT_LEVEL)) {
                 setFoveatedLevel(mFoveatedAppRadio, mFoveatedAppRadio.getIdForValue(SettingsStore.FOVEATED_APP_DEFAULT_LEVEL), true);
             }
@@ -308,6 +310,10 @@ class DisplayOptionsView extends SettingsView {
 
         if (doApply) {
             mWidgetManager.updateFoveatedLevel();
+            // "WaveVR WVR_RenderFoveation(false) doesn't work properly, we need to restart."
+            if (level == 0 && BuildConfig.FLAVOR_platform == "wavevr") {
+                showRestartDialog();
+            }
         }
     }
 

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -25,6 +25,7 @@ public:
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
+  void SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
   int32_t GetControllerModelCount() const override;


### PR DESCRIPTION
In Wave VR [1], doing foveated rendering by using FBO index from two eye buffers. They seem to have trouble in setting `WVR_RenderFoveation(false);`, so I have to restart the app to make it work although this API is under beta.

@MortimerGoro The changing of foveated rendering level in App is not so obvious in Oculus Go, is my feeling wrong?

Regarding to WebVR foveated rendering, we need to do it at the Gecko side, we can do a follow up research at [Bug 1553956](https://bugzilla.mozilla.org/show_bug.cgi?id=1553956) to see if it is possible to make.

[1] https://hub.vive.com/storage/app/doc/en-us/WVR_RenderFoveation.html