### PR TITLE
Making Focus Plus use WVR_InputId_Alias1_Trigger to check trigger only.

### DIFF
--- a/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
+++ b/app/src/wavevr/cpp/DeviceDelegateWaveVR.cpp
@@ -303,8 +303,8 @@ struct DeviceDelegateWaveVR::State {
 
       delegate->SetVisible(controller.index, !WVR_IsInputFocusCapturedBySystem());
 
-      const bool bumperPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Digital_Trigger)
-                                || WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Trigger);
+      const bool bumperPressed =  (controller.is6DoF) ? WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Trigger)
+                                  : WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Digital_Trigger);
       const bool touchpadPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Touchpad);
       const bool touchpadTouched = WVR_GetInputTouchState(controller.type, WVR_InputId_Alias1_Touchpad);
       const bool menuPressed = WVR_GetInputButtonState(controller.type, WVR_InputId_Alias1_Menu);


### PR DESCRIPTION
Fixes #1930. It looks like after the recent updates, Focus Plus only can use `WVR_InputId_Alias1_Trigger` to listen the trigger state. Otherwise, when pressing the left on the touchpad, it will send a `WVR_InputId_Alias1_Digital_Trigger`.