### PR TITLE
Hide context menu when the action is canceled

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BookmarkAdapter.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BookmarkAdapter.java
@@ -140,6 +140,10 @@ public class BookmarkAdapter extends RecyclerView.Adapter<BookmarkAdapter.Bookma
                 case MotionEvent.ACTION_DOWN:
                     binding.setIsHovered(true);
                     return false;
+
+                case MotionEvent.ACTION_CANCEL:
+                    binding.setIsHovered(false);
+                    return false;
             }
             return false;
         });

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/HistoryAdapter.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/HistoryAdapter.java
@@ -140,6 +140,10 @@ public class HistoryAdapter extends RecyclerView.Adapter<HistoryAdapter.HistoryI
                 case MotionEvent.ACTION_DOWN:
                     binding.setIsHovered(true);
                     return false;
+
+                case MotionEvent.ACTION_CANCEL:
+                    binding.setIsHovered(false);
+                    return false;
             }
             return false;
         });


### PR DESCRIPTION
Fixes #1695 Hide the context buttons when the motion event moves outside the view.