### PR TITLE
Update top bars when entering exiting private mode

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -373,6 +373,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, GeckoSessio
         } else {
             focusWindow(getFrontWindow());
         }
+        updateTopBars();
         mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
     }
 
@@ -389,6 +390,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, GeckoSessio
             setWindowVisible(window, false);
         }
         focusWindow(getFrontWindow());
+        updateTopBars();
         mWidgetManager.popWorldBrightness(this);
     }
 


### PR DESCRIPTION
Fixes #1545 Fixes the crash in Telemetry buy updating the top bar widget when entering/exiting the private mode.