### PR TITLE
Post firstDrawCallback to avoid a deadlock if the widget is resized in that callback.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 
+import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.geckoview.AllowOrDeny;
 import org.mozilla.geckoview.GeckoDisplay;
 import org.mozilla.geckoview.GeckoResult;
@@ -782,7 +783,9 @@ public class WindowWidget extends UIWidget implements SessionStore.SessionChange
     @Override
     public void onFirstComposite(GeckoSession session) {
         if (mFirstDrawCallback != null) {
-            mFirstDrawCallback.run();
+            // Post this call because running it synchronously can cause a deadlock if the runnable
+            // resizes the widget and calls surfaceChanged. See https://github.com/MozillaReality/FirefoxReality/issues/1459.
+            ThreadUtils.postToUiThread(mFirstDrawCallback);
             mFirstDrawCallback = null;
         }
     }


### PR DESCRIPTION
fixes #1459

GeckoView deadlocks if `surfaceChanged` is called within the `onFirstComposite` call, because `surfaceChanged` is synchronous internally.


<img width="994" alt="sync" src="https://user-images.githubusercontent.com/1070794/62288252-43dc1b00-b45c-11e9-990f-c2dd0ff2e1ba.png">
