### PR TITLE
Handle exceptions thrown by java.net.URI

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStack.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStack.java
@@ -793,11 +793,14 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
     private static final String MOBILE_PREFIX = "mobile.";
 
     private String checkForMobileSite(String aUri) {
+        if (aUri == null) {
+            return null;
+        }
         String result = null;
         URI uri;
         try {
             uri = new URI(aUri);
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | NullPointerException e) {
             Log.d(LOGTAG, "Error parsing URL: " + aUri + " " + e.getMessage());
             return null;
         }
@@ -816,7 +819,7 @@ public class SessionStack implements ContentBlocking.Delegate, GeckoSession.Navi
             try {
                 uri = new URI(uri.getScheme(), authority.substring(foundPrefix.length()), uri.getPath(), uri.getQuery(), uri.getFragment());
                 result = uri.toString();
-            } catch (URISyntaxException e) {
+            } catch (URISyntaxException | NullPointerException e) {
                 Log.d(LOGTAG, "Error dropping mobile prefix from: " + aUri + " " + e.getMessage());
             }
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -304,8 +304,9 @@ public class NavigationURLBar extends FrameLayout {
             try {
                 aURL = URLDecoder.decode(aURL, "UTF-8");
 
-            } catch (UnsupportedEncodingException e) {
+            } catch (UnsupportedEncodingException | IllegalArgumentException e) {
                 e.printStackTrace();
+                aURL = "";
             }
             if (aURL.startsWith("jar:")) {
                 return;


### PR DESCRIPTION
Handles the following crashes from unhandled exceptions:
https://crash-stats.mozilla.com/report/index/a0367f38-55b1-45d4-bcfc-27d150191004
https://crash-stats.mozilla.com/report/index/1815e4cf-c2b3-4630-ab42-c15990191004
