### PR TITLE
Restore userAgentOverride when restoring state (#1125)

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
@@ -14,6 +14,7 @@ class SessionSettings {
     private int userAgentMode;
     private int viewportMode;
     private boolean isServoEnabled;
+    private String userAgentOverride;
 
     private SessionSettings(@NotNull Builder builder) {
         this.isMultiprocessEnabled = builder.isMultiprocessEnabled;
@@ -22,6 +23,7 @@ class SessionSettings {
         this.userAgentMode = builder.userAgentMode;
         this.viewportMode = builder.viewportMode;
         this.isServoEnabled = builder.isServoEnabled;
+        this.userAgentOverride = builder.userAgentOverride;
     }
 
     public boolean isMultiprocessEnabled() {
@@ -52,6 +54,14 @@ class SessionSettings {
         userAgentMode = mode;
     }
 
+    public void setUserAgentOverride(String userAgentOverride) {
+        this.userAgentOverride = userAgentOverride;
+    }
+
+    public String getUserAgentOverride() {
+        return userAgentOverride;
+    }
+
     public int getViewportMode() { return viewportMode; }
 
     public void setViewportMode(final int mode) { viewportMode = mode; }
@@ -72,6 +82,7 @@ class SessionSettings {
         private int userAgentMode;
         private int viewportMode;
         private boolean isServoEnabled;
+        private String userAgentOverride;
 
         public Builder() {
         }
@@ -103,6 +114,11 @@ class SessionSettings {
 
         public Builder withServo(boolean isServoEnabled){
             this.isServoEnabled= isServoEnabled;
+            return this;
+        }
+
+        public Builder withUserAgentOverride(String userAgentOverride) {
+            this.userAgentOverride = userAgentOverride;
             return this;
         }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStack.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStack.java
@@ -280,6 +280,7 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
                     .useMultiprocess(state.mSettings.isMultiprocessEnabled())
                     .usePrivateMode(mUsePrivateMode)
                     .userAgentMode(state.mSettings.getUserAgentMode())
+                    .userAgentOverride(state.mSettings.getUserAgentOverride())
                     .suspendMediaWhenInactive(state.mSettings.isSuspendMediaWhenInactiveEnabled())
                     .useTrackingProtection(state.mSettings.isTrackingProtectionEnabled())
                     .build();
@@ -366,6 +367,7 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
 
         state.mSession.getSettings().setSuspendMediaWhenInactive(aSettings.isSuspendMediaWhenInactiveEnabled());
         state.mSession.getSettings().setUserAgentMode(aSettings.getUserAgentMode());
+        state.mSession.getSettings().setUserAgentOverride(aSettings.getUserAgentOverride());
         state.mSession.setNavigationDelegate(this);
         state.mSession.setProgressDelegate(this);
         state.mSession.setContentDelegate(this);
@@ -948,8 +950,12 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
         }
 
         if (aSession == mCurrentSession) {
+            SessionState state = mSessions.get(getCurrentSessionId());
             Log.d(LOGTAG, "Testing for UA override");
-            aSession.getSettings().setUserAgentOverride(mUserAgentOverride.lookupOverride(uri));
+
+            final String userAgentOverride = mUserAgentOverride.lookupOverride(uri);
+            aSession.getSettings().setUserAgentOverride(userAgentOverride);
+            state.mSettings.setUserAgentOverride(userAgentOverride);
         }
 
         if (mContext.getString(R.string.about_private_browsing).equalsIgnoreCase(uri)) {


### PR DESCRIPTION
When restoring state using session.restoreState, `onLoadRequest` is not called
which causes FxR's UA override logic to not run. To fix this, we remember the
UA override string and restore it.