### PR TITLE
Fixes not updating the private browsing mode tooltip

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -305,13 +305,13 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Bookm
                 if (isPrivateMode) {
                     mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
                     mPrivateButton.setImageResource(R.drawable.ic_icon_tray_private_browsing_on_v2);
-                mPrivateButton.setTooltip(getResources().getString(R.string.private_browsing_exit_tooltip));
+                    mPrivateButton.setTooltip(getResources().getString(R.string.private_browsing_exit_tooltip));
 
                 } else {
                     mWidgetManager.popWorldBrightness(this);
                     mPrivateButton.setImageResource(R.drawable.ic_icon_tray_private_browsing_v2);
+                    mPrivateButton.setTooltip(getResources().getString(R.string.private_browsing_enter_tooltip));
                 }
-                mPrivateButton.setTooltip(getResources().getString(R.string.private_browsing_enter_tooltip));
             }
 
             mIsLastSessionPrivate = isPrivateMode;


### PR DESCRIPTION
Fixes #1538 This looks very much like something that got broken during the multiple multi-window rebases.