### PR TITLE
WIP: FxA, Sync and Send Tab integrations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -401,9 +401,13 @@ dependencies {
     implementation deps.android_components.browser_search
     implementation deps.android_components.browser_storage
     implementation deps.android_components.browser_domains
+    implementation deps.android_components.service_accounts
     implementation deps.android_components.ui_autocomplete
     implementation deps.android_components.concept_fetch
     implementation deps.android_components.lib_fetch
+
+    // TODO this should not be necessary at all, see Services.kt
+    implementation deps.work.runtime
 
     // Kotlin dependency
     implementation deps.kotlin.stdlib

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 
+import org.jetbrains.annotations.NotNull;
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.geckoview.CrashReporter;
 import org.mozilla.geckoview.GeckoResult;
@@ -75,6 +76,10 @@ import java.util.function.Consumer;
 import androidx.annotation.IntDef;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
+
+import mozilla.components.concept.sync.AccountObserver;
+import mozilla.components.concept.sync.OAuthAccount;
+import mozilla.components.concept.sync.Profile;
 
 public class VRBrowserActivity extends PlatformActivity implements WidgetManagerDelegate, SessionStore.VideoAvailabilityListener {
 
@@ -170,6 +175,23 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         }
     };
 
+    private AccountObserver accountObserver = new AccountObserver() {
+        @Override
+        public void onLoggedOut() {}
+
+        @Override
+        public void onAuthenticated(@NotNull OAuthAccount account) {
+            // Check if we have any new device events (e.g. tabs).
+            account.deviceConstellation().refreshDeviceStateAsync();
+        }
+
+        @Override
+        public void onProfileUpdated(@NotNull Profile profile) {}
+
+        @Override
+        public void onAuthenticationProblems() {}
+    };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // Fix for infinite restart on startup crashes.
@@ -243,6 +265,12 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         GeolocationWrapper.update(this);
 
         mConnectivityReceiver = new ConnectivityReceiver();
+
+        // Monitor FxA account state.
+        ((VRBrowserApplication) this.getApplicationContext())
+            .getServices()
+            .getAccountManager()
+            .register(accountObserver);
     }
 
     protected void initializeWorld() {
@@ -336,6 +364,17 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         }
         handleConnectivityChange();
         mConnectivityReceiver.register(this, () -> runOnUiThread(() -> handleConnectivityChange()));
+
+        // If we're signed-in, poll for any new device events (e.g. received tabs) on activity resume.
+        // There's no push support right now, so this helps with the perception of speedy tab delivery.
+        OAuthAccount account = ((VRBrowserApplication) this.getApplicationContext())
+                .getServices()
+                .getAccountManager()
+                .authenticatedAccount();
+        if (account != null) {
+            account.deviceConstellation().refreshDeviceStateAsync();
+        }
+
         super.onResume();
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
@@ -7,18 +7,24 @@ package org.mozilla.vrbrowser;
 
 import android.app.Application;
 
