### PR TITLE
Fixes the permission dialog showing in front of the creator window

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
@@ -64,10 +64,10 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
     public void handlePermission(final String aUri, final PermissionWidget.PermissionType aType, final Callback aCallback) {
         if (mPermissionWidget == null) {
             mPermissionWidget = new PermissionWidget(mContext);
-            mPermissionWidget.getPlacement().parentHandle = mParentWidgetHandle;
             mWidgetManager.addWidget(mPermissionWidget);
         }
 
+        mPermissionWidget.getPlacement().parentHandle = mParentWidgetHandle;
         mPermissionWidget.showPrompt(aUri, aType, aCallback);
     }
 


### PR DESCRIPTION
Fixes #1547 The parent handle from the widget was not being assigned before showing the widget and it was always using the one from the window that first created it.