### PR TITLE
Fix JPG skyboxes. Do not require restart to switch to a custom env.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/EnvironmentOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/EnvironmentOptionsView.java
@@ -66,26 +66,28 @@ class EnvironmentOptionsView extends SettingsView {
         mBinding.envOverrideSwitch.setOnCheckedChangeListener(mEnvOverrideListener);
 
         SettingsStore.getInstance(getContext()).setEnvironmentOverrideEnabled(value);
+        mWidgetManager.updateEnvironment();
     }
 
     private OnClickListener mResetListener = (view) -> {
-        boolean restart = false;
+        boolean updated = false;
         if (mBinding.envOverrideSwitch.isChecked() != SettingsStore.ENV_OVERRIDE_DEFAULT) {
             setEnvOverride(SettingsStore.ENV_OVERRIDE_DEFAULT);
-            restart = true;
+            updated = true;
         }
 
         if (!mEnvironmentsRadio.getValueForId(mEnvironmentsRadio.getCheckedRadioButtonId()).equals(SettingsStore.ENV_DEFAULT)) {
             setEnv(mEnvironmentsRadio.getIdForValue(SettingsStore.ENV_DEFAULT), true);
+            updated = true;
         }
 
-        if (restart)
-            showRestartDialog();
+        if (updated) {
+            mWidgetManager.updateEnvironment();
+        }
     };
 
     private SwitchSetting.OnCheckedChangeListener mEnvOverrideListener = (compoundButton, value, doApply) -> {
         setEnvOverride(value);
-        showRestartDialog();
     };
 
     private ImageRadioGroupSetting.OnCheckedChangeListener mEnvsListener = (checkedId, doApply) -> {

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -640,23 +640,8 @@ BrowserWorld::InitializeJava(JNIEnv* aEnv, jobject& aActivity, jobject& aAssetMa
     m.controllers->SetPointerColor(vrb::Color(VRBrowser::GetPointerColor()));
     m.loadingAnimation->LoadModels(m.loader);
     m.rootController->AddNode(m.controllers->GetRoot());
-    std::string skyboxPath = VRBrowser::GetActiveEnvironment();
-    std::string extension;
-    if (VRBrowser::isOverrideEnvPathEnabled()) {
-      std::string storagePath = VRBrowser::GetStorageAbsolutePath(INJECT_SKYBOX_PATH);
-      if (std::ifstream(storagePath)) {
-        skyboxPath = storagePath;
-        extension = Skybox::ValidateCustomSkyboxAndFindFileExtension(storagePath);
-        if (!extension.empty()) {
-          skyboxPath = storagePath;
-          VRB_DEBUG("Found custom skybox file extension: %s", extension.c_str());
-        } else {
-          VRB_ERROR("Failed to find custom skybox files.");
-        }
-      }
-    }
 #if !defined(SNAPDRAGONVR)
-    CreateSkyBox(skyboxPath, extension);
+    UpdateEnvironment();
     // Don't load the env model, we are going for skyboxes in v1.0
 //    CreateFloor();
 #endif
@@ -793,9 +778,24 @@ BrowserWorld::SetTemporaryFilePath(const std::string& aPath) {
 void
 BrowserWorld::UpdateEnvironment() {
   ASSERT_ON_RENDER_THREAD();
-  std::string env = VRBrowser::GetActiveEnvironment();
-  VRB_LOG("Setting environment: %s", env.c_str());
-  CreateSkyBox(env, "");
+  std::string skyboxPath = VRBrowser::GetActiveEnvironment();
+  std::string extension;
+  if (VRBrowser::isOverrideEnvPathEnabled()) {
+    std::string storagePath = VRBrowser::GetStorageAbsolutePath(INJECT_SKYBOX_PATH);
+    if (std::ifstream(storagePath)) {
+      skyboxPath = storagePath;
+      extension = Skybox::ValidateCustomSkyboxAndFindFileExtension(storagePath);
+      if (!extension.empty()) {
+        skyboxPath = storagePath;
+        VRB_DEBUG("Found custom skybox file extension: %s", extension.c_str());
+      } else {
+        VRB_ERROR("Failed to find custom skybox files.");
+      }
+    }
+  }
+
+  VRB_LOG("Setting environment: %s", skyboxPath.c_str());
+  CreateSkyBox(skyboxPath, extension);
 }
 
 void
@@ -1320,14 +1320,14 @@ BrowserWorld::CreateSkyBox(const std::string& aBasePath, const std::string& aExt
   ASSERT_ON_RENDER_THREAD();
   const bool empty = aBasePath == "cubemap/void";
   const std::string extension = aExtension.empty() ? ".ktx" : aExtension;
-  const GLenum glFormat = extension == ".ktx" ? GL_COMPRESSED_RGB8_ETC2 : GL_RGB8;
+  const GLenum glFormat = extension == ".ktx" ? GL_COMPRESSED_RGB8_ETC2 : GL_RGBA8;
   const int32_t size = 1024;
   if (m.skybox && empty) {
     m.skybox->SetVisible(false);
     return;
   } else if (m.skybox) {
     m.skybox->SetVisible(true);
-    if (m.skybox->GetLayer() && m.skybox->GetLayer()->GetWidth() != size) {
+    if (m.skybox->GetLayer() && (m.skybox->GetLayer()->GetWidth() != size || m.skybox->GetLayer()->GetFormat() != glFormat)) {
       VRLayerCubePtr oldLayer = m.skybox->GetLayer();
       VRLayerCubePtr newLayer = m.device->CreateLayerCube(size, size, glFormat);
       m.skybox->SetLayer(newLayer);

--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -372,19 +372,22 @@ struct VRLayerCube::State: public VRLayer::State {
   int32_t height;
   bool loaded;
   uint32_t textureHandle;
+  GLuint  glFormat;
   State():
       width(0),
       height(0),
       loaded(false),
-      textureHandle(0)
+      textureHandle(0),
+      glFormat(GL_RGBA8)
   {}
 };
 
 VRLayerCubePtr
-VRLayerCube::Create(const int32_t aWidth, const int32_t aHeight) {
+VRLayerCube::Create(const int32_t aWidth, const int32_t aHeight, const GLuint aGLFormat) {
   auto result = std::make_shared<vrb::ConcreteClass<VRLayerCube, VRLayerCube::State>>();
   result->m.width = aWidth;
   result->m.height = aHeight;
+  result->m.glFormat = aGLFormat;
   return result;
 }
 
@@ -411,6 +414,11 @@ VRLayerCube::GetTextureHandle() const {
 void
 VRLayerCube::SetTextureHandle(uint32_t aTextureHandle){
   m.textureHandle = aTextureHandle;
+}
+
+GLuint
+VRLayerCube::GetFormat() const {
+  return m.glFormat;
 }
 
 void

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -150,12 +150,13 @@ typedef std::shared_ptr<VRLayerCube> VRLayerCubePtr;
 
 class VRLayerCube: public VRLayer {
 public:
-  static VRLayerCubePtr Create(const int32_t aWidth, const int32_t aHeight);
+  static VRLayerCubePtr Create(const int32_t aWidth, const int32_t aHeight, const GLuint aGLFormat);
 
   int32_t GetWidth() const;
   int32_t GetHeight() const;
   GLuint GetTextureHandle() const;
   bool IsLoaded() const;
+  GLuint GetFormat() const;
 
   void SetTextureHandle(uint32_t aTextureHandle);
   void SetLoaded(bool aReady);

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -1556,7 +1556,7 @@ DeviceDelegateOculusVR::CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint a
   if (m.cubeLayer) {
     m.cubeLayer->Destroy();
   }
-  VRLayerCubePtr layer = VRLayerCube::Create(aWidth, aHeight);
+  VRLayerCubePtr layer = VRLayerCube::Create(aWidth, aHeight, aInternalFormat);
   m.cubeLayer = OculusLayerCube::Create(layer, aInternalFormat);
   if (m.ovr) {
     vrb::RenderContextPtr context = m.context.lock();


### PR DESCRIPTION
Fixes #1493

Also makes it possible to switch between stock and custom environments without a restart, even if they have different formats.