+import org.mozilla.vrbrowser.browser.Places;
+import org.mozilla.vrbrowser.browser.Services;
 import org.mozilla.vrbrowser.db.AppDatabase;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 
 public class VRBrowserApplication extends Application {
 
     private AppExecutors mAppExecutors;
+    private Services mServices;
+    private Places mPlaces;
 
     @Override
     public void onCreate() {
         super.onCreate();
 
         mAppExecutors = new AppExecutors();
+        mPlaces = new Places(this);
+        mServices = new Services(this, mPlaces);
 
         TelemetryWrapper.init(this);
     }
@@ -29,5 +35,13 @@ public class VRBrowserApplication extends Application {
 
     public DataRepository getRepository() {
         return DataRepository.getInstance(getDatabase(), mAppExecutors);
+    }
+
+    public Services getServices() {
+        return mServices;
+    }
+
+    public Places getPlaces() {
+        return mPlaces;
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
@@ -1,0 +1,16 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.browser
+
+import android.content.Context
+import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
+
+/**
+ * Entry point for interacting with places-backed storage layers.
+ */
+class Places(context: Context) {
+    val bookmarks = PlacesBookmarksStorage(context)
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
@@ -7,10 +7,12 @@ package org.mozilla.vrbrowser.browser
 
 import android.content.Context
 import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
+import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 
 /**
  * Entry point for interacting with places-backed storage layers.
  */
 class Places(context: Context) {
-    val bookmarks = PlacesBookmarksStorage(context)
+    val bookmarks by lazy { PlacesBookmarksStorage(context) }
+    val history by lazy { PlacesHistoryStorage(context) }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -1,0 +1,115 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.browser
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import mozilla.components.concept.sync.DeviceCapability
+import mozilla.components.concept.sync.DeviceEvent
+import mozilla.components.concept.sync.DeviceEventsObserver
+import mozilla.components.concept.sync.DeviceType
+import mozilla.components.service.fxa.DeviceConfig
+import mozilla.components.service.fxa.ServerConfig
+import mozilla.components.service.fxa.SyncConfig
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
+import mozilla.components.support.base.log.Log
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.base.log.sink.AndroidLogSink
+import java.lang.IllegalStateException
+
+class Services(context: Context, places: Places) {
+    companion object {
+        // TODO this is from a sample app, get a real client id before shipping.
+        const val CLIENT_ID = "3c49430b43dfba77"
+        const val REDIRECT_URL = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
+    }
+
+    // This makes bookmarks storage accessible to background sync workers.
+    init {
+        // Make sure we get logs out of our android-components.
+        Log.addSink(AndroidLogSink())
+
+        GlobalSyncableStoreProvider.configureStore("bookmarks" to places.bookmarks)
+
+        // TODO this really shouldn't be necessary, since WorkManager auto-initializes itself, unless
+        // auto-initialization is disabled in the manifest file. We don't disable the initialization,
+        // but i'm seeing crashes locally because WorkManager isn't initialized correctly...
+        // Maybe this is a race of sorts? We're trying to access it before it had a chance to auto-initialize?
+        // It's not well-documented _when_ that auto-initialization is supposed to happen.
+
+        // For now, let's just manually initialize it here, and swallow failures (it's already initialized).
+        try {
+            WorkManager.initialize(
+                    context,
+                    Configuration.Builder().setMinimumLoggingLevel(android.util.Log.INFO).build()
+            )
+        } catch (e: IllegalStateException) {}
+    }
+
+    // Process received device events, only handling received tabs for now.
+    // They'll come from other FxA devices (e.g. Firefox Desktop).
+    private val deviceEventObserver = object : DeviceEventsObserver {
+        private val logTag = "DeviceEventsObserver"
+
+        override fun onEvents(events: List<DeviceEvent>) {
+            CoroutineScope(Dispatchers.Main).launch {
+                Logger(logTag).info("Received ${events.size} device event(s)")
+                events.filterIsInstance(DeviceEvent.TabReceived::class.java).forEach {
+                    // Just load the first tab that was sent.
+                    // TODO is there a notifications API of sorts here?
+                    SessionStore.get().loadUri(it.entries[0].url)
+                }
+            }
+        }
+    }
+
+    val accountManager = FxaAccountManager(
+        context = context,
+        serverConfig = ServerConfig.release(CLIENT_ID, REDIRECT_URL),
+        deviceConfig = DeviceConfig(
+            // This is a default name, and can be changed once user is logged in.
+            // E.g. accountManager.authenticatedAccount()?.deviceConstellation()?.setDeviceNameAsync("new name")
+            name = "Firefox Reality on ${Build.MANUFACTURER} ${Build.MODEL}",
+            // TODO need a new device type! "VR"
+            type = DeviceType.MOBILE,
+            capabilities = setOf(DeviceCapability.SEND_TAB)
+        ),
+        // If background syncing is desired, pass in a 'syncPeriodInMinutes' parameter.
+        // As-is, sync will run on app startup.
+        syncConfig = SyncConfig(setOf("bookmarks"))
+    ).also {
+        it.registerForDeviceEvents(deviceEventObserver, ProcessLifecycleOwner.get(), true)
+    }
+
+    init {
+        CoroutineScope(Dispatchers.Main).launch {
+            accountManager.initAsync().await()
+        }
+    }
+
+    /**
+     * Call this for every loaded URL to enable FxA sign-in to finish. It's a bit of a hack, but oh well.
+     */
+    fun interceptFxaUrl(uri: String) {
+        if (!uri.startsWith(REDIRECT_URL)) return
+        val parsedUri = Uri.parse(uri)
+
+        parsedUri.getQueryParameter("code")?.let { code ->
+            val state = parsedUri.getQueryParameter("state") as String
+
+            // Notify the state machine about our success.
+            accountManager.finishAuthenticationAsync(code, state)
+        }
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -41,6 +41,7 @@ class Services(context: Context, places: Places) {
         Log.addSink(AndroidLogSink())
 
         GlobalSyncableStoreProvider.configureStore("bookmarks" to places.bookmarks)
+        GlobalSyncableStoreProvider.configureStore("history" to places.history)
 
         // TODO this really shouldn't be necessary, since WorkManager auto-initializes itself, unless
         // auto-initialization is disabled in the manifest file. We don't disable the initialization,
@@ -87,7 +88,7 @@ class Services(context: Context, places: Places) {
         ),
         // If background syncing is desired, pass in a 'syncPeriodInMinutes' parameter.
         // As-is, sync will run on app startup.
-        syncConfig = SyncConfig(setOf("bookmarks"))
+        syncConfig = SyncConfig(setOf("bookmarks", "history"))
     ).also {
         it.registerForDeviceEvents(deviceEventObserver, ProcessLifecycleOwner.get(), true)
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionStore.java
@@ -30,6 +30,7 @@ import org.mozilla.geckoview.WebExtension;
 import org.mozilla.geckoview.WebRequestError;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.crashreporting.CrashReporterService;
 import org.mozilla.vrbrowser.geolocation.GeolocationData;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
@@ -1050,6 +1051,8 @@ public class SessionStore implements ContentBlocking.Delegate, GeckoSession.Navi
         String uri = aRequest.uri;
 
         Log.d(LOGTAG, "onLoadRequest: " + uri);
+
+        ((VRBrowserApplication) mContext.getApplicationContext()).getServices().interceptFxaUrl(uri);
 
         String uriOverride = checkYoutubeOverride(uri);
         if (uriOverride != null) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/AccountsHelper.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/AccountsHelper.kt
@@ -1,0 +1,49 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.ui.widgets.settings
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.future
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
+import org.mozilla.vrbrowser.VRBrowserApplication
+import org.mozilla.vrbrowser.browser.Services
+import java.util.concurrent.CompletableFuture
+
+class AccountsHelper(private val settingsWidget: SettingsWidget) {
+    val accountObserver = object : AccountObserver {
+        override fun onAuthenticated(account: OAuthAccount) {
+            settingsWidget.updateCurrentAccountState()
+        }
+
+        override fun onAuthenticationProblems() {
+            settingsWidget.updateCurrentAccountState()
+        }
+
+        override fun onLoggedOut() {
+            settingsWidget.updateCurrentAccountState()
+        }
+
+        override fun onProfileUpdated(profile: Profile) {
+            settingsWidget.updateCurrentAccountState()
+        }
+    }
+
+    fun authUrlAsync(): CompletableFuture<String?>? {
+        val context = settingsWidget.context ?: return null
+
+        return CoroutineScope(Dispatchers.Main).future {
+            context.services().accountManager.beginAuthenticationAsync().await()
+        }
+    }
+
+    private fun Context.services(): Services {
+        return (this.applicationContext as VRBrowserApplication).services
+    }
+}

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -156,6 +156,14 @@
                             app:honeycombButtonText="@string/settings_controller_options"
                             app:honeycombButtonTextSize="@dimen/settings_main_button_text_width" />
 
+                        <!-- TODO use a proper accounts icon -->
+                        <org.mozilla.vrbrowser.ui.views.HoneycombButton
+                            android:id="@+id/fxaButton"
+                            style="?attr/honeycombButtonStyle"
+                            app:honeycombButtonIcon="@drawable/ic_settings_reportissue"
+                            app:honeycombButtonText="@string/settings_accounts_sign_in"
+                            app:honeycombSwitchTextSize="@dimen/settings_main_button_text_width" />
+
                         <org.mozilla.vrbrowser.ui.views.HoneycombButton
                             android:id="@+id/reportButton"
                             style="?attr/honeycombButtonStyle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,16 @@
          a developer-build version of the app. -->
     <string name="settings_version_developer">Developer Build</string>
 
+    <!-- This string is used in the 'Settings' window when user is signed-out of Firefox Accounts -->
+    <string name="settings_accounts_sign_in">Sign in</string>
+
+    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account -->
+    <string name="settings_accounts_sign_out">Sign out</string>
+
+    <!-- This string is used in the 'Settings' window when user is signed into a Firefox Account, but needs to re-enter their password.
+         Most common reason for this state is that the account password was changed on another device. -->
+    <string name="settings_accounts_reconnect">Reconnect</string>
+
     <!-- This string is the title of a dialog box shown to the user when a settings
          change requires the application to restart. -->
     <string name="restart_dialog_restart">Restart Required</string>

--- a/versions.gradle
+++ b/versions.gradle
@@ -81,6 +81,11 @@ support.core_utils = "androidx.legacy:legacy-support-core-utils:$versions.suppor
 support.vector_drawable = "androidx.vectordrawable:vectordrawable:$versions.support"
 deps.support = support
 
+// TODO this should not be necessary at all, see Services.kt
+def work = [:]
+work.runtime = "androidx.work:work-runtime-ktx:$versions.work"
+deps.work = work
+
 def room = [:]
 room.runtime = "androidx.room:room-runtime:$versions.room"
 room.compiler = "androidx.room:room-compiler:$versions.room"

--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,7 @@ def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
 versions.gecko_view = "70.0.20190710094220"
-versions.android_components = "0.52.0"
+versions.android_components = "4.0.0-SNAPSHOT"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"
@@ -55,6 +55,7 @@ android_components.browser_errorpages = "org.mozilla.components:browser-errorpag
 android_components.browser_search = "org.mozilla.components:browser-search:$versions.android_components"
 android_components.browser_storage = "org.mozilla.components:browser-storage-sync:$versions.android_components"
 android_components.browser_domains = "org.mozilla.components:browser-domains:$versions.android_components"
+android_components.service_accounts = "org.mozilla.components:service-firefox-accounts:$versions.android_components"
 android_components.ui_autocomplete = "org.mozilla.components:ui-autocomplete:$versions.android_components"
 android_components.concept_fetch = "org.mozilla.components:concept-fetch:$versions.android_components"
 android_components.lib_fetch = "org.mozilla.components:lib-fetch-httpurlconnection:$versions.android_components"
@@ -139,6 +140,7 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url 'https://snapshots.maven.mozilla.org/maven2' }
     handler.maven { url 'https://maven.mozilla.org/maven2' }
     handler.maven { url 'https://download.servo.org/nightly/maven' }
 }


### PR DESCRIPTION
This PR integrates latest version of the FxA account manager from android-components, and adds just enough code to allow signing-in via settings, signing out, synchronizing history & bookmarks and receiving tabs sent from other Firefox devices.

Follow-up:
- #1420 Enable glean telemetry support (so that we know how sync is doing)
- #1419 Obtain a production FxA client ID (currently using a sample one)
- #1397 megazord configuration for places and fxa libs
- #1395 bookmarks UI needs folder support
- #1398 better account management UI, currently there are just sign-in/sign-out/reconnect buttons