### PR TITLE
Bump GV to 70.0.20190821095414

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "70.0.20190816094815"
+versions.gecko_view = "70.0.20190821095414"
 versions.android_components = "4.0.0"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"


### PR DESCRIPTION
Includes https://bugzilla.mozilla.org/show_bug.cgi?id=1574996

Fixes #1543 and #1559