### PR TITLE
Fix Oculus layers array stack overflow

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -487,11 +487,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         } else {
             mPrivateWindowPlacement = WindowPlacement.FRONT;
         }
-        for (WindowWidget window: mRegularWindows) {
-            setWindowVisible(window, true);
-        }
         for (WindowWidget window: mPrivateWindows) {
             setWindowVisible(window, false);
+        }
+        for (WindowWidget window: mRegularWindows) {
+            setWindowVisible(window, true);
         }
         focusWindow(getWindowWithPlacement(mRegularWindowPlacement));
         updateViews();

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -1454,7 +1454,7 @@ DeviceDelegateOculusVR::EndFrame(const bool aDiscard) {
 
   // Draw back layers
   for (const OculusLayerPtr& layer: m.uiLayers) {
-    if (!layer->GetDrawInFront() && layer->IsDrawRequested() && layerCount < ovrMaxLayerCount) {
+    if (!layer->GetDrawInFront() && layer->IsDrawRequested() && (layerCount < ovrMaxLayerCount - 1)) {
       layer->Update(m.predictedTracking);
       layers[layerCount++] = layer->Header();
       layer->ClearRequestDraw();


### PR DESCRIPTION
Fixes #1705.

We have a array stack overflow possibility when filling the layers array. The main eye buffer is always added after the UI layers, so we need to check `ovrMaxLayerCount - 1` instead of `ovrMaxLayerCount` for UI layers.

I also changed the regular/private switch to hide windows first to make it harder to hit max layers threshold.