### PR TITLE
User enum in widget show

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -55,6 +55,7 @@ import org.mozilla.vrbrowser.ui.widgets.RootWidget;
 import org.mozilla.vrbrowser.ui.widgets.TopBarWidget;
 import org.mozilla.vrbrowser.ui.widgets.TrayListener;
 import org.mozilla.vrbrowser.ui.widgets.TrayWidget;
+import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.VideoProjectionMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.Widget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
@@ -447,7 +448,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 mCrashDialog.setCrashDialogDelegate(() -> sendCrashData(intent));
             }
 
-            mCrashDialog.show();
+            mCrashDialog.show(UIWidget.REQUEST_FOCUS);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -714,7 +714,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         }
         mIsInVoiceInput = true;
         TelemetryWrapper.voiceInputEvent();
-        mVoiceSearchWidget.show(false);
+        mVoiceSearchWidget.show(CLEAR_FOCUS);
         mWidgetPlacement.visible = false;
         mWidgetManager.updateWidget(this);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -881,7 +881,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
                     if (!mPopup.isVisible()) {
                         mPopup.updatePlacement((int)WidgetPlacement.convertPixelsToDp(getContext(), mURLBar.getWidth()));
-                        mPopup.show(REQUEST_FOCUS);
+                        mPopup.show(CLEAR_FOCUS);
                     }
                 }
         );

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -824,7 +824,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             mVoiceSearchWidget.hide(REMOVE_WIDGET);
 
         } else {
-            mVoiceSearchWidget.show();
+            mVoiceSearchWidget.show(REQUEST_FOCUS);
         }
     }
 
@@ -881,7 +881,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
                     if (!mPopup.isVisible()) {
                         mPopup.updatePlacement((int)WidgetPlacement.convertPixelsToDp(getContext(), mURLBar.getWidth()));
-                        mPopup.show();
+                        mPopup.show(REQUEST_FOCUS);
                     }
                 }
         );

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
@@ -113,8 +113,8 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
     }
 
     @Override
