### PR TITLE
Fix TitleBarWidget leak. Reduce TitleBarWidget texture.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -79,8 +79,11 @@ public class TitleBarWidget extends UIWidget  {
 
     @Override
     protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
-        aPlacement.width = WidgetPlacement.dpDimension(getContext(), R.dimen.navigation_bar_width);
-        aPlacement.worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width);
+        aPlacement.width = WidgetPlacement.dpDimension(getContext(), R.dimen.title_bar_width);
+        float ratio = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) /
+                      WidgetPlacement.dpDimension(getContext(), R.dimen.navigation_bar_width);
+
+        aPlacement.worldWidth = aPlacement.width * ratio;
         aPlacement.height = WidgetPlacement.dpDimension(getContext(), R.dimen.navigation_bar_height);
         aPlacement.anchorX = 0.5f;
         aPlacement.anchorY = 1.0f;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -238,11 +238,13 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (leftWindow == aWindow) {
             removeWindow(leftWindow);
             if (mFocusedWindow == leftWindow) {
+                mFocusedWindow = null;
                 focusWindow(frontWindow);
             }
         } else if (rightWindow == aWindow) {
             removeWindow(rightWindow);
             if (mFocusedWindow == rightWindow) {
+                mFocusedWindow = null;
                 focusWindow(frontWindow);
             }
         } else if (frontWindow == aWindow) {
@@ -254,6 +256,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             }
 
             if (mFocusedWindow == frontWindow && !getCurrentWindows().isEmpty()) {
+                mFocusedWindow = null;
                 focusWindow(getFrontWindow());
             }
 

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -18,6 +18,9 @@
     <dimen name="url_bar_item_width">28dp</dimen>
     <dimen name="url_bar_last_item_width">36dp</dimen>
 
+    <!-- Title bar -->
+    <dimen name="title_bar_width">300dp</dimen>
+
     <!-- Keyboard -->
     <item name="keyboard_world_width" format="float" type="dimen">3.25</item>
     <item name="keyboard_x" format="float" type="dimen">-0.15</item>


### PR DESCRIPTION
Fixes #1653.

Also makes the surface for the TitleBar smaller because it was using much more width than needed:

![screen](https://user-images.githubusercontent.com/1070794/63683855-ca85dd00-c7fb-11e9-8af7-8b27b3358fe3.png)
