### PR TITLE
Fix wrongly displayed "Pause/Play" button

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -297,6 +297,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 mTray.setAddWindowVisible(mWindows.canOpenNewWindow());
                 updateWidget(mTray);
             }
+
+            @Override
+            public void onWindowVideoAvailabilityChanged(@NonNull WindowWidget aWindow) {
+                @CPULevelFlags int cpuLevel = mWindows.isVideoAvailable() ? WidgetManagerDelegate.CPU_LEVEL_HIGH :
+                        WidgetManagerDelegate.CPU_LEVEL_NORMAL;
+
+                queueRunnable(() -> setCPULevelNative(cpuLevel));
+            }
         });
 
         // Create Browser navigation widget
@@ -1410,11 +1418,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public float getCylinderDensity() {
         return mCurrentCylinderDensity;
-    }
-
-    @Override
-    public void setCPULevel(int aCPULevel) {
-        queueRunnable(() -> setCPULevelNative(aCPULevel));
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -187,6 +187,10 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         for (GeckoSession.ContentDelegate listener: mContentListeners) {
             dumpState(listener);
         }
+
+        for (VideoAvailabilityListener listener: mVideoAvailabilityListeners) {
+            dumpState(listener);
+        }
     }
 
     private void dumpState(GeckoSession.NavigationDelegate aListener) {
@@ -211,6 +215,10 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
     private void dumpState(GeckoSession.ContentDelegate aListener) {
         aListener.onTitleChange(mState.mSession, mState.mTitle);
+    }
+
+    private void dumpState(VideoAvailabilityListener aListener) {
+        aListener.onVideoAvailabilityChanged(mState.mMediaElements != null && mState.mMediaElements.size() > 0);
     }
 
     public void setPermissionDelegate(GeckoSession.PermissionDelegate aDelegate) {
@@ -270,6 +278,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
     public void addVideoAvailabilityListener(VideoAvailabilityListener aListener) {
         mVideoAvailabilityListeners.add(aListener);
+        dumpState(aListener);
     }
 
     public void removeVideoAvailabilityListener(VideoAvailabilityListener aListener) {
@@ -491,6 +500,10 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
     public boolean isSecure() {
         return mState.mSecurityInformation != null && mState.mSecurityInformation.isSecure;
+    }
+
+    public boolean isVideoAvailable() {
+        return mState.mMediaElements != null && mState.mMediaElements.size() > 0;
     }
 
     public Media getFullScreenVideo() {
@@ -1157,10 +1170,8 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         Media media = new Media(element);
         mState.mMediaElements.add(media);
 
-        if (mState.mMediaElements.size() == 1) {
-            for (VideoAvailabilityListener listener: mVideoAvailabilityListeners) {
-                listener.onVideoAvailabilityChanged(true);
-            }
+        for (VideoAvailabilityListener listener: mVideoAvailabilityListeners) {
+            listener.onVideoAvailabilityChanged(true);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -121,7 +121,7 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
 
     @Override
     public void setVisible(boolean aIsVisible) {
-        if (mVisible == aIsVisible) {
+        if (mVisible == aIsVisible || mWidgetManager == null) {
             return;
         }
         mVisible = aIsVisible;
@@ -179,14 +179,18 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
     }
 
     public void mediaAvailabilityChanged(boolean available) {
-        mBinding.setIsMediaAvailable(false);
+        if (mMedia != null) {
+            mMedia.removeMediaListener(mMediaDelegate);
+        }
         if (available) {
             mMedia = mAttachedWindow.getSession().getFullScreenVideo();
             if (mMedia != null) {
+                mBinding.setIsMediaAvailable(true);
                 mBinding.setIsMediaPlaying(mMedia.isPlaying());
-                mMedia.removeMediaListener(mMediaDelegate);
                 mMedia.addMediaListener(mMediaDelegate);
             }
+        } else {
+            mBinding.setIsMediaAvailable(false);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
@@ -71,7 +71,6 @@ public interface WidgetManagerDelegate {
     void resetUIYaw();
     void setCylinderDensity(float aDensity);
     float getCylinderDensity();
-    void setCPULevel(@VRBrowserActivity.CPULevelFlags int aCPULevel);
     void addFocusChangeListener(@NonNull FocusChangeListener aListener);
     void removeFocusChangeListener(@NonNull FocusChangeListener aListener);
     void addPermissionListener(PermissionListener aListener);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -140,6 +140,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         default void onFocusRequest(@NonNull WindowWidget aWindow) {}
         default void onBorderChanged(@NonNull WindowWidget aWindow) {}
         default void onSessionChanged(@NonNull Session aOldSession, @NonNull Session aSession) {}
+        default void onVideoAvailabilityChanged(@NonNull WindowWidget aWindow) {}
     }
 
     public WindowWidget(Context aContext, int windowId, boolean privateMode)  {
@@ -1472,12 +1473,12 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public void onVideoAvailabilityChanged(boolean aVideosAvailable) {
-        mWidgetManager.setCPULevel(aVideosAvailable ?
-                WidgetManagerDelegate.CPU_LEVEL_HIGH :
-                WidgetManagerDelegate.CPU_LEVEL_NORMAL);
-
         if (mTitleBar != null) {
             mTitleBar.mediaAvailabilityChanged(aVideosAvailable);
+        }
+
+        for (WindowListener listener: mListeners) {
+            listener.onVideoAvailabilityChanged(this);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -123,6 +123,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         void onWindowBorderChanged(@NonNull WindowWidget aChangeWindow);
         void onWindowsMoved();
         void onWindowClosed();
+        void onWindowVideoAvailabilityChanged(@NonNull WindowWidget aWindow);
     }
 
     public Windows(Context aContext) {
@@ -440,6 +441,16 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
     public boolean isInPrivateMode() {
         return mPrivateMode;
+    }
+
+    public boolean isVideoAvailable() {
+        for (WindowWidget window: getCurrentWindows()) {
+            if (window.getSession().isVideoAvailable()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void enterImmersiveMode() {
@@ -1090,7 +1101,13 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         if (mDelegate != null) {
             mDelegate.onWindowBorderChanged(aWindow);
         }
+    }
 
+    @Override
+    public void onVideoAvailabilityChanged(@NonNull WindowWidget aWindow) {
+        if (mDelegate != null) {
+            mDelegate.onWindowVideoAvailabilityChanged(aWindow);
+        }
     }
 
     @Override


### PR DESCRIPTION
- Fix wrongly displayed "Pause/Play" button.
- Take into account all windows to set CPU level based on video availability.

fixes #2098

