### PR TITLE
Fix FxA onLoadRequest breaking background tabs

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -118,8 +118,9 @@ class Services(context: Context, places: Places): GeckoSession.NavigationDelegat
 
                 return GeckoResult.ALLOW
             }
+            return GeckoResult.DENY
         }
 
-        return GeckoResult.DENY
+        return GeckoResult.ALLOW
     }
 }


### PR DESCRIPTION
STR:

- Open Link in a new tab using the longpress menu
- Open Tabs Widget
- The Tab has about:blank instead of the correct URL