### PR TITLE
Show the correct string for the Russian keyboard

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/RussianKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/RussianKeyboard.java
@@ -53,7 +53,7 @@ public class RussianKeyboard extends BaseKeyboard {
 
     @Override
     public String getKeyboardTitle() {
-        return StringUtils.getStringByLocale(mContext, R.string.settings_language_italian, getLocale());
+        return StringUtils.getStringByLocale(mContext, R.string.settings_language_russian, getLocale());
     }
 
     @Override


### PR DESCRIPTION
Show the correct string for the Russian keyboard, we were currently showing "Italian"