### PR TITLE
Standarize dialogs y & z positions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
@@ -10,13 +10,10 @@ import android.util.AttributeSet;
 import android.widget.Button;
 
 import org.mozilla.vrbrowser.R;
-import org.mozilla.vrbrowser.audio.AudioEngine;
 
 public class NoInternetWidget extends UIWidget {
 
     private Button mAcceptButton;
-    private AudioEngine mAudio;
-    private UIWidget mBrowserWidget;
 
     public NoInternetWidget(Context aContext) {
         super(aContext);
@@ -48,7 +45,7 @@ public class NoInternetWidget extends UIWidget {
         Context context = getContext();
         aPlacement.width = WidgetPlacement.dpDimension(context, R.dimen.no_internet_width);
         aPlacement.height = WidgetPlacement.dpDimension(context, R.dimen.no_internet_height);
-        aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.no_internet_z_distance);
+        aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_z_distance);
         aPlacement.anchorX = 0.5f;
         aPlacement.anchorY = 0.5f;
         aPlacement.parentAnchorX = 0.5f;
@@ -57,10 +54,4 @@ public class NoInternetWidget extends UIWidget {
         aPlacement.visible = false;
     }
 
-    public void setBrowserWidget(UIWidget aWidget) {
-        if (aWidget != null) {
-            mWidgetPlacement.parentHandle = aWidget.getHandle();
-        }
-        mBrowserWidget = aWidget;
-    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1083,6 +1083,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (mNoInternetToast == null) {
             mNoInternetToast = new NoInternetWidget(getContext());
             mNoInternetToast.mWidgetPlacement.parentHandle = getHandle();
+            mNoInternetToast.mWidgetPlacement.parentAnchorY = 0.0f;
+            mNoInternetToast.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         }
         if (aVisible && !mNoInternetToast.isVisible()) {
             mNoInternetToast.show(REQUEST_FOCUS);
@@ -1094,6 +1096,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void showAlert(String title, @NonNull String msg, @NonNull PromptWidget.PromptDelegate callback) {
         mAlertPrompt = new AlertPromptWidget(getContext());
         mAlertPrompt.mWidgetPlacement.parentHandle = getHandle();
+        mAlertPrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mAlertPrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mAlertPrompt.setTitle(title);
         mAlertPrompt.setMessage(msg);
         mAlertPrompt.setPromptDelegate(callback);
@@ -1103,6 +1107,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void showButtonPrompt(String title, @NonNull String msg, @NonNull String[] btnMsg, @NonNull ConfirmPromptWidget.ConfirmPromptDelegate callback) {
         mConfirmPrompt = new ConfirmPromptWidget(getContext());
         mConfirmPrompt.mWidgetPlacement.parentHandle = getHandle();
+        mConfirmPrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mConfirmPrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mConfirmPrompt.setTitle(title);
         mConfirmPrompt.setMessage(msg);
         mConfirmPrompt.setButtons(btnMsg);
@@ -1114,6 +1120,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                               @NonNull BaseAppDialogWidget.Delegate buttonsCallback, @NonNull MessageDialogWidget.Delegate messageCallback) {
         mAppDialog = new MessageDialogWidget(getContext());
         mAppDialog.mWidgetPlacement.parentHandle = getHandle();
+        mAppDialog.mWidgetPlacement.parentAnchorY = 0.0f;
+        mAppDialog.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mAppDialog.setTitle(title);
         mAppDialog.setMessage(description);
         mAppDialog.setButtons(btnMsg);
@@ -1125,6 +1133,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void showClearCacheDialog() {
         mClearCacheDialog = new ClearCacheDialogWidget(getContext());
         mClearCacheDialog.mWidgetPlacement.parentHandle = getHandle();
+        mClearCacheDialog.mWidgetPlacement.parentAnchorY = 0.0f;
+        mClearCacheDialog.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mClearCacheDialog.setTitle(R.string.history_clear);
         mClearCacheDialog.setButtons(new int[] {
                 R.string.history_clear_cancel,
@@ -1169,6 +1179,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     public void showMaxWindowsDialog(int maxDialogs) {
         mMaxWindowsDialog = new MaxWindowsWidget(getContext());
+        mMaxWindowsDialog.mWidgetPlacement.parentAnchorY = 0.0f;
+        mMaxWindowsDialog.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mMaxWindowsDialog.mWidgetPlacement.parentHandle = getHandle();
         mMaxWindowsDialog.setMessage(getContext().getString(R.string.max_windows_msg, String.valueOf(maxDialogs)));
         mMaxWindowsDialog.show(REQUEST_FOCUS);
@@ -1310,6 +1322,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mAlertPrompt = new AlertPromptWidget(getContext());
         mAlertPrompt.mWidgetPlacement.parentHandle = getHandle();
+        mAlertPrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mAlertPrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mAlertPrompt.setTitle(alertPrompt.title);
         mAlertPrompt.setMessage(alertPrompt.message);
         mAlertPrompt.setPromptDelegate(() -> result.complete(alertPrompt.dismiss()));
@@ -1325,6 +1339,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mConfirmPrompt = new ConfirmPromptWidget(getContext());
         mConfirmPrompt.mWidgetPlacement.parentHandle = getHandle();
+        mConfirmPrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mConfirmPrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mConfirmPrompt.setTitle(buttonPrompt.title);
         mConfirmPrompt.setMessage(buttonPrompt.message);
         mConfirmPrompt.setButtons(new String[] {
@@ -1354,6 +1370,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mTextPrompt = new TextPromptWidget(getContext());
         mTextPrompt.mWidgetPlacement.parentHandle = getHandle();
+        mTextPrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mTextPrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mTextPrompt.setTitle(textPrompt.title);
         mTextPrompt.setMessage(textPrompt.message);
         mTextPrompt.setDefaultText(textPrompt.defaultValue);
@@ -1380,6 +1398,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mAuthPrompt = new AuthPromptWidget(getContext());
         mAuthPrompt.mWidgetPlacement.parentHandle = getHandle();
+        mAuthPrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mAuthPrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mAuthPrompt.setTitle(authPrompt.title);
         mAuthPrompt.setMessage(authPrompt.message);
         mAuthPrompt.setAuthOptions(authPrompt.authOptions);
@@ -1411,6 +1431,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mChoicePrompt = new ChoicePromptWidget(getContext());
         mChoicePrompt.mWidgetPlacement.parentHandle = getHandle();
+        mChoicePrompt.mWidgetPlacement.parentAnchorY = 0.0f;
+        mChoicePrompt.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
         mChoicePrompt.setTitle(choicePrompt.title);
         mChoicePrompt.setMessage(choicePrompt.message);
         mChoicePrompt.setChoices(choicePrompt.choices);

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -110,7 +110,6 @@
     <!-- No Internet toast -->
     <dimen name="no_internet_width">400dp</dimen>
     <dimen name="no_internet_height">200dp</dimen>
-    <dimen name="no_internet_z_distance" format="float" type="dimen">2.5</dimen>
 
     <!-- Autocompletion Widget -->
     <dimen name="autocompletion_widget_line_height">36dp</dimen>
@@ -263,6 +262,7 @@
     <!-- Base App Dialog -->
     <dimen name="base_app_dialog_width">420dp</dimen>
     <item name="base_app_dialog_z_distance" format="float" type="dimen">2</item>
+    <item name="base_app_dialog_y_distance" format="float" type="dimen">1.2</item>
 
     <!-- Cache Dialog -->
     <dimen name="cache_app_dialog_width">585dp</dimen>


### PR DESCRIPTION
This PR fixes the Y position of all the dialogs that are triggered by the focused window. They were positioned too high on the Y axis when the window height is too high. This PR fixes that and always places them in front of the user.

STRs:
- Open a window
- Resize it vertically to the max
- Open the History panel
- Click on the Clear button

Actual Result
The dialog y position is too high

Expected result
The dialogs should always be in front of the user