### PR TITLE
Restore window size/position if the app is exited while in fullscreen

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -456,6 +456,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
 
         setFullScreenSize();
+        mAttachedWindow.setBackupPlacement(mPlacementBeforeFullscreen);
         mWidgetManager.pushBackHandler(mFullScreenBackHandler);
         mIsInFullScreenMode = true;
         AnimationHelper.fadeIn(mFullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -64,12 +64,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     private ViewGroup mResizeModeContainer;
     private WindowWidget mAttachedWindow;
     private boolean mIsLoading;
-    private boolean mIsInFullScreenMode;
-    private boolean mIsResizing;
     private boolean mIsInVRVideo;
     private boolean mAutoEnteredVRVideo;
-    private WidgetPlacement mPlacementBeforeResize;
-    private WidgetPlacement mPlacementBeforeFullscreen;
     private Runnable mResizeBackHandler;
     private Runnable mFullScreenBackHandler;
     private Runnable mVRVideoBackHandler;
@@ -131,9 +127,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mBrightnessButton = findViewById(R.id.brightnessButton);
         mFullScreenResizeButton = findViewById(R.id.fullScreenResizeEnterButton);
         mProjectionButton = findViewById(R.id.projectionButton);
-        mPlacementBeforeResize = new WidgetPlacement(aContext);
-        mPlacementBeforeFullscreen = new WidgetPlacement(aContext);
-
 
         mResizeBackHandler = () -> exitResizeMode(ResizeAction.RESTORE_SIZE);
 
@@ -365,10 +358,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void detachFromWindow() {
-        if (mIsResizing) {
+        if (mAttachedWindow != null && mAttachedWindow.isResizing()) {
             exitResizeMode(ResizeAction.RESTORE_SIZE);
         }
-        if (mIsInFullScreenMode) {
+        if (mAttachedWindow != null && mAttachedWindow.isFullScreen()) {
             exitFullScreenMode();
         }
 
@@ -434,7 +427,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void setFullScreenSize() {
-        mPlacementBeforeFullscreen.copyFrom(mAttachedWindow.getPlacement());
         final float minScale = WidgetPlacement.floatDimension(getContext(), R.dimen.window_fullscreen_min_scale);
         // Set browser fullscreen size
         float aspect = SettingsStore.getInstance(getContext()).getWindowAspect();
@@ -451,14 +443,14 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void enterFullScreenMode() {
-        if (mIsInFullScreenMode) {
+        if (mAttachedWindow.isFullScreen()) {
             return;
         }
 
+        mAttachedWindow.saveBeforeFullscreenPlacement();
         setFullScreenSize();
-        mAttachedWindow.setBackupPlacement(mPlacementBeforeFullscreen);
         mWidgetManager.pushBackHandler(mFullScreenBackHandler);
-        mIsInFullScreenMode = true;
+        mAttachedWindow.setIsFullScreen(true);
         AnimationHelper.fadeIn(mFullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
 
         AnimationHelper.fadeOut(mNavigationContainer, 0, null);
@@ -492,7 +484,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void exitFullScreenMode() {
-        if (!mIsInFullScreenMode) {
+        if (!mAttachedWindow.isFullScreen()) {
             mWidgetManager.setTrayVisible(true);
             return;
         }
@@ -505,10 +497,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         }, 50);
 
-        mAttachedWindow.getPlacement().copyFrom(mPlacementBeforeFullscreen);
+        mAttachedWindow.restoreBeforeFullscreenPlacement();
         mWidgetManager.updateWidget(mAttachedWindow);
 
-        mIsInFullScreenMode = false;
+        mAttachedWindow.setIsFullScreen(false);
         mWidgetManager.popBackHandler(mFullScreenBackHandler);
 
         AnimationHelper.fadeIn(mNavigationContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
@@ -522,14 +514,14 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void enterResizeMode() {
-        if (mIsResizing) {
+        if (mAttachedWindow.isResizing()) {
             return;
         }
-        mIsResizing = true;
-        mPlacementBeforeResize.copyFrom(mAttachedWindow.getPlacement());
+        mAttachedWindow.setIsResizing(true);
+        mAttachedWindow.saveBeforeResizePlacement();
         startWidgetResize();
         AnimationHelper.fadeIn(mResizeModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
-        if (mIsInFullScreenMode) {
+        if (mAttachedWindow.isFullScreen()) {
             AnimationHelper.fadeOut(mFullScreenModeContainer, 0, null);
         } else {
             AnimationHelper.fadeOut(mNavigationContainer, 0, null);
@@ -575,24 +567,24 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void exitResizeMode(ResizeAction aResizeAction) {
-        if (!mIsResizing) {
+        if (!mAttachedWindow.isResizing()) {
             return;
         }
         if (aResizeAction == ResizeAction.RESTORE_SIZE) {
-            mAttachedWindow.getPlacement().copyFrom(mPlacementBeforeResize);
+            mAttachedWindow.restoreBeforeResizePlacement();
             mWidgetManager.updateWidget(mAttachedWindow);
             mWidgetManager.updateVisibleWidgets();
         }
-        mIsResizing = false;
+        mAttachedWindow.setIsResizing(false);
         finishWidgetResize();
-        if (mIsInFullScreenMode) {
+        if (mAttachedWindow.isFullScreen()) {
             AnimationHelper.fadeIn(mFullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
         } else {
             AnimationHelper.fadeIn(mNavigationContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
         }
         AnimationHelper.fadeOut(mResizeModeContainer, 0, () -> updateWidget());
         mWidgetManager.popBackHandler(mResizeBackHandler);
-        mWidgetManager.setTrayVisible(!mIsInFullScreenMode);
+        mWidgetManager.setTrayVisible(!mAttachedWindow.isFullScreen());
         closeFloatingMenus();
 
         if (aResizeAction == ResizeAction.KEEP_SIZE) {
@@ -823,10 +815,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     @Override
     public void onFullScreen(GeckoSession session, boolean aFullScreen) {
         if (aFullScreen) {
-            if (!mIsInFullScreenMode) {
+            if (!mAttachedWindow.isFullScreen()) {
                 enterFullScreenMode();
             }
-            if (mIsResizing) {
+            if (mAttachedWindow.isResizing()) {
                 exitResizeMode(ResizeAction.KEEP_SIZE);
             }
             AtomicBoolean autoEnter = new AtomicBoolean(false);
@@ -848,7 +840,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     // WidgetManagerDelegate.UpdateListener
     @Override
     public void onWidgetUpdate(Widget aWidget) {
-        if (aWidget == mAttachedWindow && !mIsResizing) {
+        if (aWidget == mAttachedWindow && !mAttachedWindow.isResizing()) {
             handleWindowResize();
         }
     }
@@ -876,9 +868,9 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         handleSessionState();
 
         boolean isFullScreen = mSessionStack.isInFullScreen(aSession);
-        if (isFullScreen && !mIsInFullScreenMode) {
+        if (isFullScreen && !mAttachedWindow.isFullScreen()) {
             enterFullScreenMode();
-        } else if (!isFullScreen && mIsInFullScreenMode) {
+        } else if (!isFullScreen && mAttachedWindow.isFullScreen()) {
             exitVRVideo();
             exitFullScreenMode();
         }
@@ -1027,10 +1019,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void onBookmarksClicked() {
-        if (mIsResizing) {
+        if (mAttachedWindow.isResizing()) {
             exitResizeMode(ResizeAction.RESTORE_SIZE);
 
-        } else if (mIsInFullScreenMode) {
+        } else if (mAttachedWindow.isFullScreen()) {
             exitFullScreenMode();
 
         } else if (mIsInVRVideo) {
@@ -1045,10 +1037,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void onHistoryClicked() {
-        if (mIsResizing) {
+        if (mAttachedWindow.isResizing()) {
             exitResizeMode(ResizeAction.RESTORE_SIZE);
 
-        } else if (mIsInFullScreenMode) {
+        } else if (mAttachedWindow.isFullScreen()) {
             exitFullScreenMode();
 
         } else if (mIsInVRVideo) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
@@ -167,7 +167,7 @@ public class TopBarWidget extends UIWidget implements SessionChangeListener, Wid
 
     @Override
     public void setVisible(boolean aIsVisible) {
-        if (mVisible == aIsVisible) {
+        if (mVisible == aIsVisible ||  mWidgetManager == null) {
             return;
         }
         mVisible = aIsVisible;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -131,6 +131,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     boolean mClickedAfterFocus = false;
     boolean mIsBookmarksVisible = false;
     boolean mIsHistoryVisible = false;
+    private WidgetPlacement mBackupPlacement;
 
     public interface WindowDelegate {
         void onFocusRequest(@NonNull WindowWidget aWindow);
@@ -779,6 +780,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 mWindowDelegate.onBorderChanged(this);
             }
         }
+    }
+
+    public void setBackupPlacement(@NonNull WidgetPlacement placement) {
+        mBackupPlacement = placement;
+    }
+
+    public WidgetPlacement getBackupPlacement() {
+        return mBackupPlacement;
     }
 
     public void setWindowDelegate(WindowDelegate aDelegate) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -131,7 +131,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     boolean mClickedAfterFocus = false;
     boolean mIsBookmarksVisible = false;
     boolean mIsHistoryVisible = false;
-    private WidgetPlacement mBackupPlacement;
+    private WidgetPlacement mPlacementBeforeFullscreen;
+    private WidgetPlacement mPlacementBeforeResize;
+    private boolean mIsResizing;
+    private boolean mIsFullScreen;
 
     public interface WindowDelegate {
         void onFocusRequest(@NonNull WindowWidget aWindow);
@@ -164,6 +167,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mHandle = ((WidgetManagerDelegate)aContext).newWidgetHandle();
         mWidgetPlacement = new WidgetPlacement(aContext);
+        mPlacementBeforeFullscreen = new WidgetPlacement(aContext);
+        mPlacementBeforeResize = new WidgetPlacement(aContext);
+        mIsResizing = false;
+        mIsFullScreen = false;
         initializeWidgetPlacement(mWidgetPlacement);
 
         mTopBar = new TopBarWidget(aContext);
@@ -782,12 +789,44 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    public void setBackupPlacement(@NonNull WidgetPlacement placement) {
-        mBackupPlacement = placement;
+    public void saveBeforeFullscreenPlacement() {
+        mPlacementBeforeFullscreen.copyFrom(mWidgetPlacement);
     }
 
-    public WidgetPlacement getBackupPlacement() {
-        return mBackupPlacement;
+    public void restoreBeforeFullscreenPlacement() {
+        mWidgetPlacement.copyFrom(mPlacementBeforeFullscreen);
+    }
+
+    public WidgetPlacement getBeforeFullscreenPlacement() {
+        return mPlacementBeforeFullscreen;
+    }
+
+    public void saveBeforeResizePlacement() {
+        mPlacementBeforeResize.copyFrom(mWidgetPlacement);
+    }
+
+    public void restoreBeforeResizePlacement() {
+        mWidgetPlacement.copyFrom(mPlacementBeforeResize);
+    }
+
+    public WidgetPlacement getBeforeResizePlacement() {
+        return mPlacementBeforeResize;
+    }
+
+    public void setIsResizing(boolean isResizing) {
+        mIsResizing = isResizing;
+    }
+
+    public boolean isResizing() {
+        return mIsResizing;
+    }
+
+    public void setIsFullScreen(boolean isFullScreen) {
+        mIsFullScreen = isFullScreen;
+    }
+
+    public boolean isFullScreen() {
+        return mIsFullScreen;
     }
 
     public void setWindowDelegate(WindowDelegate aDelegate) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -818,15 +818,19 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     public void enterResizeMode() {
-        for (WindowWidget window : getCurrentWindows()) {
-            window.getTopBar().setVisible(false);
+        if (mFullscreenWindow == null) {
+            for (WindowWidget window : getCurrentWindows()) {
+                window.getTopBar().setVisible(false);
+            }
         }
     }
 
     public void exitResizeMode() {
-        for (WindowWidget window : getCurrentWindows()) {
-            if (getCurrentWindows().size() > 1 || isInPrivateMode()) {
-                window.getTopBar().setVisible(window != mFullscreenWindow);
+        if (mFullscreenWindow == null) {
+            for (WindowWidget window : getCurrentWindows()) {
+                if (getCurrentWindows().size() > 1 || isInPrivateMode()) {
+                    window.getTopBar().setVisible(true);
+                }
             }
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -41,12 +41,25 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         float worldWidth;
 
         public void load(WindowWidget aWindow) {
-            placement = aWindow.getWindowPlacement();
+            if (aWindow == mFullscreenWindow) {
+                placement = mPrevWindowPlacement;
+
+            } else {
+                placement = aWindow.getWindowPlacement();
+            }
             sessionStack = aWindow.getSessionStack();
             currentSessionId = aWindow.getSessionStack().getCurrentSessionId();
-            textureWidth = aWindow.getPlacement().width;
-            textureHeight = aWindow.getPlacement().height;
-            worldWidth = aWindow.getPlacement().worldWidth;
+            WidgetPlacement placement;
+            if (aWindow == mFullscreenWindow && aWindow.getBackupPlacement() != null) {
+                placement = aWindow.getBackupPlacement();
+
+            } else {
+                placement = aWindow.getPlacement();
+            }
+
+            textureWidth = placement.width;
+            textureHeight = placement.height;
+            worldWidth = placement.worldWidth;
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -50,8 +50,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             sessionStack = aWindow.getSessionStack();
             currentSessionId = aWindow.getSessionStack().getCurrentSessionId();
             WidgetPlacement placement;
-            if (aWindow == mFullscreenWindow && aWindow.getBackupPlacement() != null) {
-                placement = aWindow.getBackupPlacement();
+            if (aWindow.isFullScreen()) {
+                placement = aWindow.getBeforeFullscreenPlacement();
+
+            } else if (aWindow.isResizing()) {
+                placement = aWindow.getBeforeResizePlacement();
 
             } else {
                 placement = aWindow.getPlacement();


### PR DESCRIPTION
Fixes #1774 Fixes restoring the window position and size when quitting the app while in fullscreen mode. Before this PR the restored window position was not correct and the restored windows size was the fullscreen window size when quitting the app is windows > 1.