### PR TITLE
Fix gaps in the fullscreen bar

### DIFF
--- a/app/src/main/res/layout/navigation_bar_fullscreen.xml
+++ b/app/src/main/res/layout/navigation_bar_fullscreen.xml
@@ -6,6 +6,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:background="@drawable/resize_bar_background"
         android:visibility="gone">
 
         <FrameLayout


### PR DESCRIPTION
Reproducible in HTC Vive Focus
![screen](https://user-images.githubusercontent.com/1070794/67554655-1972c480-f710-11e9-9900-4ae45b8b0851.png)
