### PR TITLE
Clean up unused WebVR Foveated-Rendering code. (fixes #1275)

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -1085,8 +1085,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public void updateFoveatedLevel() {
         final int appLevel = SettingsStore.getInstance(this).getFoveatedLevelApp();
-        final int webVRLevel = SettingsStore.getInstance(this).getFoveatedLevelWebVR();
-        queueRunnable(() -> updateFoveatedLevelNative(appLevel, webVRLevel));
+        queueRunnable(() -> updateFoveatedLevelNative(appLevel));
     }
 
     @Override
@@ -1158,7 +1157,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void setCylinderDensityNative(float aDensity);
     private native void setCPULevelNative(@CPULevelFlags int aCPULevel);
     private native void setIsServo(boolean aIsServo);
-    private native void updateFoveatedLevelNative(int appLevel, int webVRLevel);
+    private native void updateFoveatedLevelNative(int appLevel);
 
     @IntDef(value = { CPU_LEVEL_NORMAL, CPU_LEVEL_HIGH})
     private @interface CPULevelFlags {}

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -750,9 +750,9 @@ BrowserWorld::UpdateEnvironment() {
 }
 
 void
-BrowserWorld::UpdateFoveatedLevel(const int aAppLevel, const int aWebVRLevel) {
+BrowserWorld::UpdateFoveatedLevel(const int aAppLevel) {
   ASSERT_ON_RENDER_THREAD();
-  m.device->SetFoveatedLevel(aAppLevel, aWebVRLevel);
+  m.device->SetFoveatedLevel(aAppLevel);
 }
 
 void
@@ -1365,8 +1365,8 @@ JNI_METHOD(void, updateEnvironmentNative)
 }
 
 JNI_METHOD(void, updateFoveatedLevelNative)
-(JNIEnv*, jobject, jint aAppLevel, jint aWebVRLevel) {
-  crow::BrowserWorld::Instance().UpdateFoveatedLevel(aAppLevel, aWebVRLevel);
+(JNIEnv*, jobject, jint aAppLevel) {
+  crow::BrowserWorld::Instance().UpdateFoveatedLevel(aAppLevel);
 }
 
 JNI_METHOD(void, updatePointerColorNative)

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -40,7 +40,7 @@ public:
   void Draw();
   void SetTemporaryFilePath(const std::string& aPath);
   void UpdateEnvironment();
-  void UpdateFoveatedLevel(const int aAppLevel, const int aWebVRLevel);
+  void UpdateFoveatedLevel(const int aAppLevel);
   void UpdatePointerColor();
   void SetSurfaceTexture(const std::string& aName, jobject& aSurface);
   void AddWidget(int32_t aHandle, const WidgetPlacementPtr& placement);

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -58,7 +58,7 @@ public:
   virtual void SetClearColor(const vrb::Color& aColor) = 0;
   virtual void SetClipPlanes(const float aNear, const float aFar) = 0;
   virtual void SetControllerDelegate(ControllerDelegatePtr& aController) = 0;
-  virtual void SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) {};
+  virtual void SetFoveatedLevel(const int32_t aAppLevel) {};
   virtual void ReleaseControllerDelegate() = 0;
   virtual int32_t GetControllerModelCount() const = 0;
   virtual const std::string GetControllerModelName(const int32_t aModelIndex) const = 0;

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -616,7 +616,6 @@ struct DeviceDelegateOculusVR::State {
   uint32_t renderWidth = 0;
   uint32_t renderHeight = 0;
   int32_t standaloneFoveatedLevel = 0;
-  int32_t immersiveFoveatedLevel = 0;
   vrb::Color clearColor;
   float near = 0.1f;
   float far = 100.f;
@@ -714,11 +713,7 @@ struct DeviceDelegateOculusVR::State {
     if (!ovr) {
       return;
     }
-    if (renderMode == device::RenderMode::StandAlone) {
-      vrapi_SetPropertyInt(&java, VRAPI_FOVEATION_LEVEL, standaloneFoveatedLevel);
-    } else {
-      vrapi_SetPropertyInt(&java, VRAPI_FOVEATION_LEVEL, immersiveFoveatedLevel);
-    }
+    vrapi_SetPropertyInt(&java, VRAPI_FOVEATION_LEVEL, standaloneFoveatedLevel);
   }
 
   void UpdateClockLevels() {
@@ -1175,9 +1170,8 @@ DeviceDelegateOculusVR::ReleaseControllerDelegate() {
 }
 
 void
-DeviceDelegateOculusVR::SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) {
+DeviceDelegateOculusVR::SetFoveatedLevel(const int32_t aAppLevel) {
   m.standaloneFoveatedLevel = aAppLevel;
-  m.immersiveFoveatedLevel = aWebVRLevel;
   m.UpdateFoveatedLevel();
 }
 

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -37,7 +37,7 @@ public:
   void SetClipPlanes(const float aNear, const float aFar) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
-  void SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) override;
+  void SetFoveatedLevel(const int32_t aAppLevel) override;
   int32_t GetControllerModelCount() const override;
   const std::string GetControllerModelName(const int32_t aModelIndex) const override;
   void SetCPULevel(const device::CPULevel aLevel) override;

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -469,7 +469,7 @@ DeviceDelegateWaveVR::SetClipPlanes(const float aNear, const float aFar) {
 }
 
 void
-DeviceDelegateWaveVR::SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) {
+DeviceDelegateWaveVR::SetFoveatedLevel(const int32_t aAppLevel) {
   m.standaloneFoveatedLevel = aAppLevel;
 }
 

--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.h
@@ -26,7 +26,7 @@ public:
   void SetReorientTransform(const vrb::Matrix& aMatrix) override;
   void SetClearColor(const vrb::Color& aColor) override;
   void SetClipPlanes(const float aNear, const float aFar) override;
-  void SetFoveatedLevel(const int32_t aAppLevel, const int32_t aWebVRLevel) override;
+  void SetFoveatedLevel(const int32_t aAppLevel) override;
   void SetControllerDelegate(ControllerDelegatePtr& aController) override;
   void ReleaseControllerDelegate() override;
   int32_t GetControllerModelCount() const override;


### PR DESCRIPTION
We understand WebVR Foveated-Rendering will be impossible to do in FxR, it has to be in GV. Let's clean up them.