### PR TITLE
Introduce a centralized places.kt which owns storage

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
@@ -7,18 +7,21 @@ package org.mozilla.vrbrowser;
 
 import android.app.Application;
 
+import org.mozilla.vrbrowser.browser.Places;
 import org.mozilla.vrbrowser.db.AppDatabase;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 
 public class VRBrowserApplication extends Application {
 
     private AppExecutors mAppExecutors;
+    private Places mPlaces;
 
     @Override
     public void onCreate() {
         super.onCreate();
 
         mAppExecutors = new AppExecutors();
+        mPlaces = new Places(this);
 
         TelemetryWrapper.init(this);
     }
@@ -29,5 +32,9 @@ public class VRBrowserApplication extends Application {
 
     public DataRepository getRepository() {
         return DataRepository.getInstance(getDatabase(), mAppExecutors);
+    }
+
+    public Places getPlaces() {
+        return mPlaces;
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
@@ -1,0 +1,16 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.browser
+
+import android.content.Context
+import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
+
+/**
+ * Entry point for interacting with places-backed storage layers.
+ */
+class Places(context: Context) {
+    val bookmarks by lazy { PlacesBookmarksStorage(context) }
+}


### PR DESCRIPTION
Starting to split-off parts of the FxA/sync work into PRs that can land on master now, and PRs that will land on a feature branch.

This lets us access storage backends from different parts of the system
at the same time. E.g. from both BookmarksStore as well as the upcoming Services
sync integration.