### PR TITLE
Fix controller state on Daydream devices.

### DIFF
--- a/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
+++ b/app/src/googlevr/cpp/DeviceDelegateGoogleVR.cpp
@@ -589,6 +589,10 @@ DeviceDelegateGoogleVR::Pause() {
     VRB_LOG("Pause GVR tracking");
     GVR_CHECK(gvr_pause_tracking(m.gvr));
   }
+
+  for (Controller& controller: m.controllers) {
+    controller.enabled = false;
+  }
 }
 
 void


### PR DESCRIPTION
On Daydream devices when the activity was paused, the controllers would get
disabled in BrowserWorld but not in the DeviceDelegate so when the activity
would resume, the controllers in the DeviceDelegate would never re-enable
the controller models in BrowserWorld.