### PR TITLE
Capture tab snapshots when stacking sessions and opening the tabs dialog.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -9,8 +9,10 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
+import android.graphics.SurfaceTexture;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import android.view.Surface;
 import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
@@ -417,6 +419,32 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
                     }
                 });
             }
+            return null;
+        });
+    }
+
+    public void captureBackgroundBitmap(int displayWidth, int displayHeight) {
+        Surface captureSurface = BitmapCache.getInstance(mContext).acquireCaptureSurface(displayWidth, displayHeight);
+        if (captureSurface == null) {
+            return;
+        }
+        GeckoSession session = mState.mSession;
+        GeckoDisplay display = session.acquireDisplay();
+        display.surfaceChanged(captureSurface, displayWidth, displayHeight);
+        display.capturePixels().then(bitmap -> {
+            if (bitmap != null) {
+                BitmapCache.getInstance(mContext).scaleBitmap(bitmap, 500, 280).thenAccept(scaledBitmap -> {
+                    BitmapCache.getInstance(mContext).addBitmap(getId(), scaledBitmap);
+                    for (BitmapChangedListener listener: mBitmapChangedListeners) {
+                        listener.onBitmapChanged(Session.this, scaledBitmap);
+                    }
+                });
+            }
+            ((Activity)mContext).runOnUiThread(() -> {
+                display.surfaceDestroyed();
+                session.releaseDisplay(display);
+                BitmapCache.getInstance(mContext).releaseCaptureSurface();
+            });
             return null;
         });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -440,11 +440,9 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
                     }
                 });
             }
-            ((Activity)mContext).runOnUiThread(() -> {
-                display.surfaceDestroyed();
-                session.releaseDisplay(display);
-                BitmapCache.getInstance(mContext).releaseCaptureSurface();
-            });
+            display.surfaceDestroyed();
+            session.releaseDisplay(display);
+            BitmapCache.getInstance(mContext).releaseCaptureSurface();
             return null;
         });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -391,6 +391,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return (mView != null && mView == mHistoryView);
     }
 
+    public int getWindowWidth() {
+        return mWidgetPlacement.width;
+    }
+
+    public int getWindowHeight() {
+        return mWidgetPlacement.height;
+    }
+
     public void addBookmarksViewListener(@NonNull BookmarksViewDelegate listener) {
         mBookmarksViewListeners.add(listener);
     }
@@ -1050,6 +1058,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         setSession(aSession);
         SessionStore.get().setActiveSession(aSession);
         current.setActive(false);
+        current.captureBackgroundBitmap(getWindowWidth(), getWindowHeight());
         mWidgetManager.getTray().showTabAddedNotification();
     }
 
@@ -1468,7 +1477,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    private void captureImage() {
+    public void captureImage() {
         if (mDisplay != null) {
             mSession.captureBitmap(mDisplay);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -956,6 +956,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             ((VRBrowserApplication)mContext.getApplicationContext()).getAccounts().refreshDevicesAsync();
             ((VRBrowserApplication)mContext.getApplicationContext()).getAccounts().pollForEventsAsync();
         }
+
+        // Capture active session snapshots when showing the tabs menu
+        for (WindowWidget window: getCurrentWindows()) {
+            window.captureImage();
+        }
     }
 
     // TopBarWidget Delegate

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/BitmapCache.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/BitmapCache.java
@@ -203,6 +203,7 @@ public class BitmapCache {
         if (mCapturedAcquired) {
             return null;
         }
+        mCapturedAcquired = true;
         mCaptureSurfaceTexture.setDefaultBufferSize(width, height);
         return mCaptureSurface;
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/BitmapCache.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/BitmapCache.java
@@ -3,9 +3,14 @@ package org.mozilla.vrbrowser.utils;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.SurfaceTexture;
 import android.util.Log;
 import android.util.LruCache;
+import android.view.Surface;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.jakewharton.disklrucache.DiskLruCache;
 
 import org.mozilla.vrbrowser.VRBrowserApplication;
@@ -24,6 +29,9 @@ public class BitmapCache {
     private final Object mLock = new Object();
     private static final int DISK_CACHE_SIZE = 1024 * 1024 * 100; // 100MB
     private static final String LOGTAG = SystemUtils.createLogtag(BitmapCache.class);
+    private SurfaceTexture mCaptureSurfaceTexture;
+    private Surface mCaptureSurface;
+    private boolean mCapturedAcquired;
 
     public static BitmapCache getInstance(Context aContext) {
         return ((VRBrowserApplication)aContext.getApplicationContext()).getBitmapCache();
@@ -33,6 +41,9 @@ public class BitmapCache {
         mContext = aContext;
         mIOExecutor = aIOExecutor;
         mMainThreadExecutor = aMainThreadExecutor;
+    }
+
+    public void onCreate() {
         initMemoryCache();
         initDiskCache();
     }
@@ -181,5 +192,43 @@ public class BitmapCache {
         });
 
         return result;
+    }
+
+    public void setCaptureSurface(SurfaceTexture aSurfaceTexture) {
+        mCaptureSurfaceTexture = aSurfaceTexture;
+        mCaptureSurface = new Surface(aSurfaceTexture);
+    }
+
+    public @Nullable Surface acquireCaptureSurface(int width, int height) {
+        if (mCapturedAcquired) {
+            return null;
+        }
+        mCaptureSurfaceTexture.setDefaultBufferSize(width, height);
+        return mCaptureSurface;
+    }
+
+    public void releaseCaptureSurface() {
+        mCapturedAcquired = false;
+    }
+
+    public void onDestroy() {
+        if (mDiskCache != null) {
+            runIO(() -> {
+                try {
+                    mDiskCache.close();
+                } catch (IOException ex) {
+                    Log.e(LOGTAG, "Failed to close DiskLruCache:" + ex.getMessage());
+                }
+                mDiskCache = null;
+            });
+        }
+        if (mCaptureSurface != null) {
+            mCaptureSurface.release();
+            mCaptureSurface = null;
+        }
+        if (mCaptureSurfaceTexture != null) {
+            mCaptureSurfaceTexture.release();
+            mCaptureSurfaceTexture = null;
+        }
     }
 }


### PR DESCRIPTION
Capture tab snapshots when stacking sessions and opening the tabs dialog. It uses a background display/surface when stacking sessions. For other situations we don't need to capture in background because the actions are originated from the tabs panel, which captures snapshots of active sessions now.