### PR TITLE
Pin sqliteassethelper library to 2.0.1

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -107,7 +107,7 @@ atsl.rules = "androidx.test:rules:$versions.atsl_runner"
 deps.atsl = atsl
 
 def sqlite = [:]
-sqlite.sqlite = 'com.readystatesoftware.sqliteasset:sqliteassethelper:+'
+sqlite.sqlite = 'com.readystatesoftware.sqliteasset:sqliteassethelper:2.0.1'
 deps.sqlite = sqlite
 
 def kotlin = [:]


### PR DESCRIPTION
This will also avoid some Taskcluster failures as it will use the cached one instead of always look for the latest one.