### PR TITLE
Bump GV version. Fix WebVR texture sharpness issues

### DIFF
--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -75,6 +75,7 @@ struct DeviceDelegateGoogleVR::State {
   gvr_swap_chain* swapChain;
   gvr_frame* frame;
   gvr_sizei maxRenderSize;
+  gvr_sizei webvrSize;
   gvr_sizei frameBufferSize;
   vrb::RenderContextWeak context;
   float near;
@@ -162,11 +163,12 @@ struct DeviceDelegateGoogleVR::State {
     if (aMode != renderMode) {
       renderMode = aMode;
       reorientMatrix = vrb::Matrix::Identity();
+      webvrSize = GetRecommendedImmersiveModeSize();
       CreateSwapChain();
     }
   }
 
-  gvr_sizei GetImmersiveModeSize() {
+  gvr_sizei GetRecommendedImmersiveModeSize() {
     // GVR SDK states that thee maximum effective render target size can be very large.
     // Most applications need to scale down to compensate.
     // Half pixel sizes are used by scaling each dimension by sqrt(2)/2 ~= 7/10ths.
@@ -185,7 +187,7 @@ struct DeviceDelegateGoogleVR::State {
     gvr_buffer_spec* spec = GVR_CHECK(gvr_buffer_spec_create(gvr));
     gvr_sizei size = maxRenderSize;
     if (renderMode == device::RenderMode::Immersive) {
-      size = GetImmersiveModeSize();
+      size = webvrSize;
       GVR_CHECK(gvr_buffer_spec_set_size(spec, size));
       GVR_CHECK(gvr_buffer_spec_set_samples(spec, 0));
       GVR_CHECK(gvr_buffer_spec_set_color_format(spec, GVR_COLOR_FORMAT_RGBA_8888));
@@ -394,10 +396,26 @@ DeviceDelegateGoogleVR::RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) {
   m.immersiveDisplay->SetDeviceName("Daydream");
   m.immersiveDisplay->SetCapabilityFlags(device::Position | device::Orientation | device::Present | device::StageParameters);
   m.immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(kAverageHeight));
-  gvr_sizei size = m.GetImmersiveModeSize();
+  gvr_sizei size = m.GetRecommendedImmersiveModeSize();
   m.immersiveDisplay->SetEyeResolution(size.width / 2, size.height);
   m.immersiveDisplay->CompleteEnumeration();
   m.UpdateCameras();
+}
+
+void
+DeviceDelegateGoogleVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) {
+  gvr_sizei recommendedSize = m.GetRecommendedImmersiveModeSize();
+
+  const auto minWidth = (uint32_t) recommendedSize.width / 2;
+  const auto minHeight = (uint32_t) recommendedSize.height / 2;
+  const auto targetWidth = (uint32_t) fmaxf(fminf(aEyeWidth, m.maxRenderSize.width), minWidth);
+  const auto targetHeight = (uint32_t) fmaxf(fminf(aEyeHeight, m.maxRenderSize.height), minHeight);
+
+  if (targetWidth != m.frameBufferSize.width || targetHeight != m.frameBufferSize.height) {
+    m.webvrSize.width = targetWidth;
+    m.webvrSize.height = targetHeight;
+    m.CreateSwapChain();
+  }
 }
 
 GestureDelegateConstPtr
@@ -548,6 +566,7 @@ void
 DeviceDelegateGoogleVR::InitializeGL() {
   gvr_initialize_gl(m.gvr);
   m.maxRenderSize =  GVR_CHECK(gvr_get_maximum_effective_render_target_size(m.gvr));
+  m.webvrSize = m.GetRecommendedImmersiveModeSize();
   m.CreateSwapChain();
   m.InitializeControllers();
   VRB_GL_CHECK(glEnable(GL_DEPTH_TEST));

--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -406,10 +406,11 @@ void
 DeviceDelegateGoogleVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) {
   gvr_sizei recommendedSize = m.GetRecommendedImmersiveModeSize();
 
-  const auto minWidth = (uint32_t) recommendedSize.width / 2;
-  const auto minHeight = (uint32_t) recommendedSize.height / 2;
-  const auto targetWidth = (uint32_t) fmaxf(fminf(aEyeWidth, m.maxRenderSize.width), minWidth);
-  const auto targetHeight = (uint32_t) fmaxf(fminf(aEyeHeight, m.maxRenderSize.height), minHeight);
+  auto targetWidth = (uint32_t)  m.frameBufferSize.width;
+  auto targetHeight = (uint32_t) m.frameBufferSize.height;
+
+  DeviceUtils::GetTargetImmersiveSize(aEyeWidth, aEyeHeight, (uint32_t) recommendedSize.width, (uint32_t) recommendedSize.height,
+                                      (uint32_t) m.maxRenderSize.width, (uint32_t) m.maxRenderSize.height, targetWidth, targetHeight);
 
   if (targetWidth != m.frameBufferSize.width || targetHeight != m.frameBufferSize.height) {
     m.webvrSize.width = targetWidth;

--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -412,11 +412,9 @@ DeviceDelegateGoogleVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_
   DeviceUtils::GetTargetImmersiveSize(aEyeWidth, aEyeHeight, (uint32_t) recommendedSize.width, (uint32_t) recommendedSize.height,
                                       (uint32_t) m.maxRenderSize.width, (uint32_t) m.maxRenderSize.height, targetWidth, targetHeight);
 
-  if (targetWidth != m.frameBufferSize.width || targetHeight != m.frameBufferSize.height) {
-    m.webvrSize.width = targetWidth;
-    m.webvrSize.height = targetHeight;
-    m.CreateSwapChain();
-  }
+  // The new swapChain is recreated in the next StartFrame call.
+  m.webvrSize.width = targetWidth;
+  m.webvrSize.height = targetHeight;
 }
 
 GestureDelegateConstPtr
@@ -490,6 +488,10 @@ DeviceDelegateGoogleVR::ProcessEvents() {
 
 void
 DeviceDelegateGoogleVR::StartFrame() {
+  if (m.renderMode == device::RenderMode::Immersive &&
+      (m.webvrSize.width != m.frameBufferSize.width || m.webvrSize.height != m.frameBufferSize.height)) {
+      m.CreateSwapChain();
+  }
   gvr_clock_time_point when = GVR_CHECK(gvr_get_time_point_now());
   // 50ms into the future is what GVR docs recommends using for head rotation prediction.
   when.monotonic_system_time_nanos += 50000000;

--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.h
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.h
@@ -23,6 +23,7 @@ public:
   void SetRenderMode(const device::RenderMode aMode) override;
   device::RenderMode GetRenderMode() override;
   void RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) override;
+  void SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) override;
   GestureDelegateConstPtr GetGestureDelegate() override;
   vrb::CameraPtr GetCamera(const device::Eye aWhich) override;
   const vrb::Matrix& GetHeadTransform() const override;

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -1148,13 +1148,16 @@ BrowserWorld::DrawImmersive() {
   m.device->StartFrame();
   VRB_GL_CHECK(glDepthMask(GL_FALSE));
   m.externalVR->PushFramePoses(m.device->GetHeadTransform(), m.controllers->GetControllers(), m.context->GetTimestamp());
-  int32_t surfaceHandle = 0;
+  int32_t surfaceHandle, textureWidth, textureHeight = 0;
   device::EyeRect leftEye, rightEye;
   bool aDiscardFrame = !m.externalVR->WaitFrameResult();
-  m.externalVR->GetFrameResult(surfaceHandle, leftEye, rightEye);
+  m.externalVR->GetFrameResult(surfaceHandle, textureWidth, textureHeight, leftEye, rightEye);
   ExternalVR::VRState state = m.externalVR->GetVRState();
   if (state == ExternalVR::VRState::Rendering) {
     if (!aDiscardFrame) {
+      if (textureWidth > 0 && textureHeight > 0) {
+        m.device->SetImmersiveSize((uint32_t) textureWidth/2, (uint32_t) textureHeight);
+      }
       m.blitter->StartFrame(surfaceHandle, leftEye, rightEye);
       m.device->BindEye(device::Eye::Left);
       m.blitter->Draw(device::Eye::Left);

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -49,6 +49,7 @@ public:
   virtual void SetRenderMode(const device::RenderMode aMode) = 0;
   virtual device::RenderMode GetRenderMode() = 0;
   virtual void RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) = 0;
+  virtual void SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) {};
   virtual GestureDelegateConstPtr GetGestureDelegate() = 0;
   virtual vrb::CameraPtr GetCamera(const device::Eye aWhich) = 0;
   virtual const vrb::Matrix& GetHeadTransform() const = 0;

--- a/app/src/main/cpp/DeviceUtils.cpp
+++ b/app/src/main/cpp/DeviceUtils.cpp
@@ -48,6 +48,18 @@ DeviceUtils::CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, con
 
 }
 
+void DeviceUtils::GetTargetImmersiveSize(const uint32_t aRequestedWidth,
+                                         const uint32_t aRequestedHeight,
+                                         const uint32_t aRecommendedWidth,
+                                         const uint32_t aRecommendedHeight,
+                                         const uint32_t aMaxWidth, const uint32_t aMaxHeight,
+                                         uint32_t& aTargetWidth, uint32_t& aTargetHeight) {
+  const uint32_t minWidth = aRecommendedWidth / 2;
+  const uint32_t minHeight = aRecommendedHeight / 2;
+  aTargetWidth = (uint32_t) fmaxf(fminf(aRequestedWidth, aMaxWidth), minWidth);
+  aTargetHeight = (uint32_t) fmaxf(fminf(aRequestedHeight, aMaxHeight), minHeight);
+}
+
 
 }
 

--- a/app/src/main/cpp/DeviceUtils.h
+++ b/app/src/main/cpp/DeviceUtils.h
@@ -14,6 +14,16 @@ namespace crow {
 class DeviceUtils {
 public:
   static vrb::Matrix CalculateReorientationMatrix(const vrb::Matrix& aHeadTransform, const vrb::Vector& aHeightPosition);
+  static void GetTargetImmersiveSize(const uint32_t aRequestedWidth, const uint32_t  aRequestedHeight,
+                                     const uint32_t aRecommendedWidth, const uint32_t aRecommendedHeight,
+                                     uint32_t& aTargetWidth, uint32_t& aTargetHeight) {
+    GetTargetImmersiveSize(aRequestedWidth, aRequestedHeight, aRecommendedWidth, aRecommendedHeight,
+                           aRecommendedWidth * 2, aRecommendedHeight * 2, aTargetWidth, aTargetHeight);
+  }
+  static void GetTargetImmersiveSize(const uint32_t aRequestedWidth, const uint32_t  aRequestedHeight,
+                                     const uint32_t aRecommendedWidth, const uint32_t aRecommendedHeight,
+                                     const uint32_t aMaxWidth, const uint32_t aMaxHeight,
+                                     uint32_t& aTargetWidth, uint32_t& aTargetHeight);
 private:
   VRB_NO_DEFAULTS(DeviceUtils)
 };

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -478,12 +478,15 @@ ExternalVR::CompleteEnumeration()
 
 
 void
-ExternalVR::GetFrameResult(int32_t& aSurfaceHandle, device::EyeRect& aLeftEye, device::EyeRect& aRightEye) const {
+ExternalVR::GetFrameResult(int32_t& aSurfaceHandle, int32_t& aTextureWidth, int32_t& aTextureHeight,
+    device::EyeRect& aLeftEye, device::EyeRect& aRightEye) const {
   aSurfaceHandle = (int32_t)m.browser.layerState[0].layer_stereo_immersive.textureHandle;
   mozilla::gfx::VRLayerEyeRect& left = m.browser.layerState[0].layer_stereo_immersive.leftEyeRect;
   mozilla::gfx::VRLayerEyeRect& right = m.browser.layerState[0].layer_stereo_immersive.rightEyeRect;
   aLeftEye = device::EyeRect(left.x, left.y, left.width, left.height);
   aRightEye = device::EyeRect(right.x, right.y, right.width, right.height);
+  aTextureWidth = (int32_t)m.browser.layerState[0].layer_stereo_immersive.textureSize.width;
+  aTextureHeight = (int32_t)m.browser.layerState[0].layer_stereo_immersive.textureSize.height;
 }
 
 void

--- a/app/src/main/cpp/ExternalVR.h
+++ b/app/src/main/cpp/ExternalVR.h
@@ -54,7 +54,11 @@ public:
   VRState GetVRState() const;
   void PushFramePoses(const vrb::Matrix& aHeadTransform, const std::vector<Controller>& aControllers, const double aTimestamp);
   bool WaitFrameResult();
-  void GetFrameResult(int32_t& aSurfaceHandle, device::EyeRect& aLeftEye, device::EyeRect& aRightEye) const;
+  void GetFrameResult(int32_t& aSurfaceHandle,
+                      int32_t& aTextureWidth,
+                      int32_t& aTextureHeight,
+                      device::EyeRect& aLeftEye,
+                      device::EyeRect& aRightEye) const;
   void StopPresenting();
   void SetSourceBrowser(VRBrowserType aBrowser);
   ExternalVR();

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -34,7 +34,7 @@ enum class GamepadCapabilityFlags : uint16_t;
 #endif  //  MOZILLA_INTERNAL_API
 namespace gfx {
 
-static const int32_t kVRExternalVersion = 7;
+static const int32_t kVRExternalVersion = 8;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -161,13 +161,14 @@ enum class VRDisplayCapabilityFlags : uint16_t {
       Cap_MountDetection = 1 << 8,
   /**
    * Cap_PositionEmulated is set if the VRDisplay is capable of setting a
-   * neck model in position even if still doesn't support 6DOF tracking.
+   * emulated position (e.g. neck model) even if still doesn't support 6DOF
+   * tracking.
    */
       Cap_PositionEmulated = 1 << 9,
   /**
    * Cap_All used for validity checking during IPC serialization
    */
-      Cap_All = (1 << 9) - 1
+      Cap_All = (1 << 10) - 1
 };
 
 #ifdef MOZILLA_INTERNAL_API
@@ -345,6 +346,7 @@ struct VRLayer_Stereo_Immersive {
   uint64_t inputFrameId;
   VRLayerEyeRect leftEyeRect;
   VRLayerEyeRect rightEyeRect;
+  IntSize_POD textureSize;
 };
 
 struct VRLayerState {

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -1110,6 +1110,30 @@ DeviceDelegateOculusVR::RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) {
   m.UpdatePerspective();
 }
 
+void
+DeviceDelegateOculusVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) {
+  uint32_t recommendedWidth, recommendedHeight;
+  m.GetImmersiveRenderSize(recommendedWidth, recommendedHeight);
+
+  const uint32_t maxWidth = recommendedWidth * 2;
+  const uint32_t maxHeight = recommendedHeight * 2;
+  const uint32_t minWidth = recommendedWidth / 2;
+  const uint32_t minHeight = recommendedHeight / 2;
+
+  const uint32_t targetWidth = (uint32_t) fmaxf(fminf(aEyeWidth, maxWidth), minWidth);
+  const uint32_t targetHeight = (uint32_t) fmaxf(fminf(aEyeHeight, maxHeight), minHeight);
+
+  if (targetWidth != m.renderWidth || targetHeight != m.renderHeight) {
+    m.renderWidth = targetWidth;
+    m.renderHeight = targetHeight;
+    vrb::RenderContextPtr render = m.context.lock();
+    for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
+      m.eyeSwapChains[i]->Init(render, m.renderMode, m.renderWidth, m.renderHeight);
+    }
+    VRB_LOG("Resize immersive mode swapChain: %dx%d", targetWidth, targetHeight);
+  }
+}
+
 vrb::CameraPtr
 DeviceDelegateOculusVR::GetCamera(const device::Eye aWhich) {
   const int32_t index = device::EyeIndex(aWhich);

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -1115,14 +1115,10 @@ DeviceDelegateOculusVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_
   uint32_t recommendedWidth, recommendedHeight;
   m.GetImmersiveRenderSize(recommendedWidth, recommendedHeight);
 
-  const uint32_t maxWidth = recommendedWidth * 2;
-  const uint32_t maxHeight = recommendedHeight * 2;
-  const uint32_t minWidth = recommendedWidth / 2;
-  const uint32_t minHeight = recommendedHeight / 2;
+  uint32_t targetWidth = m.renderWidth;
+  uint32_t targetHeight = m.renderHeight;
 
-  const uint32_t targetWidth = (uint32_t) fmaxf(fminf(aEyeWidth, maxWidth), minWidth);
-  const uint32_t targetHeight = (uint32_t) fmaxf(fminf(aEyeHeight, maxHeight), minHeight);
-
+  DeviceUtils::GetTargetImmersiveSize(aEyeWidth, aEyeHeight, recommendedWidth, recommendedHeight, targetWidth, targetHeight);
   if (targetWidth != m.renderWidth || targetHeight != m.renderHeight) {
     m.renderWidth = targetWidth;
     m.renderHeight = targetHeight;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -27,6 +27,7 @@ public:
   void SetRenderMode(const device::RenderMode aMode) override;
   device::RenderMode GetRenderMode() override;
   void RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) override;
+  void SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) override;
   GestureDelegateConstPtr GetGestureDelegate() override { return nullptr; }
   vrb::CameraPtr GetCamera(const device::Eye aWhich) override;
   const vrb::Matrix& GetHeadTransform() const override;

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -418,13 +418,10 @@ DeviceDelegateWaveVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t 
   uint32_t recommendedWidth, recommendedHeight;
   WVR_GetRenderTargetSize(&recommendedWidth, &recommendedHeight);
 
-  const uint32_t maxWidth = recommendedWidth * 2;
-  const uint32_t maxHeight = recommendedHeight * 2;
-  const uint32_t minWidth = recommendedWidth / 2;
-  const uint32_t minHeight = recommendedHeight / 2;
+  uint32_t targetWidth = m.renderWidth;
+  uint32_t targetHeight = m.renderHeight;
 
-  const auto targetWidth = (uint32_t) fmaxf(fminf(aEyeWidth, maxWidth), minWidth);
-  const auto targetHeight = (uint32_t) fmaxf(fminf(aEyeHeight, maxHeight), minHeight);
+  DeviceUtils::GetTargetImmersiveSize(aEyeWidth, aEyeHeight, recommendedWidth, recommendedHeight, targetWidth, targetHeight);
 
   if (targetWidth != m.renderWidth || targetHeight != m.renderHeight) {
     m.renderWidth = targetWidth;

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -187,15 +187,34 @@ struct DeviceDelegateWaveVR::State {
       VRB_ERROR("Please check Wave server configuration");
       return;
     }
+    InitializeTextureQueues();
+    elbow = ElbowModel::Create();
+  }
+
+  void InitializeTextureQueues() {
+    ReleaseTextureQueues();
+    VRB_LOG("Create texture queues: %dx%d", renderWidth, renderHeight);
     leftTextureQueue = WVR_ObtainTextureQueue(WVR_TextureTarget_2D, WVR_TextureFormat_RGBA, WVR_TextureType_UnsignedByte, renderWidth, renderHeight, 0);
     FillFBOQueue(leftTextureQueue, leftFBOQueue);
     rightTextureQueue = WVR_ObtainTextureQueue(WVR_TextureTarget_2D, WVR_TextureFormat_RGBA, WVR_TextureType_UnsignedByte, renderWidth, renderHeight, 0);
     FillFBOQueue(rightTextureQueue, rightFBOQueue);
-    elbow = ElbowModel::Create();
+  }
+
+  void ReleaseTextureQueues() {
+    if (leftTextureQueue) {
+      WVR_ReleaseTextureQueue(leftTextureQueue);
+      leftTextureQueue = nullptr;
+    }
+    leftFBOQueue.clear();
+    if (rightTextureQueue) {
+      WVR_ReleaseTextureQueue(rightTextureQueue);
+      rightTextureQueue = nullptr;
+    }
+    rightFBOQueue.clear();
   }
 
   void Shutdown() {
-
+    ReleaseTextureQueues();
   }
 
   void UpdateFoveatedLevel() {
@@ -355,6 +374,14 @@ DeviceDelegateWaveVR::SetRenderMode(const device::RenderMode aMode) {
 
   m.renderMode = aMode;
   m.reorientMatrix = vrb::Matrix::Identity();
+
+  uint32_t recommendedWidth, recommendedHeight;
+  WVR_GetRenderTargetSize(&recommendedWidth, &recommendedHeight);
+  if (recommendedWidth != m.renderWidth || recommendedHeight != m.renderHeight) {
+    m.renderWidth = recommendedWidth;
+    m.renderHeight = recommendedHeight;
+    m.InitializeTextureQueues();
+  }
 }
 
 device::RenderMode
@@ -386,6 +413,25 @@ DeviceDelegateWaveVR::RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) {
   m.InitializeCameras();
 }
 
+void
+DeviceDelegateWaveVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) {
+  uint32_t recommendedWidth, recommendedHeight;
+  WVR_GetRenderTargetSize(&recommendedWidth, &recommendedHeight);
+
+  const uint32_t maxWidth = recommendedWidth * 2;
+  const uint32_t maxHeight = recommendedHeight * 2;
+  const uint32_t minWidth = recommendedWidth / 2;
+  const uint32_t minHeight = recommendedHeight / 2;
+
+  const auto targetWidth = (uint32_t) fmaxf(fminf(aEyeWidth, maxWidth), minWidth);
+  const auto targetHeight = (uint32_t) fmaxf(fminf(aEyeHeight, maxHeight), minHeight);
+
+  if (targetWidth != m.renderWidth || targetHeight != m.renderHeight) {
+    m.renderWidth = targetWidth;
+    m.renderHeight = targetHeight;
+    m.InitializeTextureQueues();
+  }
+}
 
 GestureDelegateConstPtr
 DeviceDelegateWaveVR::GetGestureDelegate() {

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -18,6 +18,7 @@ public:
   void SetRenderMode(const device::RenderMode aMode) override;
   device::RenderMode GetRenderMode() override;
   void RegisterImmersiveDisplay(ImmersiveDisplayPtr aDisplay) override;
+  void SetImmersiveSize(const uint32_t aEyeWidth, const uint32_t aEyeHeight) override;
   GestureDelegateConstPtr GetGestureDelegate() override;
   vrb::CameraPtr GetCamera(const device::Eye aWhich) override;
   const vrb::Matrix& GetHeadTransform() const override;

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "69.0.20190524095337"
+versions.gecko_view = "69.0.20190530094559"
 versions.android_components = "0.52.0"
 versions.mozilla_speech = "1.0.6"
 versions.google_vr = "1.190.0"


### PR DESCRIPTION
Fixes #937

Do not merge yet, I created this to get some initial feedback of this solution. The problem is that the testcase creates a 2x canvas surface but we are still using the default size in our WebVR swapChain. This PR resizes the swapChain based on the received surface size (taking some thresholds into account).

We need a way to get the WebVR surface size received from Gecko in order to call `SetImmersiveSize` with the correct values. OpenGL ES doesn't have an API to get the texture size until 3.1. Anyway I don't like the OpenGL query solution (getters aren't good for performance). Ideally we can include the surface size in the external_vr struct or also in GeckoSurfaceTexture.java