### PR TITLE
Bookmarks deletion fix

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -55,7 +55,6 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
     private BookmarksBinding mBinding;
     private Accounts mAccounts;
     private BookmarkAdapter mBookmarkAdapter;
-    private boolean mIgnoreNextListener;
     private ArrayList<BookmarksCallback> mBookmarksViewListeners;
     private CustomLinearLayoutManager mLayoutManager;
 
@@ -113,9 +112,6 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
         mBinding.setIsSignedIn(mAccounts.isSignedIn());
         mBinding.setIsSyncEnabled(mAccounts.isEngineEnabled(SyncEngine.Bookmarks.INSTANCE));
 
-        updateBookmarks();
-        SessionStore.get().getBookmarkStore().addListener(this);
-
         setVisibility(GONE);
 
         setOnTouchListener((v, event) -> {
@@ -147,14 +143,14 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
         public void onDelete(@NonNull View view, @NonNull Bookmark item) {
             mBinding.bookmarksList.requestFocusFromTouch();
 
-            mIgnoreNextListener = true;
-            SessionStore.get().getBookmarkStore().deleteBookmarkById(item.getGuid());
             mBookmarkAdapter.removeItem(item);
             if (mBookmarkAdapter.itemCount() == 0) {
                 mBinding.setIsEmpty(true);
                 mBinding.setIsLoading(false);
                 mBinding.executePendingBindings();
             }
+
+            SessionStore.get().getBookmarkStore().deleteBookmarkById(item.getGuid());
         }
 
         @Override
@@ -322,19 +318,11 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
     @Override
     public void onBookmarksUpdated() {
-        if (mIgnoreNextListener) {
-            mIgnoreNextListener = false;
-            return;
-        }
         updateBookmarks();
     }
 
     @Override
     public void onBookmarkAdded() {
-        if (mIgnoreNextListener) {
-            mIgnoreNextListener = false;
-            return;
-        }
         updateBookmarks();
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -61,7 +61,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
     private HistoryBinding mBinding;
     private Accounts mAccounts;
     private HistoryAdapter mHistoryAdapter;
-    private boolean mIgnoreNextListener;
     private ArrayList<HistoryCallback> mHistoryViewListeners;
 
     public HistoryView(Context aContext) {
@@ -116,9 +115,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         mBinding.setIsSignedIn(mAccounts.isSignedIn());
         mBinding.setIsSyncEnabled(mAccounts.isEngineEnabled(SyncEngine.History.INSTANCE));
 
-        updateHistory();
-        SessionStore.get().getHistoryStore().addListener(this);
-
         setVisibility(GONE);
 
         setOnTouchListener((v, event) -> {
@@ -150,14 +146,14 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         public void onDelete(View view, VisitInfo item) {
             mBinding.historyList.requestFocusFromTouch();
 
-            mIgnoreNextListener = true;
-            SessionStore.get().getHistoryStore().deleteHistory(item.getUrl(), item.getVisitTime());
             mHistoryAdapter.removeItem(item);
             if (mHistoryAdapter.itemCount() == 0) {
                 mBinding.setIsEmpty(true);
                 mBinding.setIsLoading(false);
                 mBinding.executePendingBindings();
             }
+
+            SessionStore.get().getHistoryStore().deleteHistory(item.getUrl(), item.getVisitTime());
         }
 
         @Override
@@ -365,10 +361,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
     @Override
     public void onHistoryUpdated() {
-        if (mIgnoreNextListener) {
-            mIgnoreNextListener = false;
-            return;
-        }
         updateHistory();
     }
 }


### PR DESCRIPTION
Fixes #2143 There was a mIgnoreNextListener flag that was making the update after the deletion to be ignored. I guess it was added to prevent an extra update in the previous Bookmarks implementation and it's been inherited, but I don't think we need it anymore.