### PR TITLE
Fix BuildConfig.Flavor equality checks

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -42,7 +42,7 @@ import org.mozilla.vrbrowser.browser.SettingsStore;
 import org.mozilla.vrbrowser.crashreporting.CrashReporterService;
 import org.mozilla.vrbrowser.crashreporting.GlobalExceptionHandler;
 import org.mozilla.vrbrowser.geolocation.GeolocationWrapper;
-import org.mozilla.vrbrowser.input.DeviceType;
+import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.input.MotionEventGenerator;
 import org.mozilla.vrbrowser.search.SearchEngineWrapper;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
@@ -186,7 +186,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         // Set a global exception handler as soon as possible
         GlobalExceptionHandler.register(this.getApplicationContext());
 
-        if (BuildConfig.FLAVOR_platform == "oculusvr") {
+        if (DeviceType.isOculusBuild()) {
             workaroundGeckoSigAction();
         }
         mUiThread = Thread.currentThread();
@@ -497,7 +497,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent event) {
-        if (BuildConfig.FLAVOR_platform == "oculusvr") {
+        if (DeviceType.isOculusBuild()) {
             int action = event.getAction();
             if (action != KeyEvent.ACTION_DOWN) {
                 return super.dispatchKeyEvent(event);

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -11,6 +11,7 @@ import org.mozilla.telemetry.TelemetryHolder;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
+import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.utils.LocaleUtils;
 import org.mozilla.vrbrowser.utils.StringUtils;
 
@@ -362,7 +363,7 @@ public class SettingsStore {
     }
 
     public boolean getLayersEnabled() {
-        if (BuildConfig.FLAVOR_platform.equalsIgnoreCase("oculusvr")) {
+        if (DeviceType.isOculusBuild()) {
             return true;
         }
         return false;

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -23,6 +23,7 @@ import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.SettingsStore;
 import org.mozilla.vrbrowser.search.SearchEngineWrapper;
+import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.utils.UrlUtils;
 
 import java.net.URI;
@@ -100,7 +101,7 @@ public class TelemetryWrapper {
             final JSONPingSerializer serializer = new JSONPingSerializer();
             final FileTelemetryStorage storage = new FileTelemetryStorage(configuration, serializer);
             TelemetryScheduler scheduler;
-            if (BuildConfig.FLAVOR_platform.equals("oculusvr") || BuildConfig.FLAVOR_platform.equals("oculusvrStore")) {
+            if (DeviceType.isOculus6DOFBuild()) {
                 scheduler = new FxRTelemetryScheduler();
             } else {
                 scheduler = new JobSchedulerTelemetryScheduler();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HoneycombButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HoneycombButton.java
@@ -12,7 +12,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.mozilla.vrbrowser.input.DeviceType;
+import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.R;
 
 import androidx.annotation.Nullable;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -26,13 +26,11 @@ import com.mozilla.speechlibrary.STTResult;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.browser.SettingsStore;
-import org.mozilla.vrbrowser.input.DeviceType;
+import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.ui.views.UIButton;
-import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 
-import androidx.annotation.IdRes;
 import androidx.core.app.ActivityCompat;
 
 public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate.PermissionListener,

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
@@ -21,6 +21,7 @@ import org.mozilla.vrbrowser.ui.views.settings.RadioGroupSetting;
 import org.mozilla.vrbrowser.ui.views.settings.SingleEditSetting;
 import org.mozilla.vrbrowser.ui.views.settings.SwitchSetting;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
+import org.mozilla.vrbrowser.utils.DeviceType;
 
 class DisplayOptionsView extends SettingsView {
     private AudioEngine mAudio;
@@ -245,8 +246,7 @@ class DisplayOptionsView extends SettingsView {
         if (!mMSAARadio.getValueForId(mMSAARadio.getCheckedRadioButtonId()).equals(SettingsStore.MSAA_DEFAULT_LEVEL)) {
             setMSAAMode(mMSAARadio.getIdForValue(SettingsStore.MSAA_DEFAULT_LEVEL), true);
         }
-        if (BuildConfig.FLAVOR_platform == "oculusvr" ||
-            BuildConfig.FLAVOR_platform == "wavevr") {
+        if (DeviceType.isOculusBuild() || DeviceType.isWaveBuild()) {
             if (!mFoveatedAppRadio.getValueForId(mFoveatedAppRadio.getCheckedRadioButtonId()).equals(SettingsStore.FOVEATED_APP_DEFAULT_LEVEL)) {
                 setFoveatedLevel(mFoveatedAppRadio, mFoveatedAppRadio.getIdForValue(SettingsStore.FOVEATED_APP_DEFAULT_LEVEL), true);
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
@@ -22,6 +22,7 @@ import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.views.settings.ButtonSetting;
 import org.mozilla.vrbrowser.ui.views.settings.SwitchSetting;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
+import org.mozilla.vrbrowser.utils.DeviceType;
 
 import java.util.ArrayList;
 
@@ -91,8 +92,9 @@ class PrivacyOptionsView extends SettingsView {
         mPermissionButtons.add(Pair.create(findViewById(R.id.locationPermissionButton), Manifest.permission.ACCESS_FINE_LOCATION));
         mPermissionButtons.add(Pair.create(findViewById(R.id.storagePermissionButton), Manifest.permission.READ_EXTERNAL_STORAGE));
 
-        if (BuildConfig.FLAVOR_platform == "oculusvr3dof" || BuildConfig.FLAVOR_platform == "oculusvr")
+        if (DeviceType.isOculusBuild()) {
             findViewById(R.id.cameraPermissionButton).setVisibility(View.GONE);
+        }
 
         for (Pair<ButtonSetting, String> button: mPermissionButtons) {
             if (mWidgetManager.isPermissionGranted(button.second)) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/DeviceType.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/DeviceType.java
@@ -1,6 +1,8 @@
-package org.mozilla.vrbrowser.input;
+package org.mozilla.vrbrowser.utils;
 
 import android.util.Log;
+
+import org.mozilla.vrbrowser.BuildConfig;
 
 public class DeviceType {
     // These values need to match those in Device.h
@@ -20,5 +22,17 @@ public class DeviceType {
     }
     public static int getType() {
         return mType;
+    }
+
+    public static boolean isOculusBuild() {
+        return BuildConfig.FLAVOR_platform.toLowerCase().contains("oculusvr");
+    }
+
+    public static boolean isOculus6DOFBuild() {
+        return BuildConfig.FLAVOR_platform.equalsIgnoreCase("oculusvr") || BuildConfig.FLAVOR_platform.equalsIgnoreCase("oculusvrStore");
+    }
+
+    public static boolean isWaveBuild() {
+        return BuildConfig.FLAVOR_platform.toLowerCase().contains("wavevr");
     }
 }


### PR DESCRIPTION
We have added new flavors but we still do the old checks. This produces a different behavior in store builds (e.g. layers disabled in Oculus)