### PR TITLE
Do not make multi-windows visible if there is only one window

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -720,7 +720,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
     public void exitResizeMode() {
         for (WindowWidget window : getCurrentWindows()) {
-            window.getTopBar().setVisible(true);
+            if (getCurrentWindows().size() > 1) {
+                window.getTopBar().setVisible(true);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1633 Do not make multi-windows visible if there is only one window