### PR TITLE
Fixing media control misplacement when using multiple windows

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -622,6 +622,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
         mMediaControlsWidget.setProjectionMenuWidget(mProjectionMenu);
         mMediaControlsWidget.setMedia(mFullScreenMedia);
+        mMediaControlsWidget.setParentWidget(mAttachedWindow.getHandle());
         mMediaControlsWidget.setProjectionSelectorEnabled(true);
         mWidgetManager.updateWidget(mMediaControlsWidget);
         mWidgetManager.showVRVideo(mAttachedWindow.getHandle(), aProjection);


### PR DESCRIPTION
Because we only have one Media control, so we need to attach to the window that we want to play VR video. Fixes #1830.