### PR TITLE
Avoid superfluous resizes with Layers

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -603,8 +603,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             View view = (View) widget;
             // Add widget to a virtual display for invalidation
             if (aSurface != null && view.getParent() == null) {
-                float scale = widget.getPlacement().textureScale;
-                mWidgetContainer.addView(view, new FrameLayout.LayoutParams((int) Math.ceil(aWidth / scale), (int) Math.ceil(aHeight / scale)));
+                mWidgetContainer.addView(view, new FrameLayout.LayoutParams(widget.getPlacement().viewWidth(), widget.getPlacement().viewHeight()));
             } else if (aSurface == null && view.getParent() != null) {
                 mWidgetContainer.removeView(view);
             }


### PR DESCRIPTION
There is a slighty different sizing calculation that causes superfluous surface resizes when layer surfaces are created.

Affects #1459 and performance.