### PR TITLE
Clear GV history after wiping of the history

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -242,6 +242,12 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
         }
     }
 
+    public void clearHistory() {
+        for (Map.Entry<Integer, SessionStack> entry : mSessionStacks.entrySet()) {
+            entry.getValue().clearHistory();
+        }
+    }
+
     // Permission Delegate
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -134,7 +134,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private WidgetPlacement mPlacementBeforeResize;
     private boolean mIsResizing;
     private boolean mIsFullScreen;
-    private boolean mAfterFirstlPaint;
+    private boolean mAfterFirstPaint;
 
     public interface WindowDelegate {
         void onFocusRequest(@NonNull WindowWidget aWindow);
@@ -524,7 +524,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    public @NonNull Windows.WindowPlacement getmWindowPlacementBeforeFullscreen() {
+    public @NonNull Windows.WindowPlacement getWindowPlacementBeforeFullscreen() {
         return mWindowPlacementBeforeFullscreen;
     }
 
@@ -1435,7 +1435,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public void onFirstComposite(@NonNull GeckoSession session) {
-        if (!mAfterFirstlPaint) {
+        if (!mAfterFirstPaint) {
             return;
         }
         if (mFirstDrawCallback != null) {
@@ -1446,13 +1446,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public void onFirstContentfulPaint(@NonNull GeckoSession session) {
-        if (mAfterFirstlPaint) {
+        if (mAfterFirstPaint) {
             return;
         }
         if (mFirstDrawCallback != null) {
             ThreadUtils.postToUiThread(mFirstDrawCallback);
             mFirstDrawCallback = null;
-            mAfterFirstlPaint = true;
+            mAfterFirstPaint = true;
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1137,15 +1137,16 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                         store.deleteVisitsBetween(todayLimit, currentTime);
                         break;
                     case ClearCacheDialogWidget.YESTERDAY:
-                        store.deleteVisitsBetween(yesterdayLimit, todayLimit);
+                        store.deleteVisitsBetween(yesterdayLimit, currentTime);
                         break;
                     case ClearCacheDialogWidget.LAST_WEEK:
-                        store.deleteVisitsBetween(oneWeekLimit, yesterdayLimit);
+                        store.deleteVisitsBetween(oneWeekLimit, currentTime);
                         break;
                     case ClearCacheDialogWidget.EVERYTHING:
                         store.deleteEverything();
                         break;
                 }
+                SessionStore.get().clearHistory();
             }
         });
         mClearCacheDialog.show(REQUEST_FOCUS);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -48,7 +48,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             WidgetPlacement widgetPlacement;
             if (aWindow.isFullScreen()) {
                 widgetPlacement = aWindow.getBeforeFullscreenPlacement();
-                placement = aWindow.getmWindowPlacementBeforeFullscreen();
+                placement = aWindow.getWindowPlacementBeforeFullscreen();
             } else if (aWindow.isResizing()) {
                 widgetPlacement = aWindow.getBeforeResizePlacement();
                 placement = aWindow.getWindowPlacement();
@@ -126,7 +126,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         try (Writer writer = new FileWriter(file)) {
             WindowsState state = new WindowsState();
             state.privateMode = mPrivateMode;
-            state.focusedWindowPlacement = mFocusedWindow.isFullScreen() ?  mFocusedWindow.getmWindowPlacementBeforeFullscreen() : mFocusedWindow.getWindowPlacement();
+            state.focusedWindowPlacement = mFocusedWindow.isFullScreen() ?  mFocusedWindow.getWindowPlacementBeforeFullscreen() : mFocusedWindow.getWindowPlacement();
             for (WindowWidget window : mRegularWindows) {
                 WindowState windowState = new WindowState();
                 windowState.load(window);


### PR DESCRIPTION
Fixes #1749 Clear navigation buttons after history is cleared by recreating the session. Also fixed the way history is cleared, before we could clear yesterday and last week's entries but seeing the way desktop does it it makes more sense to always clean from now to those ranges.