### PR TITLE
Do not show the multi-window controls if the window is in theatre mode.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -751,7 +751,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     public void exitResizeMode() {
         for (WindowWidget window : getCurrentWindows()) {
             if (getCurrentWindows().size() > 1 || isInPrivateMode()) {
-                window.getTopBar().setVisible(true);
+                window.getTopBar().setVisible(window != mFullscreenWindow);
             }
         }
     }


### PR DESCRIPTION
Fixes #1738 This fixes the multi-window controls being displayed if opening the resize controls while in theatre mode.