### PR TITLE
Fix top bar glitch when moving windows

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
@@ -190,12 +190,10 @@ public class TopBarWidget extends UIWidget implements SessionChangeListener, Wid
     }
 
     public void setMoveLeftButtonEnabled(boolean aEnabled) {
-        mMoveRightButton.setHovered(false);
         mMoveLeftButton.setEnabled(aEnabled);
     }
 
     public void setMoveRightButtonEnabled(boolean aEnabled) {
-        mMoveLeftButton.setHovered(false);
         mMoveRightButton.setEnabled(aEnabled);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -624,6 +624,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return mTopBar;
     }
 
+    public void setTopBar(TopBarWidget aWidget) {
+        if (mTopBar != aWidget) {
+            mTopBar = aWidget;
+            mTopBar.attachToWindow(this);
+        }
+    }
+
     public TitleBarWidget getTitleBar() {
         return mTitleBar;
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -307,11 +307,14 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (aWindow == leftWindow) {
             placeWindow(leftWindow, WindowPlacement.FRONT);
             placeWindow(frontWindow, WindowPlacement.LEFT);
+            switchTopBars(leftWindow, frontWindow);
         } else if (aWindow == frontWindow) {
             if (rightWindow != null) {
                 placeWindow(rightWindow, WindowPlacement.FRONT);
+                switchTopBars(rightWindow, frontWindow);
             } else if (leftWindow != null) {
                 placeWindow(leftWindow, WindowPlacement.FRONT);
+                switchTopBars(leftWindow, frontWindow);
             }
             placeWindow(frontWindow, WindowPlacement.RIGHT);
         }
@@ -329,11 +332,14 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (aWindow == rightWindow) {
             placeWindow(rightWindow, WindowPlacement.FRONT);
             placeWindow(frontWindow, WindowPlacement.RIGHT);
+            switchTopBars(rightWindow, frontWindow);
         } else if (aWindow == frontWindow) {
             if (leftWindow != null) {
                 placeWindow(leftWindow, WindowPlacement.FRONT);
+                switchTopBars(leftWindow, frontWindow);
             } else if (rightWindow != null) {
                 placeWindow(rightWindow, WindowPlacement.FRONT);
+                switchTopBars(rightWindow, frontWindow);
             }
             placeWindow(frontWindow, WindowPlacement.LEFT);
         }
@@ -724,6 +730,15 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
     public int getWindowsCount() {
         return getCurrentWindows().size();
+    }
+
+    private void switchTopBars(WindowWidget w1, WindowWidget w2) {
+        // Used to fix a minor visual glitch.
+        // See https://github.com/MozillaReality/FirefoxReality/issues/1722
+        TopBarWidget bar1 = w1.getTopBar();
+        TopBarWidget bar2 = w2.getTopBar();
+        w1.setTopBar(bar2);
+        w2.setTopBar(bar1);
     }
 
     private void updateViews() {


### PR DESCRIPTION
Fixes #1722

It's difficult to correctly sync native widget update (move) with the Android compositor render. So I opted for switching the top bar between moving windows.