### PR TITLE
Fix Java crash reporter

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/GlobalExceptionHandler.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.crashreporting;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.Log;
 
 import org.mozilla.gecko.CrashHandler;
@@ -17,7 +18,20 @@ public class GlobalExceptionHandler {
     GlobalExceptionHandler register(Context aContext) {
         if (mInstance == null) {
             mInstance = new GlobalExceptionHandler();
-            mInstance.mCrashHandler = new CrashHandler(aContext, CrashReporterService.class);
+            mInstance.mCrashHandler = new CrashHandler(aContext, CrashReporterService.class) {
+                @Override
+                protected Bundle getCrashExtras(final Thread thread, final Throwable exc) {
+                    final Bundle extras = super.getCrashExtras(thread, exc);
+                    if (extras == null) {
+                        return null;
+                    }
+                    extras.putString("Version", org.mozilla.geckoview.BuildConfig.MOZ_APP_VERSION);
+                    extras.putString("BuildID", org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID);
+                    extras.putString("Vendor", org.mozilla.geckoview.BuildConfig.MOZ_APP_VENDOR);
+                    extras.putString("ReleaseChannel", org.mozilla.geckoview.BuildConfig.MOZ_UPDATE_CHANNEL);
+                    return extras;
+                }
+            };
             Log.d(LOGTAG, "======> GlobalExceptionHandler registered");
         }
 

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -31,7 +31,8 @@
     <string name="settings_key_foveated_app" translatable="false">settings_foveated_app</string>
     <string name="settings_key_foveated_webvr" translatable="false">settings_foveated_webvr</string>
     <string name="settings_key_keyboard_locale" translatable="false">settings_key_keyboard_locale</string>
-    <string name="settings_key_latest_crash_restart_time" translatable="false">settings_key_latest_crash_restart_time</string>
+    <string name="settings_key_crash_restart_count" translatable="false">settings_key_crash_restart_count</string>
+    <string name="settings_key_crash_restart_count_timestamp" translatable="false">settings_key_crash_restart_count_timestamp</string>
     <string name="private_browsing_support_url" translatable="false">https://support.mozilla.org/kb/private-mode-firefox-reality</string>
     <string name="settings_key_browser_world_width" translatable="false">settings_browser_world_width</string>
     <string name="settings_key_browser_world_height" translatable="false">settings_browser_world_height</string>


### PR DESCRIPTION
Java crashes did not have the correct version or build id set and were thus not showing up on crash stats.
Additionally, the infinite loop crash prevention code was bocking the app from restarting after a normal
crash. So now in addition to keeping a time stamp, a count is kept so it is know if FxR has restarted
multiple times in a short period.