### PR TITLE
Do not check parent sorting in invisible widgets

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -638,10 +638,12 @@ BrowserWorld::State::SortWidgets() {
     Widget* wb = db->second.first;
 
     // Parenting sort
-    if (wa && wb && IsParent(*wa, *wb)) {
-      return true;
-    } else if (wa && wb && IsParent(*wb, *wa)) {
-      return false;
+    if (wa && wb && wa->IsVisible() && wb->IsVisible()) {
+      if (IsParent(*wa, *wb)) {
+        return true;
+      } else if (IsParent(*wb, *wa)) {
+        return false;
+      }
     }
 
     // Depth sort


### PR DESCRIPTION
fixes #2014 

Invisible widgets are set 1.0f ndc z value to avoid doing unneeded computation in depth sorting. But parenting checking is still done so the pointer can be sorted after a parent that has been hidden and is using the max z 1.0 value.