### PR TITLE
Add name property to WidgetPlacement

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
@@ -71,6 +71,7 @@ public abstract class UIWidget extends FrameLayout implements Widget {
         mBorderWidth = SettingsStore.getInstance(getContext()).getTransparentBorderWidth();
         mWidgetManager = (WidgetManagerDelegate) getContext();
         mWidgetPlacement = new WidgetPlacement(getContext());
+        mWidgetPlacement.name = getClass().getSimpleName();
         mHandle = mWidgetManager.newWidgetHandle();
         mWorldWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.world_width);
         initializeWidgetPlacement(mWidgetPlacement);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
@@ -51,6 +51,7 @@ public class WidgetPlacement {
     // Widget will be curved if enabled.
     public boolean cylinder = true;
     public int borderColor = 0;
+    public String name;
     /*
      * Flat surface placements are automatically mapped to curved coordinates.
      * If a radius is set it's used for the automatic mapping of the yaw & angle when the
@@ -92,6 +93,7 @@ public class WidgetPlacement {
         this.cylinder = w.cylinder;
         this.cylinderMapRadius = w.cylinderMapRadius;
         this.borderColor = w.borderColor;
+        this.name = w.name;
     }
 
     public int textureWidth() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -194,6 +194,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         aPlacement.visible = true;
         aPlacement.cylinder = true;
         aPlacement.textureScale = 1.0f;
+        aPlacement.name = "Window";
         // Check Windows.placeWindow method for remaining placement set-up
     }
 

--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -26,6 +26,7 @@ struct VRLayer::State {
   device::EyeRect textureRect[2];
   SurfaceChangedDelegate surfaceChangedDelegate;
   std::function<void()> pendingEvent;
+  std::string name;
   State():
       initialized(false),
       priority(0),
@@ -92,6 +93,11 @@ VRLayer::GetTextureRect(crow::device::Eye aEye) const {
 bool
 VRLayer::GetDrawInFront() const {
   return m.drawInFront;
+}
+
+std::string
+VRLayer::GetName() const {
+  return m.name;
 }
 
 bool
@@ -175,6 +181,11 @@ VRLayer::SetSurfaceChangedDelegate(const crow::VRLayer::SurfaceChangedDelegate &
 void
 VRLayer::SetDrawInFront(bool aDrawInFront) {
   m.drawInFront = aDrawInFront;
+}
+
+void
+VRLayer::SetName(const std::string &aName) {
+  m.name = aName;
 }
 
 void VRLayer::NotifySurfaceChanged(SurfaceChange aChange, const std::function<void()>& aFirstCompositeCallback) {

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -47,6 +47,7 @@ public:
   const vrb::Color& GetTintColor() const;
   const device::EyeRect& GetTextureRect(device::Eye aEye) const;
   bool GetDrawInFront() const;
+  std::string GetName() const;
 
   bool ShouldDrawBefore(const VRLayer& aLayer);
   void SetInitialized(bool aInitialized);
@@ -60,6 +61,7 @@ public:
   void SetTextureRect(device::Eye aEye, const device::EyeRect& aTextureRect);
   void SetSurfaceChangedDelegate(const SurfaceChangedDelegate& aDelegate);
   void SetDrawInFront(bool aDrawInFront);
+  void SetName(const std::string& aName);
   void NotifySurfaceChanged(SurfaceChange aChange, const std::function<void()>& aFirstCompositeCallback);
 protected:
   struct State;

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -449,6 +449,9 @@ Widget::SetPlacement(const WidgetPlacementPtr& aPlacement) {
   if (m.cylinder) {
     m.UpdateCylinderMatrix();
   }
+  if (GetLayer()) {
+    GetLayer()->SetName(aPlacement->name);
+  }
 }
 
 WidgetResizerPtr

--- a/app/src/main/cpp/WidgetPlacement.cpp
+++ b/app/src/main/cpp/WidgetPlacement.cpp
@@ -34,6 +34,17 @@ WidgetPlacement::FromJava(JNIEnv* aEnv, jobject& aObject) {
   result->name = aEnv->GetBooleanField(aObject, f); \
 }
 
+#define GET_STRING_FIELD(name) { \
+  jfieldID f = aEnv->GetFieldID(clazz, #name, "Ljava/lang/String;"); \
+  jstring javaString = (jstring)aEnv->GetObjectField(aObject, f); \
+  if (javaString) { \
+    const char* nativeString = aEnv->GetStringUTFChars(javaString, 0); \
+    result->name = nativeString; \
+    aEnv->ReleaseStringUTFChars(javaString, nativeString); \
+  } \
+}
+
+
   GET_INT_FIELD(width);
   GET_INT_FIELD(height);
   GET_FLOAT_FIELD(anchor.x(), "anchorX");
@@ -60,6 +71,7 @@ WidgetPlacement::FromJava(JNIEnv* aEnv, jobject& aObject) {
   GET_BOOLEAN_FIELD(cylinder);
   GET_FLOAT_FIELD(cylinderMapRadius, "cylinderMapRadius");
   GET_INT_FIELD(borderColor);
+  GET_STRING_FIELD(name);
 
   return result;
 }

--- a/app/src/main/cpp/WidgetPlacement.h
+++ b/app/src/main/cpp/WidgetPlacement.h
@@ -36,6 +36,7 @@ struct WidgetPlacement {
   bool cylinder;
   float cylinderMapRadius;
   int borderColor;
+  std::string name;
 
   int32_t GetTextureWidth() const;
   int32_t GetTextureHeight() const;


### PR DESCRIPTION
It's useful to have some name when debugging actual rendered widgets in native.

Note: this is not required for 1.4. 