### PR TITLE
Include VisitType.RELOAD query type when re-visiting.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
@@ -46,8 +46,7 @@ class HistoryStore constructor(val context: Context) {
         storage.getDetailedVisits(0, excludeTypes = listOf(
                 VisitType.NOT_A_VISIT,
                 VisitType.REDIRECT_TEMPORARY,
-                VisitType.REDIRECT_PERMANENT,
-                VisitType.RELOAD))
+                VisitType.REDIRECT_PERMANENT))
     }
 
     fun recordVisit(aURL: String, visitType: VisitType) = GlobalScope.future {
@@ -90,7 +89,8 @@ class HistoryStore constructor(val context: Context) {
     }
 
     fun isInHistory(aURL: String): CompletableFuture<Boolean> = GlobalScope.future {
-        storage.getVisited(listOf(aURL)).isNotEmpty()
+        var result = storage.getVisited(listOf(aURL))
+        result.isNotEmpty() && result[0]
     }
 
     private fun notifyListeners() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1479,22 +1479,19 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         VisitType visitType;
         if (isReload) {
             visitType = VisitType.RELOAD;
-
         } else {
             if ((flags & VISIT_REDIRECT_SOURCE_PERMANENT) != 0) {
                 visitType = VisitType.REDIRECT_PERMANENT;
-
             } else if ((flags & VISIT_REDIRECT_SOURCE) != 0) {
                 visitType = VisitType.REDIRECT_TEMPORARY;
-
             } else {
                 visitType = VisitType.LINK;
             }
         }
 
-        SessionStore.get().getHistoryStore().deleteVisitsFor(url);
-        SessionStore.get().getHistoryStore().recordVisit(url, visitType);
-
+        SessionStore.get().getHistoryStore().deleteVisitsFor(url).thenAcceptAsync(result -> {
+            SessionStore.get().getHistoryStore().recordVisit(url, visitType);
+        });
         return GeckoResult.fromValue(true);
     }
 


### PR DESCRIPTION
I don't why we want to remove the previous URL from the history even though the URLs are the same. IMHO, we should just keep it because they are **HISTORY**.