### PR TITLE
Avoid removing history items when updating history

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -9,7 +9,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
-import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Surface;
@@ -47,7 +46,6 @@ import org.mozilla.vrbrowser.utils.SystemUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.LinkedList;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1236,11 +1234,9 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
             } else {
                 mQueuedCalls.add(() -> {
-                    new Handler(mContext.getMainLooper()).postDelayed(() -> {
-                        if (mHistoryDelegate != null) {
-                            mHistoryDelegate.onHistoryStateChange(aSession, historyList);
-                        }
-                    }, 100);
+                    if (mHistoryDelegate != null) {
+                        mHistoryDelegate.onHistoryStateChange(aSession, historyList);
+                    }
                 });
             }
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -41,7 +41,11 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import mozilla.components.concept.storage.VisitInfo;
@@ -277,6 +281,12 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         }
     };
 
+    @NotNull
+    public static <T> Predicate<T> distinctByUrl(Function<? super T, ?> keyExtractor) {
+        Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return t -> seen.add(keyExtractor.apply(t));
+    }
+
     private void updateHistory() {
         Calendar date = new GregorianCalendar();
         date.set(Calendar.HOUR_OF_DAY, 0);
@@ -292,6 +302,7 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
             List<VisitInfo> orderedItems = items.stream()
                     .sorted(Comparator.comparing(VisitInfo::getVisitTime)
                     .reversed())
+                    .filter(distinctByUrl(VisitInfo::getUrl))
                     .collect(Collectors.toList());
 
             addSection(orderedItems, getResources().getString(R.string.history_section_today), Long.MAX_VALUE, todayLimit);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1575,15 +1575,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             }
         }
 
-        SessionStore.get().getHistoryStore().deleteVisitsFor(url).thenAcceptAsync(result -> {
-            SessionStore.get().getHistoryStore().recordVisit(url, pageVisit);
-            SessionStore.get().getHistoryStore().recordObservation(url, new PageObservation(url));
+        SessionStore.get().getHistoryStore().recordVisit(url, pageVisit);
+        SessionStore.get().getHistoryStore().recordObservation(url, new PageObservation(url));
 
-        }, mUIThreadExecutor).exceptionally(throwable -> {
-            Log.d(LOGTAG, "Error deleting history: " + throwable.getLocalizedMessage());
-            throwable.printStackTrace();
-            return null;
-        });
         return GeckoResult.fromValue(true);
     }
 


### PR DESCRIPTION
Fixes #2032 We are deleting items with the sole purpose of having a nice looking history without duplicate items. This was causing other issues that the linked one. This PR fixes that moving the processing to the client side instead of Places.