### PR TITLE
Fixes issues after switching the tracking protection

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -723,7 +723,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     protected void setTrackingProtection(final boolean aEnabled) {
         if (mState.mSettings.isTrackingProtectionEnabled() != aEnabled) {
             mState.mSettings.setTrackingProtectionEnabled(aEnabled);
-            recreateSession();
+            mState.mSession.getSettings().setUseTrackingProtection(aEnabled);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -404,6 +404,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         if (previous.mSession != null) {
             closeSession(previous.mSession);
         }
+        setupSessionListeners(mState.mSession);
 
         for (SessionChangeListener listener : mSessionChangeListeners) {
             listener.onCurrentSessionChange(previous.mSession, mState.mSession);


### PR DESCRIPTION
Fixes #2121 This fixes the underlying cause that was that the session was not being properly recreated and affected multiprocess switch and caches clear. 

We actually don't need to recreate for switching the tracking protection so just update the settings now in that case.