### PR TITLE
Whats new dialog fixes

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
-import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -43,6 +42,7 @@ import org.mozilla.geckoview.GeckoRuntime;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.geckoview.GeckoVRManager;
 import org.mozilla.vrbrowser.audio.AudioEngine;
+import org.mozilla.vrbrowser.browser.Accounts;
 import org.mozilla.vrbrowser.browser.PermissionDelegate;
 import org.mozilla.vrbrowser.browser.SettingsStore;
 import org.mozilla.vrbrowser.browser.engine.Session;
@@ -326,10 +326,21 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         // Show the what's upp dialog if we haven't showed it yet and this is v6.
         if (!SettingsStore.getInstance(this).isWhatsNewDisplayed() && BuildConfig.VERSION_NAME.equals("6")) {
-            WhatsNewWidget whatsNew = new WhatsNewWidget(this);
+            final WhatsNewWidget whatsNew = new WhatsNewWidget(this);
+            whatsNew.setLoginOrigin(Accounts.LoginOrigin.NONE);
             whatsNew.getPlacement().parentHandle = mWindows.getFocusedWindow().getHandle();
-            whatsNew.setStartBrowsingCallback(() -> whatsNew.hide(UIWidget.REMOVE_WIDGET));
-            whatsNew.setSignInCallback(() -> whatsNew.hide(UIWidget.REMOVE_WIDGET));
+            whatsNew.setStartBrowsingCallback(() -> {
+                whatsNew.hide(UIWidget.REMOVE_WIDGET);
+                whatsNew.releaseWidget();
+            });
+            whatsNew.setSignInCallback(() -> {
+                whatsNew.hide(UIWidget.REMOVE_WIDGET);
+                whatsNew.releaseWidget();
+            });
+            whatsNew.setDelegate(() -> {
+                whatsNew.hide(UIWidget.REMOVE_WIDGET);
+                whatsNew.releaseWidget();
+            });
             whatsNew.show(UIWidget.REQUEST_FOCUS);
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
@@ -41,10 +41,10 @@ class Accounts constructor(val context: Context) {
         HISTORY,
         SETTINGS,
         SEND_TABS,
-        UNDEFINED
+        NONE
     }
 
-    var loginOrigin: LoginOrigin = LoginOrigin.UNDEFINED
+    var loginOrigin: LoginOrigin = LoginOrigin.NONE
     var accountStatus = AccountStatus.SIGNED_OUT
     private val accountListeners = ArrayList<AccountObserver>()
     private val syncListeners = ArrayList<SyncStatusObserver>()

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
@@ -181,6 +181,10 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
                 mSendTabsDialogBinding.devicesList.setOptions(devicesNamesList.toArray(new String[]{}));
             }
 
+            if (!mDevicesList.isEmpty()) {
+                mSendTabsDialogBinding.devicesList.setChecked(0, false);
+            }
+
             mSendTabsDialogBinding.setIsEmpty(mDevicesList.isEmpty());
             mBinding.footerLayout.setFooterButtonVisibility(mDevicesList.isEmpty() ? View.GONE : View.VISIBLE);
         });

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
@@ -10,14 +10,17 @@ import android.view.LayoutInflater;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 
 import org.jetbrains.annotations.NotNull;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.Accounts;
+import org.mozilla.vrbrowser.browser.engine.Session;
 import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.databinding.SendTabsDisplayBinding;
+import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 
@@ -26,18 +29,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import mozilla.components.concept.sync.AccountObserver;
+import mozilla.components.concept.sync.AuthType;
 import mozilla.components.concept.sync.ConstellationState;
 import mozilla.components.concept.sync.Device;
 import mozilla.components.concept.sync.DeviceCapability;
 import mozilla.components.concept.sync.DeviceConstellationObserver;
+import mozilla.components.concept.sync.OAuthAccount;
+import mozilla.components.concept.sync.Profile;
 
 public class SendTabDialogWidget extends SettingDialogWidget implements
         DeviceConstellationObserver,
