### PR TITLE
Bump a-c dependency to 4.0.0

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,7 @@ def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
 versions.gecko_view = "70.0.20190710094220"
-versions.android_components = "0.52.0"
+versions.android_components = "4.0.0"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"


### PR DESCRIPTION
Starting to split-off parts of the FxA/sync work into PRs that can land on `master` now, and PRs that will land on a feature branch.

4.0.0 is the latest version of `android-components`. By extension, this gets us a very recent version of application-services dependencies, as well.

In the future we may consider using the -SNAPSHOT variant (essentially, a nightly version)
to keep up with the latest changes in a-c and a-s.