### PR TITLE
Copy paste improvements

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/CustomInlineAutocompleteEditText.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/CustomInlineAutocompleteEditText.java
@@ -1,0 +1,40 @@
+package org.mozilla.vrbrowser.ui.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import mozilla.components.ui.autocomplete.InlineAutocompleteEditText;
+
+public class CustomInlineAutocompleteEditText extends InlineAutocompleteEditText {
+    private OnSelectionChangedCallback mSelectionCallback;
+    interface OnSelectionChangedCallback {
+        void onSelectionChanged(int selectionStart, int selectionEnd);
+    }
+
+    public CustomInlineAutocompleteEditText(@NotNull Context ctx, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(ctx, attrs, defStyleAttr);
+    }
+
+    public CustomInlineAutocompleteEditText(@NotNull Context ctx, @Nullable AttributeSet attrs) {
+        super(ctx, attrs);
+    }
+
+    public CustomInlineAutocompleteEditText(@NotNull Context ctx) {
+        super(ctx);
+    }
+
+    @Override
+    public void onSelectionChanged(int selStart, int selEnd) {
+        super.onSelectionChanged(selStart, selEnd);
+        if (mSelectionCallback != null) {
+            mSelectionCallback.onSelectionChanged(selStart, selEnd);
+        }
+    }
+
+    public void setOnSelectionChangedCallback(@Nullable OnSelectionChangedCallback aCallback) {
+        mSelectionCallback = aCallback;
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
@@ -20,6 +20,7 @@ import org.mozilla.vrbrowser.utils.StringUtils;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import static android.view.Gravity.CENTER_VERTICAL;
 
@@ -33,6 +34,7 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
     private Point mPosition;
     private LinearLayout mContainer;
     private int mMinButtonWidth;
+    private String[] mActions;
 
     public SelectionActionWidget(Context aContext) {
         super(aContext);
@@ -101,23 +103,24 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
         }
     }
 
-    public void setActions(@NonNull String[] actions) {
+    public void setActions(@NonNull String[] aActions) {
+        mActions = aActions;
         mContainer.removeAllViews();
         ArrayList<UITextButton> buttons = new ArrayList<>();
 
-        if (StringUtils.contains(actions, GeckoSession.SelectionActionDelegate.ACTION_CUT)) {
+        if (StringUtils.contains(aActions, GeckoSession.SelectionActionDelegate.ACTION_CUT)) {
             buttons.add(createButton(R.string.context_menu_cut_text, GeckoSession.SelectionActionDelegate.ACTION_CUT, this::handleAction));
         }
-        if (StringUtils.contains(actions, GeckoSession.SelectionActionDelegate.ACTION_COPY)) {
+        if (StringUtils.contains(aActions, GeckoSession.SelectionActionDelegate.ACTION_COPY)) {
             buttons.add(createButton(R.string.context_menu_copy_text, GeckoSession.SelectionActionDelegate.ACTION_COPY, this::handleAction));
         }
-        if (StringUtils.contains(actions, GeckoSession.SelectionActionDelegate.ACTION_PASTE)) {
+        if (StringUtils.contains(aActions, GeckoSession.SelectionActionDelegate.ACTION_PASTE)) {
             buttons.add(createButton(R.string.context_menu_paste_text, GeckoSession.SelectionActionDelegate.ACTION_PASTE, this::handleAction));
         }
-        if (StringUtils.contains(actions, GeckoSession.SelectionActionDelegate.ACTION_SELECT_ALL)) {
+        if (StringUtils.contains(aActions, GeckoSession.SelectionActionDelegate.ACTION_SELECT_ALL)) {
             buttons.add(createButton(R.string.context_menu_select_all_text, GeckoSession.SelectionActionDelegate.ACTION_SELECT_ALL, this::handleAction));
         }
-        if (StringUtils.contains(actions, GeckoSession.SelectionActionDelegate.ACTION_UNSELECT)) {
+        if (StringUtils.contains(aActions, GeckoSession.SelectionActionDelegate.ACTION_UNSELECT)) {
             buttons.add(createButton(R.string.context_menu_unselect, GeckoSession.SelectionActionDelegate.ACTION_UNSELECT, this::handleAction));
         }
 
@@ -137,6 +140,14 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
             }
             buttons.get(i).setBackgroundDrawable(getContext().getDrawable(backgroundId));
         }
+    }
+
+    public boolean hasAction(String aAction) {
+        return mActions != null && StringUtils.contains(mActions, aAction);
+    }
+
+    public boolean hasSameActions(@NonNull String[] aActions) {
+        return Arrays.deepEquals(mActions, aActions);
     }
 
     private UITextButton createButton(int aStringId, String aAction, OnClickListener aHandler) {

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -7,7 +7,7 @@
         android:descendantFocusability="beforeDescendants"
         android:focusableInTouchMode="true">
 
-        <mozilla.components.ui.autocomplete.InlineAutocompleteEditText
+        <org.mozilla.vrbrowser.ui.views.CustomInlineAutocompleteEditText
             android:id="@+id/urlEditText"
             android:layout_width="match_parent"
             android:layout_height="match_parent"


### PR DESCRIPTION
Fixes #1983

- Correctly update Copy/Cut actions on the URLbar when the selection changes
- Hide or commit autocompletion selection when the user starts a select gesture
- Fix conflict between URL bar scroll gesture and select text gesture
- Do not recreate the CopyPaste menu if the new gesture has the same actions as before (avoids a minor flicker)

