### PR TITLE
Upgrade to Mozilla Android Component v.19.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -36,8 +36,7 @@ public class GleanMetricsService {
         } else {
             GleanMetricsService.stop();
         }
-        Configuration config = new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT,
-                                                 BuildConfig.BUILD_TYPE);
+        Configuration config = new Configuration();
         Glean.INSTANCE.initialize(aContext, config);
     }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,7 @@ def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
 versions.gecko_view = "72.0.20191029093803"
-versions.android_components = "18.0.0"
+versions.android_components = "19.0.0"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"


### PR DESCRIPTION
Per #1854, we need to upgrade Mozilla Android Component to v.19 to avoid unnecessary Glean data migration.