### PR TITLE
Allow multiple listeners for media state updates

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
@@ -1,11 +1,11 @@
 package org.mozilla.vrbrowser.browser;
 
+import androidx.annotation.NonNull;
+
 import org.mozilla.geckoview.MediaElement;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import java.util.ArrayList;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class Media implements MediaElement.Delegate {
     private static final String LOGTAG = "VRB";
@@ -19,8 +19,8 @@ public class Media implements MediaElement.Delegate {
     private double mVolume = 1.0f;
     private boolean mIsMuted = false;
     private boolean mIsUnloaded = false;
-    private org.mozilla.geckoview.MediaElement mMedia;
-    private ArrayList<MediaElement.Delegate> mMediaListeners;
+    private MediaElement mMedia;
+    private CopyOnWriteArrayList<MediaElement.Delegate> mMediaListeners;
     private ResizeDelegate mResizeDelegate;
 
     public Media(@NonNull MediaElement aMediaElement) {
@@ -29,11 +29,11 @@ public class Media implements MediaElement.Delegate {
         aMediaElement.setDelegate(this);
     }
 
-    public void addNavigationListener(MediaElement.Delegate aListener) {
+    public void addMediaListener(MediaElement.Delegate aListener) {
         mMediaListeners.add(aListener);
     }
 
-    public void removeNavigationListener(MediaElement.Delegate aListener) {
+    public void removeMediaListener(MediaElement.Delegate aListener) {
         mMediaListeners.remove(aListener);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
@@ -4,7 +4,6 @@ import androidx.annotation.NonNull;
 
 import org.mozilla.geckoview.MediaElement;
 
-import java.util.ArrayList;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class Media implements MediaElement.Delegate {
@@ -25,7 +24,7 @@ public class Media implements MediaElement.Delegate {
 
     public Media(@NonNull MediaElement aMediaElement) {
         mMedia = aMediaElement;
-        mMediaListeners = new ArrayList<>();
+        mMediaListeners = new CopyOnWriteArrayList<>();
         aMediaElement.setDelegate(this);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
@@ -244,7 +244,7 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             return;
         }
         if (mMedia != null) {
-            mMedia.setDelegate(null);
+            mMedia.removeNavigationListener(this);
         }
         mMedia = aMedia;
         boolean enabled = mMedia != null;
@@ -266,7 +266,7 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             onPlaybackStateChange(mMedia.getMediaElement(), MediaElement.MEDIA_STATE_PLAY);
         }
 
-        mMedia.setDelegate(this);
+        mMedia.addNavigationListener(this);
     }
 
     public void setProjectionSelectorEnabled(boolean aEnabled) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
@@ -244,7 +244,7 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             return;
         }
         if (mMedia != null) {
-            mMedia.removeNavigationListener(this);
+            mMedia.removeMediaListener(this);
         }
         mMedia = aMedia;
         boolean enabled = mMedia != null;
@@ -266,7 +266,7 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             onPlaybackStateChange(mMedia.getMediaElement(), MediaElement.MEDIA_STATE_PLAY);
         }
 
-        mMedia.addNavigationListener(this);
+        mMedia.addMediaListener(this);
     }
 
     public void setProjectionSelectorEnabled(boolean aEnabled) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -181,7 +181,8 @@ public class TitleBarWidget extends UIWidget {
             mMedia = mAttachedWindow.getSessionStack().getFullScreenVideo();
             if (mMedia != null) {
                 mBinding.setIsMediaPlaying(mMedia.isPlaying());
-                mMedia.setDelegate(mMediaDelegate);
+                mMedia.removeNavigationListener(mMediaDelegate);
+                mMedia.addNavigationListener(mMediaDelegate);
             }
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -181,8 +181,8 @@ public class TitleBarWidget extends UIWidget {
             mMedia = mAttachedWindow.getSessionStack().getFullScreenVideo();
             if (mMedia != null) {
                 mBinding.setIsMediaPlaying(mMedia.isPlaying());
-                mMedia.removeNavigationListener(mMediaDelegate);
-                mMedia.addNavigationListener(mMediaDelegate);
+                mMedia.removeMediaListener(mMediaDelegate);
+                mMedia.addMediaListener(mMediaDelegate);
             }
         }
     }


### PR DESCRIPTION
Fixes #1674 Title bar was not getting media updates when the media controls took over the delegate. Allow multiple listeners for media state updates