### PR TITLE
Fixes sessions restore crashes when the session is null

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -930,7 +930,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             if (mPoorPerformanceWhiteList.contains(originalUrl)) {
                 return;
             }
-            window.getSessionStack().loadUri("about:blank");
+            window.getSessionStack().loadHomePage();
             final String[] buttons = {getString(R.string.ok_button), getString(R.string.performance_unblock_page)};
             window.showButtonPrompt(getString(R.string.performance_title), getString(R.string.performance_message), buttons, new ConfirmPromptWidget.ConfirmPromptDelegate() {
                 @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStack.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStack.java
@@ -54,7 +54,8 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
     private static final String LOGTAG = "VRB";
 
     // You can test a local file using: "resource://android/assets/webvr/index.html"
-    public static final String PRIVATE_BROWSING_URI = "about:privatebrowsing";
+    private static final String PRIVATE_BROWSING_URI = "about:privatebrowsing";
+    private static final String BLANK_BROWSING_URI = "about:blank";
     public static final int NO_SESSION = -1;
 
     private transient LinkedList<GeckoSession.NavigationDelegate> mNavigationListeners;
@@ -310,6 +311,10 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
 
             if (mUsePrivateMode) {
                 loadPrivateBrowsingPage();
+
+            } else if(state.mSessionState == null || state.mUri.equals(BLANK_BROWSING_URI) ||
+                    (state.mSessionState != null && state.mSessionState.size() == 0)) {
+                loadHomePage();
             }
 
             dumpAllState(state.mSession);
@@ -635,6 +640,14 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
         }
         Log.d(LOGTAG, "Loading URI: " + aUri);
         mCurrentSession.loadUri(aUri);
+    }
+
+    public void loadHomePage() {
+        if (mCurrentSession == null) {
+            return;
+        }
+
+        mCurrentSession.loadUri(getHomeUri());
     }
 
     public void loadPrivateBrowsingPage() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
@@ -17,7 +17,7 @@ import org.mozilla.vrbrowser.browser.Media;
 import java.io.IOException;
 import java.util.ArrayList;
 
-@JsonAdapter(SessionState.SafeTypeAdapterFactory.class)
+@JsonAdapter(SessionState.SessionStateAdapterFactory.class)
 public class SessionState {
 
     public boolean mCanGoBack;
@@ -53,7 +53,7 @@ public class SessionState {
         }
     }
 
-    public class SafeTypeAdapterFactory implements TypeAdapterFactory {
+    public class SessionStateAdapterFactory implements TypeAdapterFactory {
         public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
             final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
             final TypeAdapter<GeckoSession.SessionState> gsDelegate = new GeckoSessionStateAdapter();
@@ -77,7 +77,12 @@ public class SessionState {
                                 out.name("mSessionState").jsonValue(null);
 
                             } else {
-                                out.name("mSessionState").jsonValue(gsDelegate.toJson(session.mSessionState));
+                                if (session.mSessionState != null) {
+                                    out.name("mSessionState").jsonValue(gsDelegate.toJson(session.mSessionState));
+
+                                } else {
+                                    out.name("mSessionState").jsonValue(null);
+                                }
                             }
                             out.endObject();
 


### PR DESCRIPTION
Fixes #1597 Handle the cases where the GeckoSession state could be null or could be not fully created. This will help to persist correctly and load the home page in a new session in those cases.