### PR TITLE
Remove camera permission in Oculus Go and Quest builds

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
@@ -8,10 +8,12 @@ package org.mozilla.vrbrowser.ui.widgets.settings;
 import android.Manifest;
 import android.content.Context;
 import android.util.Pair;
+import android.view.View;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
 import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.browser.SessionStore;
@@ -88,6 +90,9 @@ class PrivacyOptionsView extends SettingsView {
         mPermissionButtons.add(Pair.create(findViewById(R.id.microphonePermissionButton), Manifest.permission.RECORD_AUDIO));
         mPermissionButtons.add(Pair.create(findViewById(R.id.locationPermissionButton), Manifest.permission.ACCESS_FINE_LOCATION));
         mPermissionButtons.add(Pair.create(findViewById(R.id.storagePermissionButton), Manifest.permission.READ_EXTERNAL_STORAGE));
+
+        if (BuildConfig.FLAVOR_platform == "oculusvr3dof" || BuildConfig.FLAVOR_platform == "oculusvr")
+            findViewById(R.id.cameraPermissionButton).setVisibility(View.GONE);
 
         for (Pair<ButtonSetting, String> button: mPermissionButtons) {
             if (mWidgetManager.isPermissionGranted(button.second)) {

--- a/app/src/oculusvr/java/org/mozilla/vrbrowser/PlatformActivity.java
+++ b/app/src/oculusvr/java/org/mozilla/vrbrowser/PlatformActivity.java
@@ -6,11 +6,9 @@
 package org.mozilla.vrbrowser;
 
 import android.app.NativeActivity;
+import android.Manifest;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.InputDevice;
-import android.view.KeyEvent;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowManager;
 
@@ -18,6 +16,9 @@ public class PlatformActivity extends NativeActivity {
     static String LOGTAG = "VRB";
 
     public static boolean filterPermission(final String aPermission) {
+        if (aPermission.equals(Manifest.permission.CAMERA)) {
+            return true;
+        }
         return false;
     }
 

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.mozilla.vrbrowser">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.mozilla.vrbrowser" xmlns:tools="http://schemas.android.com/tools">
     <uses-feature android:glEsVersion="0x00030001"/>
     <uses-feature android:name="android.hardware.vr.headtracking" android:version="1" android:required="${headtrackingRequired}" />
+    <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <application>
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -5,6 +5,7 @@
     android:installLocation="auto">
     <uses-feature android:glEsVersion="0x00030001"/>
     <uses-feature android:name="android.hardware.vr.headtracking" android:version="1" android:required="${headtrackingRequired}" />
+    <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <application
         android:name=".VRBrowserApplication"
         android:allowBackup="true"


### PR DESCRIPTION
Fixes #1345 Added a tag in the Oculus manifest to remove inherited camera permission from the parent manifest. Also removed it from the Privacy options just for oculus builds.