+        AccountObserver,
         WidgetManagerDelegate.WorldClickListener {
 
     private SendTabsDisplayBinding mSendTabsDialogBinding;
     private Accounts mAccounts;
     private List<Device> mDevicesList = new ArrayList<>();
+    private WhatsNewWidget mWhatsNew;
+    private String mSessionId;
 
     public SendTabDialogWidget(@NonNull Context aContext) {
         super(aContext);
@@ -55,23 +65,13 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
         mSendTabsDialogBinding.setIsEmpty(false);
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
+        mAccounts.addAccountListener(this);
         mAccounts.addDeviceConstellationListener(this);
 
         mBinding.headerLayout.setTitle(getResources().getString(R.string.send_tab_dialog_title));
         mBinding.headerLayout.setDescription(R.string.send_tab_dialog_description);
         mBinding.footerLayout.setFooterButtonText(R.string.send_tab_dialog_button);
-        mBinding.footerLayout.setFooterButtonClickListener(v -> {
-            Device device = mDevicesList.get(mSendTabsDialogBinding.devicesList.getCheckedRadioButtonId());
-            String uri = SessionStore.get().getActiveSession().getCurrentUri();
-            String title = SessionStore.get().getActiveSession().getCurrentTitle();
-            // At some point we will support sending to multiple devices or to all of them
-            mAccounts.sendTabs(Collections.singletonList(device), uri, title);
-
-            // Show the tab sent notifications in the tray
-            mWidgetManager.getTray().showTabSentNotification();
-
-            onDismiss();
-        });
+        mBinding.footerLayout.setFooterButtonClickListener(this::sendTabButtonClick);
 
         mWidgetPlacement.width = WidgetPlacement.dpDimension(getContext(), R.dimen.cache_app_dialog_width);
     }
@@ -89,6 +89,7 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
 
     @Override
     public void releaseWidget() {
+        mAccounts.removeAccountListener(this);
         mAccounts.removeDeviceConstellationListener(this);
 
         super.releaseWidget();
@@ -100,15 +101,14 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
             mAccounts.refreshDevicesAsync();
             mSendTabsDialogBinding.setIsSyncing(true);
 
+            mWidgetManager.addWorldClickListener(this);
+            mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
+
+            super.show(aShowFlags);
+
         } else {
-            mSendTabsDialogBinding.setIsEmpty(true);
-            mBinding.footerLayout.setFooterButtonVisibility(View.GONE);
+            showWhatsNewDialog();
         }
-
-        mWidgetManager.addWorldClickListener(this);
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-
-        super.show(aShowFlags);
     }
 
     @Override
@@ -118,6 +118,53 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
         mWidgetManager.popWorldBrightness(this);
         mWidgetManager.removeWorldClickListener(this);
     }
+
+    public void setSessionId(@Nullable String sessionId) {
+        mSessionId = sessionId;
+    }
+
+    private void sendTabButtonClick(View v) {
+        Device device = mDevicesList.get(mSendTabsDialogBinding.devicesList.getCheckedRadioButtonId());
+        Session session = SessionStore.get().getActiveSession();
+        if (mSessionId != null) {
+            session = SessionStore.get().getSession(mSessionId);
+        }
+
+        // At some point we will support sending to multiple devices or to all of them
+        mAccounts.sendTabs(Collections.singletonList(device), session.getCurrentUri(), session.getCurrentTitle());
+
+        // Show the tab sent notifications in the tray
+        mWidgetManager.getTray().showTabSentNotification();
+
+        onDismiss();
+    }
+
+    private void showWhatsNewDialog() {
+        mWhatsNew = new WhatsNewWidget(getContext());
+        mWhatsNew.setLoginOrigin(Accounts.LoginOrigin.SEND_TABS);
+        mWhatsNew.getPlacement().parentHandle = mWidgetManager.getFocusedWindow().getHandle();
+        mWhatsNew.setStartBrowsingCallback(() -> {
+            mWhatsNew.hide(REMOVE_WIDGET);
+            mWhatsNew.releaseWidget();
+            mWhatsNew = null;
+            onDismiss();
+        });
+        mWhatsNew.setSignInCallback(() -> {
+            mWhatsNew.hide(REMOVE_WIDGET);
+            mWhatsNew.releaseWidget();
+            mWhatsNew = null;
+            hide(KEEP_WIDGET);
+        });
+        mWhatsNew.setDelegate(() -> {
+            mWhatsNew.hide(REMOVE_WIDGET);
+            mWhatsNew.releaseWidget();
+            mWhatsNew = null;
+            onDismiss();
+        });
+        mWhatsNew.show(UIWidget.REQUEST_FOCUS);
+    }
+
+    // DeviceConstellationObserver
 
     @Override
     public void onDevicesUpdate(@NotNull ConstellationState constellationState) {
@@ -137,6 +184,36 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
             mSendTabsDialogBinding.setIsEmpty(mDevicesList.isEmpty());
             mBinding.footerLayout.setFooterButtonVisibility(mDevicesList.isEmpty() ? View.GONE : View.VISIBLE);
         });
+    }
+
+    // AccountObserver
+
+    @Override
+    public void onLoggedOut() {
+        if (isVisible()) {
+            hide(KEEP_WIDGET);
+        }
+        showWhatsNewDialog();
+    }
+
+    @Override
+    public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+        if (mAccounts.getLoginOrigin() == Accounts.LoginOrigin.SEND_TABS) {
+            show(REQUEST_FOCUS);
+        }
+    }
+
+    @Override
+    public void onProfileUpdated(@NotNull Profile profile) {
+
+    }
+
+    @Override
+    public void onAuthenticationProblems() {
+        if (isVisible()) {
+            hide(KEEP_WIDGET);
+        }
+        showWhatsNewDialog();
     }
 
     // WidgetManagerDelegate.WorldClickListener


### PR DESCRIPTION
This PR fixes two things:
- Send the target tab from the tabs panel, we were sending the active session instead of the one the user is actually sending.
- The initial what's new dialog went to the tabs panel after login. Now it just stays in the browser window.
- Better handling the Send tab -> What's new flow.