### PR TITLE
Fixed the Telemetry issues

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/FxRTelemetryScheduler.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/FxRTelemetryScheduler.java
@@ -1,0 +1,46 @@
+package org.mozilla.vrbrowser.telemetry;
+
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+import org.mozilla.telemetry.schedule.TelemetryScheduler;
+import org.mozilla.telemetry.schedule.jobscheduler.TelemetryJobService;
+
+/**
+ * Replacement for the AC Telemetry Scheduler that avoids using the RECEIVE_BOOT_COMPLETED permission.
+ */
+public class FxRTelemetryScheduler implements TelemetryScheduler {
+
+    private static final int DEFAULT_JOB_ID = 42;
+
+    private final int jobId;
+
+    public FxRTelemetryScheduler() {
+        this(DEFAULT_JOB_ID);
+    }
+
+    public FxRTelemetryScheduler(int jobId) {
+        this.jobId = jobId;
+    }
+
+    @Override
+    public void scheduleUpload(TelemetryConfiguration configuration) {
+        final ComponentName jobService = new ComponentName(configuration.getContext(), TelemetryJobService.class);
+
+        // The only difference between this and the one provided by the Telemetry component is that we don't
+        // use the setPersisted flag as it requires the RECEIVE_BOOT_COMPLETED permission and it was removed
+        // here: https://github.com/MozillaReality/FirefoxReality-SecureBugs/issues/3
+        final JobInfo jobInfo = new JobInfo.Builder(jobId, jobService)
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                .setBackoffCriteria(configuration.getInitialBackoffForUpload(), JobInfo.BACKOFF_POLICY_EXPONENTIAL)
+                .build();
+
+        final JobScheduler scheduler = (JobScheduler) configuration.getContext()
+                .getSystemService(Context.JOB_SCHEDULER_SERVICE);
+
+        scheduler.schedule(jobInfo);
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -15,7 +15,6 @@ import org.mozilla.telemetry.measurement.SearchesMeasurement;
 import org.mozilla.telemetry.net.TelemetryClient;
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder;
 import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder;
-import org.mozilla.telemetry.schedule.jobscheduler.JobSchedulerTelemetryScheduler;
 import org.mozilla.telemetry.serialize.JSONPingSerializer;
 import org.mozilla.telemetry.storage.FileTelemetryStorage;
 import org.mozilla.vrbrowser.BuildConfig;
@@ -99,7 +98,7 @@ public class TelemetryWrapper {
             final JSONPingSerializer serializer = new JSONPingSerializer();
             final FileTelemetryStorage storage = new FileTelemetryStorage(configuration, serializer);
             final TelemetryClient client = new TelemetryClient(new HttpURLConnectionClient());
-            final JobSchedulerTelemetryScheduler scheduler = new JobSchedulerTelemetryScheduler();
+            final FxRTelemetryScheduler scheduler = new FxRTelemetryScheduler();
 
             TelemetryHolder.set(new Telemetry(configuration, storage, client, scheduler)
                     .addPingBuilder(new TelemetryCorePingBuilder(configuration))


### PR DESCRIPTION
Telemetry events were not being sent since last update. Removed setPersisted flag from the Telemetry scheduler jobs as it required the RECEIVE_BOOT_COMPLETED permission