-    public void show() {
-        super.show(false);
+    public void show(@ShowFlags int aShowFlags) {
+        super.show(CLEAR_FOCUS);
         mList.startAnimation(mScaleUpAnimation);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
@@ -114,7 +114,7 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
 
     @Override
     public void show(@ShowFlags int aShowFlags) {
-        super.show(CLEAR_FOCUS);
+        super.show(aShowFlags);
         mList.startAnimation(mScaleUpAnimation);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -268,7 +268,7 @@ public class TrayWidget extends UIWidget implements SessionStore.SessionChangeLi
         if (widget.isVisible()) {
             widget.hide(REMOVE_WIDGET);
         } else {
-            widget.show();
+            widget.show(REQUEST_FOCUS);
         }
     }
 
@@ -281,14 +281,14 @@ public class TrayWidget extends UIWidget implements SessionStore.SessionChangeLi
 
     private void updateVisibility() {
         if (mTrayVisible && !mKeyboardVisible) {
-            this.show();
+            this.show(REQUEST_FOCUS);
         } else {
             this.hide(UIWidget.KEEP_WIDGET);
         }
     }
 
     @Override
-    public void show() {
+    public void show(@ShowFlags int aShowFlags) {
         if (!mWidgetPlacement.visible) {
             mWidgetPlacement.visible = true;
             mWidgetManager.addWidget(this);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
@@ -248,24 +248,28 @@ public abstract class UIWidget extends FrameLayout implements Widget {
             hide(REMOVE_WIDGET);
 
         } else {
-            show();
+            show(REQUEST_FOCUS);
         }
     }
 
-    public void show() {
-        show(true);
-    }
+    @IntDef(value = { REQUEST_FOCUS, CLEAR_FOCUS })
+    public @interface ShowFlags {}
+    public static final int REQUEST_FOCUS = 0;
+    public static final int CLEAR_FOCUS = 1;
 
-    public void show(boolean focus) {
+    public void show(@ShowFlags int aShowFlags) {
         if (!mWidgetPlacement.visible) {
             mWidgetPlacement.visible = true;
             mWidgetManager.addWidget(this);
             mWidgetManager.pushBackHandler(mBackHandler);
         }
 
-        if (focus) {
-            setFocusableInTouchMode(true);
+        setFocusableInTouchMode(false);
+        if (aShowFlags == REQUEST_FOCUS) {
             requestFocusFromTouch();
+
+        } else {
+            clearFocus();
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -103,16 +103,19 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
     }
 
     @Override
-    public void show(boolean focus) {
+    public void show(@ShowFlags int aShowFlags) {
         if (!mWidgetPlacement.visible) {
             mWidgetPlacement.visible = true;
         }
 
         mWidgetManager.updateWidget(this);
 
-        if (focus) {
-            setFocusableInTouchMode(true);
+        setFocusableInTouchMode(false);
+        if (aShowFlags == REQUEST_FOCUS) {
             requestFocusFromTouch();
+
+        } else {
+            clearFocus();
         }
     }
 
@@ -581,7 +584,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
             mNoInternetToast.mWidgetPlacement.parentHandle = getHandle();
         }
         if (aVisible && !mNoInternetToast.isVisible()) {
-            mNoInternetToast.show();
+            mNoInternetToast.show(REQUEST_FOCUS);
         } else if (!aVisible && mNoInternetToast.isVisible()) {
             mNoInternetToast.hide(REMOVE_WIDGET);
         }
@@ -593,7 +596,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         mAlertPrompt.setTitle(title);
         mAlertPrompt.setMessage(msg);
         mAlertPrompt.setDelegate(callback);
-        mAlertPrompt.show();
+        mAlertPrompt.show(REQUEST_FOCUS);
     }
 
     // PromptDelegate
@@ -605,7 +608,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         mAlertPrompt.setTitle(title);
         mAlertPrompt.setMessage(msg);
         mAlertPrompt.setDelegate(callback);
-        mAlertPrompt.show();
+        mAlertPrompt.show(REQUEST_FOCUS);
     }
 
     @Override
@@ -616,7 +619,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         mConfirmPrompt.setMessage(msg);
         mConfirmPrompt.setButtons(btnMsg);
         mConfirmPrompt.setDelegate(callback);
-        mConfirmPrompt.show();
+        mConfirmPrompt.show(REQUEST_FOCUS);
     }
 
     @Override
@@ -627,7 +630,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         mTextPrompt.setMessage(msg);
         mTextPrompt.setDefaultText(value);
         mTextPrompt.setDelegate(callback);
-        mTextPrompt.show();
+        mTextPrompt.show(REQUEST_FOCUS);
     }
 
     @Override
@@ -637,7 +640,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         mAuthPrompt.setTitle(title);
         mAuthPrompt.setMessage(msg);
         mAuthPrompt.setAuthOptions(options, callback);
-        mAuthPrompt.show();
+        mAuthPrompt.show(REQUEST_FOCUS);
     }
 
     @Override
@@ -649,7 +652,7 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
         mChoicePrompt.setChoices(choices);
         mChoicePrompt.setMenuType(type);
         mChoicePrompt.setDelegate(callback);
-        mChoicePrompt.show();
+        mChoicePrompt.show(REQUEST_FOCUS);
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
@@ -134,8 +134,8 @@ public class CrashDialogWidget extends UIDialog {
     }
 
     @Override
-    public void show() {
-        super.show();
+    public void show(@ShowFlags int aShowFlags) {
+        super.show(aShowFlags);
 
         mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
@@ -82,8 +82,8 @@ public class PermissionWidget extends UIDialog implements WidgetManagerDelegate.
     }
 
     @Override
-    public void show() {
-        super.show();
+    public void show(@ShowFlags int aShowFlags) {
+        super.show(aShowFlags);
 
         mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
     }
@@ -141,7 +141,7 @@ public class PermissionWidget extends UIDialog implements WidgetManagerDelegate.
         mPermissionMessage.setText(str);
         mPermissionIcon.setImageResource(iconId);
 
-        show();
+        show(REQUEST_FOCUS);
     }
 
     String getRequesterName(String aUri) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -258,18 +258,18 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
             }
 
             if (granted) {
-                show();
+                show(REQUEST_FOCUS);
 
             } else {
-                super.show(true);
+                super.show(REQUEST_FOCUS);
                 setPermissionNotGranted();
             }
         }
     }
 
     @Override
-    public void show(boolean aFocus) {
-        super.show(aFocus);
+    public void show(@ShowFlags int aShowFlags) {
+        super.show(aShowFlags);
 
         setStartListeningState();
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ChoicePromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ChoicePromptWidget.java
@@ -145,8 +145,8 @@ public class ChoicePromptWidget extends PromptWidget {
     }
 
     @Override
-    public void show() {
-        show(true);
+    public void show(@ShowFlags int aShowFlags) {
+        show(aShowFlags);
         for (int i = 0; i < mListItems.length; i++) {
             mList.setItemChecked(i, mListItems[i].mChoice.selected);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
@@ -65,11 +65,13 @@ public class PromptWidget extends UIDialog {
 
 
     @Override
-    public void show() {
+    public void show(@ShowFlags int aShowFlags) {
         mLayout.measure(View.MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED),
                         View.MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
         mWidgetPlacement.height = (int)(mLayout.getMeasuredHeight()/mWidgetPlacement.density);
-        super.show();
+        super.show(aShowFlags);
+
+        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
 
         ViewTreeObserver viewTreeObserver = mLayout.getViewTreeObserver();
         if (viewTreeObserver.isAlive()) {
@@ -82,11 +84,6 @@ public class PromptWidget extends UIDialog {
                 }
             });
         }
-    }
-
-    public void show(boolean focus) {
-        super.show(focus);
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
     }
 
     public void hide(@HideFlags int aHideFlags) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -370,8 +370,8 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
     }
 
     @Override
-    public void show() {
-        super.show();
+    public void show(@ShowFlags int aShowFlags) {
+        super.show(aShowFlags);
 
         mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
     }
@@ -413,10 +413,10 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
         if (widget == null) {
             widget = createChild(RestartDialogWidget.class, false);
             mRestartDialogHandle = widget.getHandle();
-            widget.setDelegate(this::show);
+            widget.setDelegate(() -> show(REQUEST_FOCUS));
         }
 
-        widget.show();
+        widget.show(REQUEST_FOCUS);
     }
 
     @Override
@@ -427,13 +427,13 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
         if (widget == null) {
             widget = createChild(AlertPromptWidget.class, false);
             mAlertDialogHandle = widget.getHandle();
-            widget.setDelegate(this::show);
+            widget.setDelegate(() -> show(REQUEST_FOCUS));
         }
         widget.getPlacement().translationZ = 0;
         widget.getPlacement().parentHandle = mHandle;
         widget.setTitle(aTitle);
         widget.setMessage(aMessage);
 
-        widget.show();
+        widget.show(REQUEST_FOCUS);
     }
 }


### PR DESCRIPTION
Fixes #1346 Refactored the show methods from UIWidget into a single method that uses a enum for readability.