### PR TITLE
Fix resize border z-fighting  on non-Oculus devices

### DIFF
--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -30,6 +30,9 @@ typedef std::shared_ptr<Quad> QuadPtr;
 class Widget;
 typedef std::shared_ptr<Widget> WidgetPtr;
 
+class WidgetResizer;
+typedef std::shared_ptr<WidgetResizer> WidgetResizerPtr;
+
 class WidgetPlacement;
 typedef std::shared_ptr<WidgetPlacement> WidgetPlacementPtr;
 
@@ -66,7 +69,7 @@ public:
   vrb::TransformPtr GetTransformNode() const;
   const WidgetPlacementPtr& GetPlacement() const;
   void SetPlacement(const WidgetPlacementPtr& aPlacement);
-  void StartResize(const vrb::Vector& aMaxSize,  const vrb::Vector& aMinSize);
+  WidgetResizerPtr StartResize(const vrb::Vector& aMaxSize,  const vrb::Vector& aMinSize);
   void FinishResize();
   bool IsResizing() const;
   bool IsResizingActive() const;

--- a/app/src/main/cpp/WidgetResizer.cpp
+++ b/app/src/main/cpp/WidgetResizer.cpp
@@ -14,6 +14,7 @@
 #include "vrb/Color.h"
 #include "vrb/CreationContext.h"
 #include "vrb/Matrix.h"
+#include "vrb/GLError.h"
 #include "vrb/Geometry.h"
 #include "vrb/RenderState.h"
 #include "vrb/SurfaceTextureFactory.h"
@@ -255,6 +256,7 @@ struct WidgetResizer::State {
   vrb::Vector minSize;
   bool resizing;
   vrb::TogglePtr root;
+  vrb::TransformPtr transform;
   std::vector<ResizeHandlePtr> resizeHandles;
   std::vector<ResizeBarPtr> resizeBars;
   ResizeHandlePtr activeHandle;
@@ -272,6 +274,8 @@ struct WidgetResizer::State {
       return;
     }
     root = vrb::Toggle::Create(create);
+    transform = vrb::Transform::Create(create);
+    root->AddNode(transform);
     currentMin = min;
     currentMax = max;
     maxSize = kDefaultMaxResize;
@@ -313,7 +317,7 @@ struct WidgetResizer::State {
     }
     ResizeBarPtr result = ResizeBar::Create(create, aCenter, aScale, aBorder, aMode);
     resizeBars.push_back(result);
-    root->AddNode(result->border->GetTransformNode());
+    transform->AddNode(result->border->GetTransformNode());
     return result;
   }
 
@@ -325,7 +329,7 @@ struct WidgetResizer::State {
     ResizeHandlePtr result = ResizeHandle::Create(create, aCenter, aResizeMode, aBars);
     result->touchRatio = aTouchRatio;
     resizeHandles.push_back(result);
-    root->InsertNode(result->root, 0);
+    transform->InsertNode(result->root, 0);
     return result;
   }
 
@@ -629,6 +633,15 @@ WidgetResizer::IsActive() const {
   return m.activeHandle && m.activeHandle->resizeState == ResizeState::Active;
 }
 
+void
+WidgetResizer::SetTransform(const vrb::Matrix &aTransform){
+  m.transform->SetTransform(aTransform);
+}
+
+Widget*
+WidgetResizer::GetWidget() const {
+  return m.widget;
+}
 
 WidgetResizer::WidgetResizer(State& aState, vrb::CreationContextPtr& aContext) : m(aState) {
   m.context = aContext;

--- a/app/src/main/cpp/WidgetResizer.h
+++ b/app/src/main/cpp/WidgetResizer.h
@@ -22,7 +22,7 @@ typedef std::shared_ptr<WidgetResizer> WidgetResizerPtr;
 
 class WidgetResizer {
 public:
-  static WidgetResizerPtr Create(vrb::CreationContextPtr& aContext, Widget * aWidget);
+  static WidgetResizerPtr Create(vrb::CreationContextPtr& aContext, Widget* aWidget);
   vrb::NodePtr GetRoot() const;
   void SetSize(const vrb::Vector& aMin, const vrb::Vector& aMax);
   void SetResizeLimits(const vrb::Vector& aMaxSize, const vrb::Vector& aMinSize);
@@ -33,6 +33,8 @@ public:
   const vrb::Vector& GetResizeMin() const;
   const vrb::Vector& GetResizeMax() const;
   bool IsActive() const;
+  Widget* GetWidget() const;
+  void SetTransform(const vrb::Matrix& aTransform);
 protected:
   struct State;
   WidgetResizer(State& aState, vrb::CreationContextPtr& aContext);


### PR DESCRIPTION
Fixes #1682

This required more work than I initially thought of. Currently we are doing the depth sorting on a Widget level and not recursively, that's why adding more z to the resize local transform didn't fix the issue. I also tried to enable depth write on that node but transparency and depth testing are not very good friends. It worked but with pretty bad quality (We are using transparency in borders specially on non-Oculus devices).

So I moved the resizer to the parent container so that depth testing is done separately. For the future we can implement the correct depth sorting on a vrb level.