### PR TITLE
Fix package name when the activities are restarted

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/crashreporting/CrashReporterService.java
@@ -73,6 +73,7 @@ public class CrashReporterService extends JobIntentService {
 
                     if (!otherProcessesFound) {
                         intent.setClass(CrashReporterService.this, VRBrowserActivity.class);
+                        intent.setPackage(BuildConfig.APPLICATION_ID);
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         startActivity(intent);
                         break;

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/SystemUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/SystemUtils.java
@@ -7,17 +7,20 @@ import android.content.Intent;
 
 import androidx.annotation.NonNull;
 
+import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.VRBrowserActivity;
 
 public class SystemUtils {
 
     public static final void restart(@NonNull Context context) {
         Intent i = new Intent(context, VRBrowserActivity.class);
+        i.setPackage(BuildConfig.APPLICATION_ID);
         context.startActivity(i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK));
     }
 
     public static final void scheduleRestart(@NonNull Context context, long delay) {
         Intent i = new Intent(context, VRBrowserActivity.class);
+        i.setPackage(BuildConfig.APPLICATION_ID);
         i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 


### PR DESCRIPTION
Code package name and application package names can be different. Explicitly set the package to avoid launching a different staging/release build.

Fixes #1499