### PR TITLE
Fixed storage.getVisited() is always true warning.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
@@ -51,7 +51,7 @@ class HistoryStore constructor(val context: Context) {
     }
 
     fun isInHistory(aURL: String): CompletableFuture<Boolean> = GlobalScope.future {
-        storage.getVisited(listOf(aURL)) != null
+        storage.getVisited(listOf(aURL)).size != 0
     }
 
     private fun notifyListeners() {


### PR DESCRIPTION
storage.getVisited(listOf(aURL)) returns a container instead of a ptr.