### PR TITLE
Transition to R8 in full mode

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -53,6 +53,12 @@
 -keep class org.mozilla.vrbrowser.ui.widgets.WidgetPlacement {*;}
 
 # --------------------------------------------------------------------
+# Keep classes from HTC SDK
+# --------------------------------------------------------------------
+-keep class com.htc.** {*;}
+-keep class com.qualcomm.** {*;}
+
+# --------------------------------------------------------------------
 # Keep rules for mozillaspeechlibrary dependency
 # --------------------------------------------------------------------
 -keep class cz.msebera.android.httpclient.** {*;}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,6 +47,27 @@
     public static android.content.Intent createVoiceRecognizerIntent(java.lang.String);
 }
 
+
+# --------------------------------------------------------------------
+# Keep classes from gecko.
+# --------------------------------------------------------------------
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+-keep class org.mozilla.gecko.mozglue.JNIObject {*;}
+
+# --------------------------------------------------------------------
+# Keep classes from FxR
+# --------------------------------------------------------------------
+-keep class org.mozilla.vrbrowser.ui.widgets.WidgetPlacement {*;}
+
+# --------------------------------------------------------------------
+# Keep rules for mozillaspeechlibrary dependency
+# --------------------------------------------------------------------
+-keep class cz.msebera.android.httpclient.** {*;}
+-keep class com.loopj.android.http.** {*;}
+-keep class com.github.axet.opusjni.Opus {*;}
+
 -dontwarn **
 -target 1.7
 -dontusemixedcaseclassnames
@@ -55,6 +76,4 @@
 -verbose
 -optimizations !code/simplification/arithmetic,!code/allocation/variable
 -keepattributes *
--keep class !org.mozilla.gecko.Speech* { *; }
--keepclassmembers class !org.mozilla.gecko.Speech*, ** { *; }
 -printconfiguration "build/outputs/mapping/configuration.txt"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,15 +47,6 @@
     public static android.content.Intent createVoiceRecognizerIntent(java.lang.String);
 }
 
-
-# --------------------------------------------------------------------
-# Keep classes from gecko.
-# --------------------------------------------------------------------
--keepclasseswithmembernames,includedescriptorclasses class * {
-    native <methods>;
-}
--keep class org.mozilla.gecko.mozglue.JNIObject {*;}
-
 # --------------------------------------------------------------------
 # Keep classes from FxR
 # --------------------------------------------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: 'versions.gradle'
     addRepos(repositories)
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "$deps.kotlin.plugin"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,5 @@ android.injected.testOnly=false
 android.databinding.enableV2=true
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=false
+android.enableR8=true
+android.enableR8.fullMode=true


### PR DESCRIPTION
This PR adds the proguard rules required to make R8 work in full mode. It will allow to reduce compiling times significantly.

In addition, we were not doing correct minification before. We had a rule to keep all classes. I removed that so it has required to add some extra rules such as `WidgetPlacement` class which fields are uses from native.

One of the problematic dependencies was `mozillaspeechlibrary`. I added some rules here but also pushed a PR to add the rules upstream: https://github.com/mozilla/androidspeech/pull/17

Other problematic dependency was Gecko. The fenix tem has already enabled full mode: https://github.com/mozilla-mobile/fenix/blob/master/gradle.properties. But it triggered a weird error in FxR. After some tries I fixed it keeping everything inside `public class org.mozilla.gecko.**`. I'll follow up with the GV team and file a bug. But for now we can use this rule (keep in mind we were keeping everything before...)