### PR TITLE
Fixed wrong thread ui call

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -20,6 +20,7 @@ import org.mozilla.vrbrowser.databinding.OptionsFxaAccountBinding;
 import org.mozilla.vrbrowser.ui.views.settings.SwitchSetting;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.utils.SystemUtils;
+import org.mozilla.vrbrowser.utils.UIThreadExecutor;
 
 import java.util.Objects;
 
@@ -133,7 +134,7 @@ class FxAAccountOptionsView extends SettingsView {
                     updateProfile(profile);
 
                 } else {
-                    Objects.requireNonNull(mAccounts.updateProfileAsync()).thenAcceptAsync((u) -> updateProfile(mAccounts.accountProfile()));
+                    Objects.requireNonNull(mAccounts.updateProfileAsync()).thenAcceptAsync((u) -> updateProfile(mAccounts.accountProfile()), new UIThreadExecutor());
                 }
                 break;
 


### PR DESCRIPTION
Fixes #2103 Fixes issues caused by calling UI code from the wrong thread.

This seems easier to reproduce using the emulator that a device.
STRs:
- Fresh install
- Start a login from settings
- Finish the login process and let it go back to the Account settings panel
- Go back to the main settings panel
- Click on  language settings

Actual result: The language settings is not visible although is there

Expected: All the widgets should be visible