### PR TITLE
Support for WaveVR appId 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ def getCrashRestartDisabled = { ->
     return "false"
 }
 
-def getDevApplicationIdSufix = { ->
+def getDevApplicationIdSuffix = { ->
     if (gradle.hasProperty("simultaneousDevProduction")) {
         return gradle.simultaneousDevProduction == "true" ? ".dev" : ""
     }
@@ -78,7 +78,7 @@ android {
             signingConfig getUseDebugSigningOnRelease() ? debug.signingConfig : release.signingConfig
         }
         debug {
-            applicationIdSuffix getDevApplicationIdSufix()
+            applicationIdSuffix getDevApplicationIdSuffix()
             pseudoLocalesEnabled true
         }
     }
@@ -169,6 +169,7 @@ android {
                 }
             }
         }
+
         wavevr {
             minSdkVersion build_versions.min_sdk_wave
             dimension "platform"
@@ -179,7 +180,21 @@ android {
                     arguments "-DVR_SDK_LIB=wavevr-lib", "-DWAVEVR=ON"
                 }
             }
+            applicationIdSuffix ".wavevr"
         }
+
+        wavevrStore {
+            minSdkVersion build_versions.min_sdk_wave
+            dimension "platform"
+            externalNativeBuild {
+                cmake {
+                    cppFlags " -I" + file("${project.rootDir}/third_party/wavesdk/build/wvr_client/include").absolutePath +
+                            " -DWAVEVR"
+                    arguments "-DVR_SDK_LIB=wavevr-lib", "-DWAVEVR=ON"
+                }
+            }
+        }
+
         noapi {
             dimension "platform"
             externalNativeBuild {
@@ -211,6 +226,13 @@ android {
                 abiFilters "x86"
             }
         }
+
+        x86_64 {
+            dimension "abi"
+            ndk {
+                abiFilters "x86_64"
+            }
+        }
     }
 
     variantFilter { variant ->
@@ -239,12 +261,16 @@ android {
                 'wavevrArmRelease',
                 'wavevrArm64Debug',
                 'wavevrArm64Release',
+                'wavevrStoreArmDebug',
+                'wavevrStoreArmRelease',
+                'wavevrStoreArm64Debug',
+                'wavevrStoreArm64Release',
                 'noapiArmDebug',
                 'noapiArmRelease',
                 'noapiArm64Debug',
                 'noapiArm64Release',
-                'noapiX86Debug',
-                'noapiX86Release'
+                'noapiX86_64Debug',
+                'noapiX86_64Release'
         ]
         variant.setIgnore(!needed)
     }
@@ -361,6 +387,18 @@ android {
             ]
             jniLibs.srcDirs = ["${project.rootDir}/third_party/wavesdk/build/wvr_client/jni"]
         }
+
+        wavevrStore {
+            java.srcDirs = [
+                    'src/wavevr/java'
+            ]
+            res.srcDirs = [
+                    'src/wavevr/res'
+            ]
+            jniLibs.srcDirs = ["${project.rootDir}/third_party/wavesdk/build/wvr_client/jni"]
+            manifest.srcFile "src/wavevr/AndroidManifest.xml"
+        }
+
         noapi {
             java.srcDirs = [
                     'src/noapi/java'
@@ -440,6 +478,7 @@ if (findProject(':servo')) {
 if (findProject(':wavesdk')) {
     dependencies {
         wavevrImplementation project(':wavesdk')
+        wavevrStoreImplementation project(':wavesdk')
     }
 }
 
@@ -455,6 +494,7 @@ if (findProject(':geckoview-local')) {
         armImplementation deps.gecko_view.nightly_armv7a
         arm64Implementation deps.gecko_view.nightly_arm64
         x86Implementation deps.gecko_view.nightly_x86
+        x86_64Implementation deps.gecko_view.nightly_x86_64
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -220,13 +220,6 @@ android {
             }
         }
 
-        x86 {
-            dimension "abi"
-            ndk {
-                abiFilters "x86"
-            }
-        }
-
         x86_64 {
             dimension "abi"
             ndk {
@@ -493,7 +486,6 @@ if (findProject(':geckoview-local')) {
         // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/geckoview-nightly-armeabi-v7a/
         armImplementation deps.gecko_view.nightly_armv7a
         arm64Implementation deps.gecko_view.nightly_arm64
-        x86Implementation deps.gecko_view.nightly_x86
         x86_64Implementation deps.gecko_view.nightly_x86_64
     }
 }
@@ -517,8 +509,7 @@ android.applicationVariants.all { variant ->
         // compatibility mode.
         def multiplier = 100000000
 
-        // Currently only support arm7
-        if (variant.flavorName.contains("X86")) {
+        if (variant.flavorName.contains("x86_64")) {
             versionCode = versionCode + (3 * multiplier)
         } else if (variant.flavorName.contains("Aarch64")) {
             versionCode = versionCode + (2 * multiplier)

--- a/tools/taskcluster/build_targets.py
+++ b/tools/taskcluster/build_targets.py
@@ -37,8 +37,9 @@ platforms = {
    'oculusvrStore': ['arm', 'arm64'],
    'oculusvr3dofStore': ['arm', 'arm64'],
    'wavevr': ['arm', 'arm64'],
+   'wavevrStore': ['arm', 'arm64'],
    'googlevr': ['arm', 'arm64'],
-   'noapi': ['arm', 'arm64', 'x86'],
+   'noapi': ['arm', 'arm64', 'x86_64'],
    'svr': ['arm', 'arm64'],
 }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -46,7 +46,6 @@ def deps = [:]
 def gecko_view = [:]
 gecko_view.nightly_armv7a = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:$versions.gecko_view"
 gecko_view.nightly_arm64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:$versions.gecko_view"
-gecko_view.nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:$versions.gecko_view"
 gecko_view.nightly_x86_64 = "org.mozilla.geckoview:geckoview-nightly-x86_64:$versions.gecko_view"
 deps.gecko_view = gecko_view
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -47,6 +47,7 @@ def gecko_view = [:]
 gecko_view.nightly_armv7a = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:$versions.gecko_view"
 gecko_view.nightly_arm64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:$versions.gecko_view"
 gecko_view.nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:$versions.gecko_view"
+gecko_view.nightly_x86_64 = "org.mozilla.geckoview:geckoview-nightly-x86_64:$versions.gecko_view"
 deps.gecko_view = gecko_view
 
 def android_components = [:]


### PR DESCRIPTION
Fixes #1458 Added a .wavevr for non-store WaveVR builds so we can install debug and staging builds without clashing with the preinstalled app id.

Also replace noapi x86 builds with x86_64.