### PR TITLE
Fixes a crash in tooltips in Android > 26

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UIButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UIButton.java
@@ -79,7 +79,7 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             return mTooltipText;
         else
-            return getTooltipText().toString();
+            return getTooltipText() == null ? null : getTooltipText().toString();
     }
 
     @TargetApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
In Android > 26 there is crash when trying to show a tooltip in a Button without tooltip text.

STRs:
- Launch FxR in an Android > 26
- Open Settings
- Open languages
- Click on the back button