### PR TITLE
Upgrade to AC 19.0.1 to get app_channel telemetry back.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -36,7 +36,7 @@ public class GleanMetricsService {
         } else {
             GleanMetricsService.stop();
         }
-        Configuration config = new Configuration();
+        Configuration config = new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT, BuildConfig.BUILD_TYPE);
         Glean.INSTANCE.initialize(aContext, config);
     }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,7 @@ def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
 versions.gecko_view = "72.0.20191029093803"
-versions.android_components = "19.0.0"
+versions.android_components = "19.0.1"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"


### PR DESCRIPTION
This is a minor fix for app_channel missing in AC 19.0.0. After upgrading to AC 19.0.1, it can get back. The only difference between 19.0.0 and 19.0.1 is Glean bug fixes [1]. We can either choose to merge it to Firefox Reality 6 or hold it until we start the work of the next release.

[1] https://github.com/mozilla-mobile/android-components/compare/v19.0.0...v19.0.1