### PR TITLE
Fix item not being set before the menu measure is called

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BookmarkAdapter.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BookmarkAdapter.java
@@ -104,7 +104,7 @@ public class BookmarkAdapter extends RecyclerView.Adapter<BookmarkAdapter.Bookma
 
     public int getItemPosition(String id) {
         for (int position=0; position<mBookmarkList.size(); position++)
-            if (mBookmarkList.get(position).getGuid() == id)
+            if (mBookmarkList.get(position).getGuid().equalsIgnoreCase(id))
                 return position;
         return 0;
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -5,6 +5,7 @@
 
 package org.mozilla.vrbrowser.ui.views;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -53,6 +54,7 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
         initialize(aContext);
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private void initialize(Context aContext) {
         mAudio = AudioEngine.fromContext(aContext);
 
@@ -115,7 +117,8 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
             boolean isLastVisibleItem = false;
             if (mBinding.bookmarksList.getLayoutManager() instanceof LinearLayoutManager) {
                 LinearLayoutManager layoutManager = (LinearLayoutManager) mBinding.bookmarksList.getLayoutManager();
-                if (rowPosition == layoutManager.findLastVisibleItemPosition()) {
+                int lastVisibleItem = layoutManager.findLastCompletelyVisibleItemPosition();
+                if (rowPosition == layoutManager.findLastVisibleItemPosition() && rowPosition != lastVisibleItem) {
                     isLastVisibleItem = true;
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -121,7 +121,8 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
             boolean isLastVisibleItem = false;
             if (mBinding.historyList.getLayoutManager() instanceof LinearLayoutManager) {
                 LinearLayoutManager layoutManager = (LinearLayoutManager) mBinding.historyList.getLayoutManager();
-                if (rowPosition == layoutManager.findLastVisibleItemPosition()) {
+                int lastVisibleItem = layoutManager.findLastCompletelyVisibleItemPosition();
+                if (rowPosition == layoutManager.findLastVisibleItemPosition() && rowPosition != lastVisibleItem) {
                     isLastVisibleItem = true;
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/LibraryItemContextMenu.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/LibraryItemContextMenu.java
@@ -79,8 +79,8 @@ public class LibraryItemContextMenu extends FrameLayout {
     }
 
     public void setItem(@NonNull LibraryContextMenuItem item) {
+        mBinding.setItem(item);
         SessionStore.get().getBookmarkStore().isBookmarked(item.getUrl()).thenAccept((isBookmarked -> {
-            mBinding.setItem(item);
             mBinding.setIsBookmarked(isBookmarked);
             mBinding.bookmark.setText(isBookmarked ? R.string.history_context_remove_bookmarks : R.string.history_context_add_bookmarks);
             invalidate();
@@ -96,6 +96,10 @@ public class LibraryItemContextMenu extends FrameLayout {
     }
 
     public int getMenuHeight() {
+        if (mBinding.getItem() == null) {
+            throw new IllegalStateException("setItem must be called before getMenuHeight");
+
+        }
         switch (mBinding.getItem().getType()) {
             case BOOKMARKS:
                 mBinding.bookmarkLayout.setVisibility(GONE);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1148,6 +1148,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         offsetDescendantRectToMyCoords(view, offsetViewBounds);
 
         mLibraryItemContextMenu = new LibraryItemContextMenuWidget(getContext());
+        mLibraryItemContextMenu.setItem(item);
         mLibraryItemContextMenu.mWidgetPlacement.parentHandle = getHandle();
 
         PointF position;
@@ -1165,7 +1166,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
 
         mLibraryItemContextMenu.setPosition(position);
-        mLibraryItemContextMenu.setItem(item);
         mLibraryItemContextMenu.setHistoryContextMenuItemCallback((new LibraryItemContextMenuClickCallback() {
             @Override
             public void onOpenInNewWindowClick(LibraryItemContextMenu.LibraryContextMenuItem item) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/LibraryItemContextMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/LibraryItemContextMenuWidget.java
@@ -26,7 +26,6 @@ public class LibraryItemContextMenuWidget extends UIWidget implements WidgetMana
     private LibraryItemContextMenu mContextMenu;
     private int mMaxHeight;
     private PointF mTranslation;
-    private int height;
 
     public LibraryItemContextMenuWidget(Context aContext) {
         super(aContext);


### PR DESCRIPTION
Fixes #1756 Fix item not being set before the menu measure is called. Also improved context menu positioning for last rows so the menu doesn't fall outside the library view.