### PR TITLE
Use real hitPoint distance for pointer scale

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -367,6 +367,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
         vrb::Matrix localRotation = vrb::Matrix::Rotation(hitNormal);
         vrb::Matrix reorient = device->GetReorientTransform();
         controller.pointer->SetTransform(reorient.AfineInverse().PostMultiply(translation).PostMultiply(localRotation));
+        controller.pointer->SetScale(hitPoint, device->GetHeadTransform());
       }
     }
 

--- a/app/src/main/cpp/Pointer.cpp
+++ b/app/src/main/cpp/Pointer.cpp
@@ -153,9 +153,11 @@ Pointer::SetVisible(bool aVisible) {
 void
 Pointer::SetTransform(const vrb::Matrix& aTransform) {
   m.transform->SetTransform(aTransform);
-  vrb::Vector point;
-  point = aTransform.MultiplyPosition(point);
-  const float scale = fabsf(point.z());
+}
+
+void
+Pointer::SetScale(const vrb::Vector& aHitPoint, const vrb::Matrix& aHeadTransform) {
+  const float scale = (aHitPoint - aHeadTransform.MultiplyPosition(vrb::Vector(0.0f, 0.0f, 0.0f))).Magnitude();
   m.pointerScale->SetTransform(vrb::Matrix::Identity().ScaleInPlace(vrb::Vector(scale, scale, scale)));
 }
 

--- a/app/src/main/cpp/Pointer.h
+++ b/app/src/main/cpp/Pointer.h
@@ -27,6 +27,7 @@ public:
   bool IsLoaded() const;
   void SetVisible(bool aVisible);
   void SetTransform(const vrb::Matrix& aTransform);
+  void SetScale(const vrb::Vector& aHitPoint, const vrb::Matrix& aHeadTransform);
   void SetPointerColor(const vrb::Color& aColor);
   void SetHitWidget(const WidgetPtr& aWidget);
 


### PR DESCRIPTION
The current pointer size gets too small for widgets that are placed far on the x axis but close on the z.