### PR TITLE
Disable tray animations

### DIFF
--- a/app/src/main/res/drawable/tray_background_checked_middle.xml
+++ b/app/src/main/res/drawable/tray_background_checked_middle.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/asphalt"/>

--- a/app/src/main/res/drawable/tray_background_checked_start.xml
+++ b/app/src/main/res/drawable/tray_background_checked_start.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:bottomLeftRadius="10dp" android:topLeftRadius="10dp" />

--- a/app/src/main/res/drawable/tray_background_ckecked_end.xml
+++ b/app/src/main/res/drawable/tray_background_ckecked_end.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:bottomRightRadius="10dp" android:topRightRadius="10dp" />

--- a/app/src/main/res/drawable/tray_background_end_private.xml
+++ b/app/src/main/res/drawable/tray_background_end_private.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:bottomRightRadius="10dp" android:topRightRadius="10dp" />

--- a/app/src/main/res/drawable/tray_background_middle_private.xml
+++ b/app/src/main/res/drawable/tray_background_middle_private.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/void_color"/>

--- a/app/src/main/res/drawable/tray_background_start_private.xml
+++ b/app/src/main/res/drawable/tray_background_start_private.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:bottomLeftRadius="10dp" android:topLeftRadius="10dp" />

--- a/app/src/main/res/drawable/tray_background_unchecked_middle.xml
+++ b/app/src/main/res/drawable/tray_background_unchecked_middle.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/void_color"/>

--- a/app/src/main/res/drawable/tray_background_unchecked_start.xml
+++ b/app/src/main/res/drawable/tray_background_unchecked_start.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:bottomLeftRadius="10dp" android:topLeftRadius="10dp" />

--- a/app/src/main/res/drawable/tray_background_unckecked_end.xml
+++ b/app/src/main/res/drawable/tray_background_unckecked_end.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:enterFadeDuration="@integer/ui_fadeAnimTime"
-    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <corners android:bottomRightRadius="10dp" android:topRightRadius="10dp" />


### PR DESCRIPTION
Closes #2054 It seems that dynamically settings the background doesn't play well with animations in certain cases. I was starting to be a time sink so I've just disabled the animation for the tray and opened a follow-up #2081

The other issues should be fixed by https://github.com/MozillaReality/FirefoxReality/pull/2071