### PR TITLE
FxA updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -461,6 +461,22 @@ dependencies {
     implementation deps.android_components.support_rusthttp
     implementation deps.android_components.glean
 
+    // For production builds, the native code for all `org.mozilla.appservices`
+    // dependencies gets compiled together into a single "megazord" build, and
+    // different megazords are published for different subsets of features. Ref
+    // https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html
+    // For now we can jut use the one that's specifically designed for Fenix.
+    implementation deps.app_services.megazord
+    testImplementation deps.app_services.megazord_forUnitTests
+    modules {
+        module('org.mozilla.appservices:full-megazord') {
+            replacedBy('org.mozilla.appservices:fenix-megazord', 'prefer the fenix megazord, to reduce final application size')
+        }
+        module('org.mozilla.appservices:fenix-megazord') {
+            replacedBy('org.mozilla.appservices:fenix-megazord-forUnitTests', 'prefer the forUnitTests variant if present')
+        }
+    }
+
     // TODO this should not be necessary at all, see Services.kt
     implementation deps.work.runtime
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -14,6 +14,7 @@ import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import mozilla.appservices.Megazord
 import mozilla.components.concept.sync.*
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.fxa.*
@@ -45,6 +46,7 @@ class Services(context: Context, places: Places): GeckoSession.NavigationDelegat
 
     // This makes bookmarks storage accessible to background sync workers.
     init {
+        Megazord.init()
         RustLog.enable()
         RustHttpConfig.setClient(lazy { EngineProvider.createClient(context) })
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -53,6 +53,20 @@ class Services(context: Context, places: Places): GeckoSession.NavigationDelegat
 
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Bookmarks to places.bookmarks)
         GlobalSyncableStoreProvider.configureStore(SyncEngine.History to places.history)
+
+        // TODO this really shouldn't be necessary, since WorkManager auto-initializes itself, unless
+        // auto-initialization is disabled in the manifest file. We don't disable the initialization,
+        // but i'm seeing crashes locally because WorkManager isn't initialized correctly...
+        // Maybe this is a race of sorts? We're trying to access it before it had a chance to auto-initialize?
+        // It's not well-documented _when_ that auto-initialization is supposed to happen.
+
+        // For now, let's just manually initialize it here, and swallow failures (it's already initialized).
+        try {
+            WorkManager.initialize(
+                    context,
+                    Configuration.Builder().setMinimumLoggingLevel(android.util.Log.INFO).build()
+            )
+        } catch (e: IllegalStateException) {}
     }
 
     // Process received device events, only handling received tabs for now.

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -28,6 +28,9 @@ import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.vrbrowser.R
+import org.mozilla.vrbrowser.browser.engine.EngineProvider
+import org.mozilla.vrbrowser.browser.engine.GeckoViewFetchClient
+import org.mozilla.vrbrowser.browser.engine.SessionStore
 
 class Services(context: Context, places: Places): GeckoSession.NavigationDelegate {
     companion object {
@@ -43,7 +46,7 @@ class Services(context: Context, places: Places): GeckoSession.NavigationDelegat
     // This makes bookmarks storage accessible to background sync workers.
     init {
         RustLog.enable()
-        RustHttpConfig.setClient(lazy { HttpURLConnectionClient() })
+        RustHttpConfig.setClient(lazy { EngineProvider.createClient(context) })
 
         // Make sure we get logs out of our android-components.
         Log.addSink(AndroidLogSink())

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -53,20 +53,6 @@ class Services(context: Context, places: Places): GeckoSession.NavigationDelegat
 
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Bookmarks to places.bookmarks)
         GlobalSyncableStoreProvider.configureStore(SyncEngine.History to places.history)
-
-        // TODO this really shouldn't be necessary, since WorkManager auto-initializes itself, unless
-        // auto-initialization is disabled in the manifest file. We don't disable the initialization,
-        // but i'm seeing crashes locally because WorkManager isn't initialized correctly...
-        // Maybe this is a race of sorts? We're trying to access it before it had a chance to auto-initialize?
-        // It's not well-documented _when_ that auto-initialization is supposed to happen.
-
-        // For now, let's just manually initialize it here, and swallow failures (it's already initialized).
-        try {
-            WorkManager.initialize(
-                    context,
-                    Configuration.Builder().setMinimumLoggingLevel(android.util.Log.INFO).build()
-            )
-        } catch (e: IllegalStateException) {}
     }
 
     // Process received device events, only handling received tabs for now.

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.browser.engine
+
+import android.content.Context
+import mozilla.components.concept.fetch.Client
+import org.mozilla.geckoview.ContentBlocking
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
+import org.mozilla.geckoview.WebExtension
+import org.mozilla.vrbrowser.BuildConfig
+import org.mozilla.vrbrowser.browser.SettingsStore
+import org.mozilla.vrbrowser.crashreporting.CrashReporterService
+
+object EngineProvider {
+
+    private val WEB_EXTENSIONS = arrayOf("webcompat_vimeo", "webcompat_youtube")
+
+    private var runtime: GeckoRuntime? = null
+
+    @Synchronized
+    fun getOrCreateRuntime(context: Context): GeckoRuntime {
+        if (runtime == null) {
+            val builder = GeckoRuntimeSettings.Builder()
+
+            builder.crashHandler(CrashReporterService::class.java)
+            builder.contentBlocking(ContentBlocking.Settings.Builder()
+                    .antiTracking(ContentBlocking.AntiTracking.AD or ContentBlocking.AntiTracking.SOCIAL or ContentBlocking.AntiTracking.ANALYTIC)
+                    .build())
+            builder.consoleOutput(SettingsStore.getInstance(context).isConsoleLogsEnabled)
+            builder.displayDensityOverride(SettingsStore.getInstance(context).displayDensity)
+            builder.remoteDebuggingEnabled(SettingsStore.getInstance(context).isRemoteDebuggingEnabled)
+            builder.displayDpiOverride(SettingsStore.getInstance(context).displayDpi)
+            builder.screenSizeOverride(SettingsStore.getInstance(context).maxWindowWidth,
+                    SettingsStore.getInstance(context).maxWindowHeight)
+            builder.autoplayDefault(if (SettingsStore.getInstance(context).isAutoplayEnabled) GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED else GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED)
+
+            if (SettingsStore.getInstance(context).transparentBorderWidth > 0) {
+                builder.useMaxScreenDepth(true)
+            }
+
+            if (BuildConfig.DEBUG) {
+                builder.arguments(arrayOf("-purgecaches"))
+                builder.debugLogging(true)
+                builder.aboutConfigEnabled(true)
+            } else {
+                builder.debugLogging(SettingsStore.getInstance(context).isDebugLogginEnabled)
+            }
+
+            runtime = GeckoRuntime.create(context, builder.build())
+            for (extension in WEB_EXTENSIONS) {
+                val path = "resource://android/assets/web_extensions/$extension/"
+                runtime!!.registerWebExtension(WebExtension(path))
+            }
+
+
+        }
+
+        return runtime!!
+    }
+
+    fun createClient(context: Context): Client {
+        val runtime = getOrCreateRuntime(context)
+        return GeckoViewFetchClient(context, runtime)
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -14,8 +14,6 @@ import org.mozilla.geckoview.ContentBlocking;
 import org.mozilla.geckoview.GeckoRuntime;
 import org.mozilla.geckoview.GeckoRuntimeSettings;
 import org.mozilla.geckoview.GeckoSession;
-import org.mozilla.geckoview.WebExtension;
-import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.BookmarksStore;
 import org.mozilla.vrbrowser.browser.HistoryStore;
@@ -32,11 +30,6 @@ import java.util.List;
 public class SessionStore implements GeckoSession.PermissionDelegate {
     private static final String LOGTAG = SystemUtils.createLogtag(SessionStore.class);
     private static final int MAX_GECKO_SESSIONS = 5;
-
-    private static final String[] WEB_EXTENSIONS = new String[] {
-            "webcompat_vimeo",
-            "webcompat_youtube"
-    };
 
     private static SessionStore mInstance;
 
@@ -64,48 +57,10 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
     public void setContext(Context context, Bundle aExtras) {
         mContext = context;
 
-        if (mRuntime == null) {
-            // FIXME: Once GeckoView has a prefs API
-            SessionUtils.vrPrefsWorkAround(context, aExtras);
+        mRuntime = EngineProvider.INSTANCE.getOrCreateRuntime(context);
 
-            GeckoRuntimeSettings.Builder runtimeSettingsBuilder = new GeckoRuntimeSettings.Builder();
-            runtimeSettingsBuilder.crashHandler(CrashReporterService.class);
-            runtimeSettingsBuilder.contentBlocking((new ContentBlocking.Settings.Builder()
-                    .antiTracking(ContentBlocking.AntiTracking.AD | ContentBlocking.AntiTracking.SOCIAL| ContentBlocking.AntiTracking.ANALYTIC))
-                    .build());
-            runtimeSettingsBuilder.consoleOutput(SettingsStore.getInstance(context).isConsoleLogsEnabled());
-            runtimeSettingsBuilder.displayDensityOverride(SettingsStore.getInstance(context).getDisplayDensity());
-            runtimeSettingsBuilder.remoteDebuggingEnabled(SettingsStore.getInstance(context).isRemoteDebuggingEnabled());
-            runtimeSettingsBuilder.displayDpiOverride(SettingsStore.getInstance(context).getDisplayDpi());
-            runtimeSettingsBuilder.screenSizeOverride(SettingsStore.getInstance(context).getMaxWindowWidth(),
-                    SettingsStore.getInstance(context).getMaxWindowHeight());
-            runtimeSettingsBuilder.autoplayDefault(SettingsStore.getInstance(mContext).isAutoplayEnabled() ? GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED : GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED);
-
-            if (SettingsStore.getInstance(context).getTransparentBorderWidth() > 0) {
-                runtimeSettingsBuilder.useMaxScreenDepth(true);
-            }
-
-            if (BuildConfig.DEBUG) {
-                runtimeSettingsBuilder.arguments(new String[] { "-purgecaches" });
-                runtimeSettingsBuilder.debugLogging(true);
-                runtimeSettingsBuilder.aboutConfigEnabled(true);
-            } else {
-                runtimeSettingsBuilder.debugLogging(SettingsStore.getInstance(context).isDebugLogginEnabled());
-            }
-
-            mRuntime = GeckoRuntime.create(context, runtimeSettingsBuilder.build());
-            for (String extension: WEB_EXTENSIONS) {
-                String path = "resource://android/assets/web_extensions/" + extension + "/";
-                mRuntime.registerWebExtension(new WebExtension(path));
-            }
-
-        } else {
-            mRuntime.attachTo(context);
-        }
-    }
-
-    public GeckoRuntime getRuntime() {
-        return mRuntime;
+        // FIXME: Once GeckoView has a prefs API
+        SessionUtils.vrPrefsWorkAround(context, aExtras);
     }
 
     public void initializeServices() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -57,10 +57,10 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
     public void setContext(Context context, Bundle aExtras) {
         mContext = context;
 
-        mRuntime = EngineProvider.INSTANCE.getOrCreateRuntime(context);
-
         // FIXME: Once GeckoView has a prefs API
         SessionUtils.vrPrefsWorkAround(context, aExtras);
+
+        mRuntime = EngineProvider.INSTANCE.getOrCreateRuntime(context);
     }
 
     public void initializeServices() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -230,6 +230,8 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
                             WidgetManagerDelegate widgetManager = ((VRBrowserActivity) getContext());
                             widgetManager.openNewTabForeground(url);
                             widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+
+                            mBookmarksViewListeners.forEach((listener) -> listener.onFxALogin(view));
                         }
 
                     }, mUIThreadExecutor).exceptionally(throwable -> {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -214,13 +214,21 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
         @Override
         public void onFxALogin(@NonNull View view) {
-            mAccounts.getAuthenticationUrlAsync().thenAcceptAsync((url) -> {
-                if (url != null) {
-                    mAccounts.setLoginOrigin(Accounts.LoginOrigin.BOOKMARKS);
-                    WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
-                    widgetManager.openNewTabForeground(url);
-                    widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
-                }
+            if (mAccounts.getAccountStatus() == Accounts.AccountStatus.SIGNED_IN) {
+                mAccounts.logoutAsync();
+
+            } else {
+                mAccounts.authUrlAsync().thenAcceptAsync((url) -> {
+                    if (url == null) {
+                        mAccounts.logoutAsync();
+
+                    } else {
+                        mAccounts.setLoginOrigin(Accounts.LoginOrigin.BOOKMARKS);
+                        WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
+                        widgetManager.openNewTabForeground(url);
+                        widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+                    }
+
             }, mUIThreadExecutor).exceptionally(throwable -> {
                 Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
                 throwable.printStackTrace();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -40,6 +40,7 @@ import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import mozilla.appservices.places.BookmarkRoot;
@@ -218,22 +219,26 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
                 mAccounts.logoutAsync();
 
             } else {
-                mAccounts.authUrlAsync().thenAcceptAsync((url) -> {
-                    if (url == null) {
-                        mAccounts.logoutAsync();
+                CompletableFuture<String> result = mAccounts.authUrlAsync();
+                if (result != null) {
+                    result.thenAcceptAsync((url) -> {
+                        if (url == null) {
+                            mAccounts.logoutAsync();
 
-                    } else {
-                        mAccounts.setLoginOrigin(Accounts.LoginOrigin.BOOKMARKS);
-                        WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
-                        widgetManager.openNewTabForeground(url);
-                        widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
-                    }
+                        } else {
+                            mAccounts.setLoginOrigin(Accounts.LoginOrigin.BOOKMARKS);
+                            WidgetManagerDelegate widgetManager = ((VRBrowserActivity) getContext());
+                            widgetManager.openNewTabForeground(url);
+                            widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+                        }
 
-            }, mUIThreadExecutor).exceptionally(throwable -> {
-                Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
-                throwable.printStackTrace();
-                return null;
-            });
+                    }, mUIThreadExecutor).exceptionally(throwable -> {
+                        Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
+                        throwable.printStackTrace();
+                        return null;
+                    });
+                }
+            }
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -211,13 +211,21 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
         @Override
         public void onFxALogin(@NonNull View view) {
-            mAccounts.getAuthenticationUrlAsync().thenAcceptAsync((url) -> {
-                if (url != null) {
-                    mAccounts.setLoginOrigin(Accounts.LoginOrigin.HISTORY);
-                    WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
-                    widgetManager.openNewTabForeground(url);
-                    widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
-                }
+            if (mAccounts.getAccountStatus() == Accounts.AccountStatus.SIGNED_IN) {
+                mAccounts.logoutAsync();
+
+            } else {
+                mAccounts.authUrlAsync().thenAcceptAsync((url) -> {
+                    if (url == null) {
+                        mAccounts.logoutAsync();
+
+                    } else {
+                        mAccounts.setLoginOrigin(Accounts.LoginOrigin.HISTORY);
+                        WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
+                        widgetManager.openNewTabForeground(url);
+                        widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+                    }
+
             }, mUIThreadExecutor).exceptionally(throwable -> {
                 Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
                 throwable.printStackTrace();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -227,6 +227,8 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
                             WidgetManagerDelegate widgetManager = ((VRBrowserActivity) getContext());
                             widgetManager.openNewTabForeground(url);
                             widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+
+                            mHistoryViewListeners.forEach((listener) -> listener.onFxALogin(view));
                         }
 
                     }, mUIThreadExecutor).exceptionally(throwable -> {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1428,6 +1428,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         public void onItemClicked(@NonNull View view, Bookmark item) {
             hideBookmarks();
         }
+
+        @Override
+        public void onFxALogin(@NonNull View view) {
+            hideBookmarks();
+        }
     };
 
     private HistoryCallback mHistoryListener = new HistoryCallback() {
@@ -1460,6 +1465,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onItemClicked(@NonNull View view, VisitInfo item) {
+            hideHistory();
+        }
+
+        @Override
+        public void onFxALogin(@NonNull View view) {
             hideHistory();
         }
     };

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
@@ -99,17 +99,20 @@ public class WhatsNewWidget extends UIDialog implements WidgetManagerDelegate.Wo
     }
 
     private void signIn(View view) {
-        mAccounts.getAuthenticationUrlAsync().thenAcceptAsync((url) -> {
-            if (url != null) {
-                mAccounts.setLoginOrigin(mLoginOrigin);
-                mWidgetManager.openNewTabForeground(url);
-                mWidgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_VR);
-                mWidgetManager.getFocusedWindow().getSession().loadUri(url);
-            }
+        if (mAccounts.getAccountStatus() == Accounts.AccountStatus.SIGNED_IN) {
+            mAccounts.logoutAsync();
 
-            if (mSignInCallback != null) {
-                mSignInCallback.run();
-            }
+        } else {
+            mAccounts.authUrlAsync().thenAcceptAsync((url) -> {
+                if (url == null) {
+                    mAccounts.logoutAsync();
+
+                } else {
+                    mAccounts.setLoginOrigin(mLoginOrigin);
+                    mWidgetManager.openNewTabForeground(url);
+                    mWidgetManager.getFocusedWindow().getSession().loadUri(url);
+                    mWidgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_VR);
+                }
 
         }, mUIThreadExecutor).exceptionally(throwable -> {
             Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
@@ -114,6 +114,12 @@ public class WhatsNewWidget extends UIDialog implements WidgetManagerDelegate.Wo
                     mWidgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_VR);
                 }
 
+                if (mSignInCallback != null) {
+                    mSignInCallback.run();
+                }
+
+            }, new UIThreadExecutor());
+        }
         }, mUIThreadExecutor).exceptionally(throwable -> {
             Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
             throwable.printStackTrace();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
@@ -104,6 +104,8 @@ public class WhatsNewWidget extends UIDialog implements WidgetManagerDelegate.Wo
             mAccounts.logoutAsync();
 
         } else {
+            hide(REMOVE_WIDGET);
+
             CompletableFuture<String> result = mAccounts.authUrlAsync();
             if (result != null) {
                 result.thenAcceptAsync((url) -> {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -281,13 +281,21 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
             case SIGNED_OUT:
             case NEEDS_RECONNECT:
                 hide(REMOVE_WIDGET);
-                mAccounts.getAuthenticationUrlAsync().thenAcceptAsync((url) -> {
-                    if (url != null) {
-                        mAccounts.setLoginOrigin(Accounts.LoginOrigin.SETTINGS);
-                        WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
-                        widgetManager.openNewTabForeground(url);
-                        widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
-                    }
+                if (mAccounts.getAccountStatus() == Accounts.AccountStatus.SIGNED_IN) {
+                    mAccounts.logoutAsync();
+
+                    mAccounts.authUrlAsync().thenAcceptAsync((url) -> {
+                } else {
+                        if (url == null) {
+
+                            mAccounts.logoutAsync();
+                        } else {
+                            mAccounts.setLoginOrigin(Accounts.LoginOrigin.SETTINGS);
+                            widgetManager.openNewTabForeground(url);
+                            WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
+                            widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+                        }
+
                 }, mUIThreadExecutor).exceptionally(throwable -> {
                     Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
                     throwable.printStackTrace();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -281,11 +281,12 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
         switch(mAccounts.getAccountStatus()) {
             case SIGNED_OUT:
             case NEEDS_RECONNECT:
-                hide(REMOVE_WIDGET);
                 if (mAccounts.getAccountStatus() == Accounts.AccountStatus.SIGNED_IN) {
                     mAccounts.logoutAsync();
 
                 } else {
+                    hide(REMOVE_WIDGET);
+
                     CompletableFuture<String> result = mAccounts.authUrlAsync();
                     if (result != null) {
                         result.thenAcceptAsync((url) -> {

--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,14 @@ def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
 versions.gecko_view = "72.0.20191118093852"
-versions.android_components = "19.0.1"
+versions.android_components = "21.0.0"
+// Note that android-components also depends on application-services,
+// and in fact is our main source of appservices-related functionality.
+// The version number below tracks the application-services version
+// that we depend on directly for the fenix-megazord (and for it's
+// forUnitTest variant), and it's important that it be kept in
+// sync with the version used by android-components above.
+versions.mozilla_appservices = "0.42.2"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"
@@ -65,6 +72,11 @@ android_components.lib_fetch = "org.mozilla.components:lib-fetch-httpurlconnecti
 android_components.support_rustlog = "org.mozilla.components:support-rustlog:$versions.android_components"
 android_components.support_rusthttp = "org.mozilla.components:support-rusthttp:$versions.android_components"
 deps.android_components = android_components
+
+def app_services = [:]
+app_services.megazord = "org.mozilla.appservices:fenix-megazord:${versions.mozilla_appservices}"
+app_services.megazord_forUnitTests = "org.mozilla.appservices:fenix-megazord-forUnitTests:${versions.mozilla_appservices}"
+deps.app_services = app_services
 
 deps.mozilla_speech = "com.github.mozilla:mozillaspeechlibrary:$versions.mozilla_speech"
 


### PR DESCRIPTION
Closes https://github.com/MozillaReality/FirefoxReality/issues/1397 
This addresses some comments from @grigoryk that didn't make it to the main PR. 

- getAuthenticationUrlAsync function refactoring: https://github.com/MozillaReality/FirefoxReality/pull/1973#discussion_r337533325
- Use a GeckWebExecutor for FxA requests
- Megazord integration: https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html

The WorkManager auto-initialization fix is still there as crashes are still happening without this and we haven't found the cause.