### PR TITLE
Hide the context menu when the window loses focus

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -551,6 +551,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             updateTitleBar();
         }
 
+        if (mContextMenu != null) {
+            mContextMenu.hide(REMOVE_WIDGET);
+        }
+
         TelemetryWrapper.activePlacementEvent(mWindowPlacement.getValue(), mActive);
         updateBorder();
     }


### PR DESCRIPTION
Fixes #1713 Hide the context when the window loses focus