### PR TITLE
Bump GV to 72.0.20191104094118

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "72.0.20191029093803"
+versions.gecko_view = "72.0.20191104094118"
 versions.android_components = "19.0.1"
 versions.mozilla_speech = "1.0.6"
 versions.openwnn = "1.3.7"


### PR DESCRIPTION
Includes the fix for the restore issue.

fixes #1777