### PR TITLE
Make the UI react faster to page loads

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1487,6 +1487,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     @Override
     public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String s) {
         mCaptureOnPageStop = true;
+
+        if (isHistoryVisible()) {
+            hideHistory();
+        }
+
+        if (isBookmarksVisible()) {
+            hideBookmarks();
+        }
     }
 
     @Override
@@ -1505,13 +1513,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public void onLocationChange(@NonNull GeckoSession session, @Nullable String url) {
-        if (isBookmarksVisible()) {
-            hideBookmarks();
-
-        } else if (isHistoryVisible()) {
-            hideHistory();
-        }
-
         updateTitleBarUrl(url);
     }
 


### PR DESCRIPTION
Improve the UI change reaction time when loading pages. ie. when loading a history/bookmarks item it when initiating a login flow. 

Instead of reacting on page load callback we just hide on page start, helps improve the responsiveness perception.