### PR TITLE
Fix the open windows weighted mean calculation

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -509,7 +509,7 @@ public class TelemetryWrapper {
             Log.d(LOGTAG, "\tTWO: " + openWindowsTime[WindowPlacement.LEFT.getValue()]);
             Log.d(LOGTAG, "\tTHREE: " + openWindowsTime[WindowPlacement.RIGHT.getValue()]);
 
-            Log.d(LOGTAG, "Open Private Windows Count:");
+            Log.d(LOGTAG, "Open Windows Count:");
             Log.d(LOGTAG, "\tFRONT: " + openWindows[WindowPlacement.FRONT.getValue()]);
             Log.d(LOGTAG, "\tLEFT: " + openWindows[WindowPlacement.LEFT.getValue()]);
             Log.d(LOGTAG, "\tRIGHT: " + openWindows[WindowPlacement.RIGHT.getValue()]);

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -601,7 +601,7 @@ public class TelemetryWrapper {
                 openPrivateWindows[i] = 0;
             }
             if (number > 0) {
-                openPrivateWindows[number -1 ] = 1;
+                openPrivateWindows[number-1] = 1;
             }
 
         } else {
@@ -610,7 +610,7 @@ public class TelemetryWrapper {
             }
 
             if (number > 0) {
-                openWindows[number - 1] = 1;
+                openWindows[number-1] = 1;
             }
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -595,6 +595,26 @@ public class TelemetryWrapper {
         }
     }
 
+    public static void resetOpenedWindowsCount(int number, boolean isPrivate) {
+        if (isPrivate) {
+            for (int i=0; i<openPrivateWindows.length; i++) {
+                openPrivateWindows[i] = 0;
+            }
+            if (number > 0) {
+                openPrivateWindows[number -1 ] = 1;
+            }
+
+        } else {
+            for (int i=0; i<openWindows.length; i++) {
+                openWindows[i] = 0;
+            }
+
+            if (number > 0) {
+                openWindows[number - 1] = 1;
+            }
+        }
+    }
+
     private static void queueOpenWindowsAvgEvent() {
         float weight = 0;
         float weightSum = 0;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -426,6 +426,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         for (WindowWidget window: mPrivateWindows) {
             window.onResume();
         }
+
+        TelemetryWrapper.resetOpenedWindowsCount(mRegularWindows.size(), false);
+        TelemetryWrapper.resetOpenedWindowsCount(mPrivateWindows.size(), true);
     }
 
     public void onDestroy() {


### PR DESCRIPTION
This fixes an issue with the window count weighted mean that was accounting for the already opened windows after the telemetry was flushed.

Also after talking to @daoshengmu we decided that is better to force a telemetry status ping every time the app is created for easier telemetry status tracking in the backend. 

After this patch the telemetry status ping is always sent:
- When the app is opened
- When the user changes the telemetry status using the privacy options switch