### PR TITLE
Bump GV to 70.0.20190726094308

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "70.0.20190721094948"
+versions.gecko_view = "70.0.20190726094308"
 versions.android_components = "4.0.0"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"


### PR DESCRIPTION
Fixes #1399

Also includes updated rules for #1190