### PR TITLE
Improve widgets depth sorting

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/BrightnessMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/BrightnessMenuWidget.java
@@ -23,7 +23,7 @@ public class BrightnessMenuWidget extends MenuWidget {
         aPlacement.anchorX = 0.0f;
         aPlacement.anchorY = 0.0f;
         aPlacement.translationY = WidgetPlacement.dpDimension(getContext(), R.dimen.video_projection_menu_translation_y);
-        aPlacement.translationZ = 30.0f;
+        aPlacement.translationZ = 2.0f;
     }
 
     public void setParentWidget(UIWidget aParent) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/VideoProjectionMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/VideoProjectionMenuWidget.java
@@ -46,7 +46,7 @@ public class VideoProjectionMenuWidget extends MenuWidget {
         aPlacement.anchorX = 0.0f;
         aPlacement.anchorY = 0.0f;
         aPlacement.translationY = WidgetPlacement.dpDimension(getContext(), R.dimen.video_projection_menu_translation_y);
-        aPlacement.translationZ = 30.0f;
+        aPlacement.translationZ = 2.0f;
     }
 
     public void setParentWidget(UIWidget aParent) {

--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -72,7 +72,7 @@ protected:
   void DrawLoadingAnimation();
   void DrawSplashAnimation();
   void CreateSkyBox(const std::string& aBasePath, const std::string& aExtension);
-  float DistanceToPlane(const vrb::NodePtr& aNode, const vrb::Vector& aPosition, const vrb::Vector& aDirection) const;
+  float ComputeNormalizedZ(const vrb::NodePtr& aNode) const;
 private:
   State& m;
   BrowserWorld() = delete;


### PR DESCRIPTION
Fixes #1468. Also fixes other visual glitches in multiwindow (keyboard dissapearing on a side window depending on the position of your head).

Oculus layers don't support a depth buffer so we have to sort them manually. 