### PR TITLE
Correctly restore SessionSettings

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
@@ -96,6 +96,9 @@ public class SessionState {
                                     }
                                 }
                             }
+                            if (session.mSettings != null) {
+                                out.name("mSettings").jsonValue(gson.toJson(session.mSettings));
+                            }
                             out.endObject();
 
                         } else {
@@ -110,16 +113,7 @@ public class SessionState {
                 public T read(JsonReader in) throws IOException {
                     try {
                         return delegate.read(in);
-
-                    } catch (IOException e) {
-                        in.skipValue();
-                        return null;
-
-                    } catch (IllegalStateException e) {
-                        in.skipValue();
-                        return null;
-
-                    } catch (JsonSyntaxException e) {
+                    } catch (Exception e) {
                         in.skipValue();
                         return null;
                     }


### PR DESCRIPTION
I found that SessionSettings were not saved correctly, which can cause restore issues.

Example:

- Open a page with desktop viewport
- Close app
- When FxR is reopened the page has mobile viewport