### PR TITLE
Prevent voice search from getting stuck in a cancel loop

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -200,9 +200,8 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
                         setResultState();
                         break;
                     case CANCELED:
-                        // Handle when a cancelation was fully executed
+                        // Handle when a cancellation was fully executed
                         Log.d(LOGTAG, "===> CANCELED");
-                        setResultState();
                         if (mDelegate != null) {
                             mDelegate.OnVoiceSearchCanceled();
                         }


### PR DESCRIPTION
Fixes #1988 Fixes #1989
The search widget would call mMozillaSpeechService.cancel() after
receiving a CANCELED status change and get stuck in a continuous loop.