### PR TITLE
Fix inactive forward button for videos on youtube.com

### DIFF
--- a/app/src/main/assets/web_extensions/webcompat_youtube/main.js
+++ b/app/src/main/assets/web_extensions/webcompat_youtube/main.js
@@ -116,7 +116,7 @@ try {
     }
 
     const newUrl = getNewUrl(qs);
-    if (newUrl && window.location.pathname + window.location.search !== newUrl) {
+    if (newUrl && (window.location.pathname + window.location.search) !== newUrl) {
       window.history.replaceState({}, document.title, newUrl);
       return newUrl;
     }
@@ -289,6 +289,16 @@ try {
       window.ytplayer.config.args.jsapicallback = 'onYouTubePlayerReady';
     }
   });
+
+  window.addEventListener("beforeunload", function (e) {
+    // Make sure that the disable_polymer parameter is kept. Youtube processes the parameter but removes it from the URL.
+    // See https://github.com/MozillaReality/FirefoxReality/issues/1426
+    let qs = new URLSearchParams(window.location.search);
+    qs.set('disable_polymer', '1');
+    let url = getNewUrl(qs);
+    window.history.replaceState({}, document.title, url);
+  });
+
 } catch (err) {
   console.error(LOGTAG, 'Encountered error:', err);
 }


### PR DESCRIPTION
Fixes #1426

Found the problem after some research. It seems that youtube processes the `disable_polymer` parameter but removes it from the URL at some point. This causes another override when going back to a previous youtube video, and the forward action is lost there.

GV doesn't have an API to override URLs. You need to cancel the current load and perform another `loadUri`. So I decided to add a history override from the webextension when the page is unloaded to get the parameter back.