### PR TITLE
Added global autoplay support

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
@@ -967,6 +967,24 @@ public class SessionStore implements ContentBlocking.Delegate, GeckoSession.Navi
         }
     }
 
+    public void setAutoplayEnabled(final boolean enabled) {
+        if (mRuntime != null) {
+            mRuntime.getSettings().setAutoplayDefault(enabled ?
+                    GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED :
+                    GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED);
+        }
+    }
+
+    public boolean getAutoplayEnabled() {
+        if (mRuntime != null) {
+            return mRuntime.getSettings().getAutoplayDefault() == GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED ?
+                    true :
+                    false;
+        }
+
+        return false;
+    }
+
     // NavigationDelegate
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/SwitchSetting.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/SwitchSetting.java
@@ -94,6 +94,7 @@ public class SwitchSetting extends LinearLayout {
 
     public void setChecked(boolean value) {
         mSwitch.setChecked(value);
+        updateSwitchText();
     }
 
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
@@ -27,6 +27,7 @@ class PrivacyOptionsView extends SettingsView {
     private AudioEngine mAudio;
     private UIButton mBackButton;
     private SwitchSetting mTrackingSetting;
+    private SwitchSetting mAutoplaySetting;
     private ButtonSetting mResetButton;
     private ArrayList<Pair<ButtonSetting, String>> mPermissionButtons;
     private int mAlertDialogHandle;
@@ -71,6 +72,12 @@ class PrivacyOptionsView extends SettingsView {
         mTrackingSetting.setOnCheckedChangeListener((compoundButton, enabled, apply) -> {
             SettingsStore.getInstance(getContext()).setTrackingProtectionEnabled(enabled);
             SessionStore.get().setTrackingProtection(enabled);
+        });
+
+        mAutoplaySetting = findViewById(R.id.autoplaySwitch);
+        mAutoplaySetting.setChecked(SessionStore.get().getAutoplayEnabled());
+        mAutoplaySetting.setOnCheckedChangeListener((compoundButton, enabled, apply) -> {
+            SessionStore.get().setAutoplayEnabled(enabled);
         });
 
         TextView permissionsTitleText = findViewById(R.id.permissionsTitle);

--- a/app/src/main/res/layout/options_privacy.xml
+++ b/app/src/main/res/layout/options_privacy.xml
@@ -58,6 +58,12 @@
                     android:layout_height="wrap_content"
                     app:description="@string/security_options_tracking_protection" />
 
+                <org.mozilla.vrbrowser.ui.views.settings.SwitchSetting
+                    android:id="@+id/autoplaySwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:description="@string/security_options_autoplay" />
+
                 <TextView
                     android:id="@+id/permissionsTitle"
                     style="@style/settingsDescription"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -11,7 +11,7 @@
     <string name="settings_key_console_logs" translatable="false">settings_console_logs</string>
     <string name="settings_key_environment_override" translatable="false">settings_environment_override</string>
     <string name="settings_key_multiprocess" translatable="false">settings_environment_multiprocess</string>
-    <string name="settings_key_servo">settings_environment_servo</string>
+    <string name="settings_key_servo" translatable="false">settings_environment_servo</string>
     <string name="settings_key_tracking_protection" translatable="false">settings_tracking_protection</string>
     <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version</string>
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,6 +377,10 @@
      and is used to enable or disable tracking protection. -->
     <string name="security_options_tracking_protection">Tracking Protection</string>
 
+    <!-- This string labels an On/Off switch in the Privacy and Security settings dialog
+     and is used to enable or disable media autoplay. -->
+    <string name="security_options_autoplay">Autoplay Media</string>
+
     <!-- This string is a label above the group of buttons that indicates that the buttons below
          relate to Android system permissions granted to the app.
          '%1$s' will be replaced at runtime with the app's name. -->


### PR DESCRIPTION
Fixes #1231 Added support for globally enable/disable media autoplay.

Fixed a switch setting bug not showing "Off" text upon initialisation.