### PR TITLE
Fix tray position when exiting from fullscreen in regular and VR Videos

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -492,6 +492,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     private void exitFullScreenMode() {
         if (!mIsInFullScreenMode) {
+            mWidgetManager.setTrayVisible(true);
             return;
         }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -392,6 +392,9 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Windo
         if (mTrayVisible != aVisible) {
             mTrayVisible = aVisible;
             updateVisibility();
+
+        } else {
+            mWidgetManager.updateWidget(this);
         }
     }
 


### PR DESCRIPTION
Fixes #1730 Fix tray position when exiting from fullscreen in regular and VR Videos