### PR TITLE
Sync updates

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
@@ -112,7 +112,7 @@ class Accounts constructor(val context: Context) {
             // Enable syncing after signing in
             syncStorage.setStatus(SyncEngine.Bookmarks, SettingsStore.getInstance(context).isBookmarksSyncEnabled)
             syncStorage.setStatus(SyncEngine.History, SettingsStore.getInstance(context).isHistorySyncEnabled)
-            services.accountManager.syncNowAsync(SyncReason.EngineChange, false)
+            services.accountManager.syncNowAsync(SyncReason.EngineChange, true)
 
             // Update device list
             account.deviceConstellation().registerDeviceObserver(

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BindingAdapters.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BindingAdapters.java
@@ -7,6 +7,7 @@ import android.text.SpannableString;
 import android.text.style.ImageSpan;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.DimenRes;
@@ -138,5 +139,19 @@ public class BindingAdapters {
                 view.setDescription(view.getContext().getString(R.string.fxa_account_last_synced, timeDiff / 60000));
             }
         }
+    }
+
+    @BindingAdapter("android:layout_height")
+    public static void setLayoutHeight(@NonNull ImageView view, @NonNull @Dimension float dimen) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        params.width = (int)dimen;
+        view.setLayoutParams(params);
+    }
+
+    @BindingAdapter("android:layout_width")
+    public static void setLayoutWidth(@NonNull ImageView view, @NonNull @Dimension float dimen) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        params.height = (int)dimen;
+        view.setLayoutParams(params);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BindingAdapters.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BindingAdapters.java
@@ -18,6 +18,7 @@ import androidx.databinding.BindingAdapter;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.views.HoneycombButton;
 import org.mozilla.vrbrowser.ui.views.UIButton;
+import org.mozilla.vrbrowser.ui.views.settings.ButtonSetting;
 import org.mozilla.vrbrowser.ui.views.settings.SwitchSetting;
 
 import java.text.SimpleDateFormat;
@@ -121,5 +122,21 @@ public class BindingAdapters {
     @BindingAdapter("android:enabled")
     public static void setEnabled(@NonNull SwitchSetting button, boolean enabled) {
         button.setEnabled(enabled);
+    }
+
+    @BindingAdapter("lastSync")
+    public static void setFxALastSync(@NonNull ButtonSetting view, long lastSync) {
+        if (lastSync == 0) {
+            view.setDescription(view.getContext().getString(R.string.fxa_account_last_no_synced));
+
+        } else {
+            long timeDiff = System.currentTimeMillis() - lastSync;
+            if (timeDiff < 60000) {
+                view.setDescription(view.getContext().getString(R.string.fxa_account_last_synced_now));
+
+            } else {
+                view.setDescription(view.getContext().getString(R.string.fxa_account_last_synced, timeDiff / 60000));
+            }
+        }
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -56,6 +56,8 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
     private static final String LOGTAG = SystemUtils.createLogtag(BookmarksView.class);
 
+    private static final boolean ACCOUNTS_UI_ENABLED = false;
+
     private BookmarksBinding mBinding;
     private Accounts mAccounts;
     private BookmarkAdapter mBookmarkAdapter;
@@ -116,6 +118,7 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
             mBinding.setIsSyncing(mAccounts.isSyncing());
         }
         mBinding.setIsNarrow(false);
+        mBinding.setIsAccountsUIEnabled(ACCOUNTS_UI_ENABLED);
         mBinding.executePendingBindings();
 
         updateBookmarks();
@@ -249,7 +252,7 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
             updateSyncBindings(false);
 
             // This shouldn't be necessary but for some reason the buttons stays hovered after the sync.
-            // I guess Android is after enabling it it's state is restored to the latest one (hovered)
+            // I guess Android restoring it to the latest state (hovered) before being disabled
             // Probably an Android bindings bug.
             mBinding.bookmarksNarrow.syncButton.setHovered(false);
             mBinding.bookmarksWide.syncButton.setHovered(false);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -107,8 +107,10 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
         mBinding.setIsLoading(true);
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
-        mAccounts.addAccountListener(mAccountListener);
-        mAccounts.addSyncListener(mSyncListener);
+        if (ACCOUNTS_UI_ENABLED) {
+            mAccounts.addAccountListener(mAccountListener);
+            mAccounts.addSyncListener(mSyncListener);
+        }
 
         mBinding.setIsSignedIn(mAccounts.isSignedIn());
         boolean isSyncEnabled = mAccounts.isEngineEnabled(SyncEngine.Bookmarks.INSTANCE);
@@ -138,8 +140,11 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
     public void onDestroy() {
         SessionStore.get().getBookmarkStore().removeListener(this);
-        mAccounts.removeAccountListener(mAccountListener);
-        mAccounts.removeSyncListener(mSyncListener);
+
+        if (ACCOUNTS_UI_ENABLED) {
+            mAccounts.removeAccountListener(mAccountListener);
+            mAccounts.removeSyncListener(mSyncListener);
+        }
     }
 
     private final BookmarkItemCallback mBookmarkItemCallback = new BookmarkItemCallback() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -62,6 +62,8 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
     private static final String LOGTAG = SystemUtils.createLogtag(HistoryView.class);
 
+    private static final boolean ACCOUNTS_UI_ENABLED = false;
+
     private HistoryBinding mBinding;
     private Accounts mAccounts;
     private HistoryAdapter mHistoryAdapter;
@@ -119,6 +121,7 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
             mBinding.setIsSyncing(mAccounts.isSyncing());
         }
         mBinding.setIsNarrow(false);
+        mBinding.setIsAccountsUIEnabled(ACCOUNTS_UI_ENABLED);
         mBinding.executePendingBindings();
 
         updateHistory();
@@ -246,7 +249,7 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
             updateSyncBindings(false);
 
             // This shouldn't be necessary but for some reason the buttons stays hovered after the sync.
-            // I guess Android is after enabling it it's state is restored to the latest one (hovered)
+            // I guess Android restoring it to the latest state (hovered) before being disabled
             // Probably an Android bindings bug.
             mBinding.historyNarrow.syncButton.setHovered(false);
             mBinding.historyWide.syncButton.setHovered(false);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -110,8 +110,10 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         mBinding.setIsLoading(true);
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
-        mAccounts.addAccountListener(mAccountListener);
-        mAccounts.addSyncListener(mSyncListener);
+        if (ACCOUNTS_UI_ENABLED) {
+            mAccounts.addAccountListener(mAccountListener);
+            mAccounts.addSyncListener(mSyncListener);
+        }
 
         mBinding.setIsSignedIn(mAccounts.isSignedIn());
         boolean isSyncEnabled = mAccounts.isEngineEnabled(SyncEngine.History.INSTANCE);
@@ -137,8 +139,11 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
     public void onDestroy() {
         SessionStore.get().getHistoryStore().removeListener(this);
-        mAccounts.removeAccountListener(mAccountListener);
-        mAccounts.removeSyncListener(mSyncListener);
+
+        if (ACCOUNTS_UI_ENABLED) {
+            mAccounts.removeAccountListener(mAccountListener);
+            mAccounts.removeSyncListener(mSyncListener);
+        }
     }
 
     public void onShow() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/ButtonSetting.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/ButtonSetting.java
@@ -108,4 +108,10 @@ public class ButtonSetting extends LinearLayout {
         mButton.setVisibility(visibility);
     }
 
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+
+        mButton.setEnabled(enabled);
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -194,7 +194,7 @@ class FxAAccountOptionsView extends SettingsView {
     }
 
     private void sync(View view) {
-        mAccounts.syncNowAsync(SyncReason.User.INSTANCE, true);
+        mAccounts.syncNowAsync(SyncReason.User.INSTANCE, false);
     }
 
     private AccountObserver mAccountListener = new AccountObserver() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -8,6 +8,7 @@ package org.mozilla.vrbrowser.ui.widgets.settings;
 import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.View;
 
 import androidx.databinding.DataBindingUtil;
 
@@ -40,6 +41,8 @@ class FxAAccountOptionsView extends SettingsView {
     private OptionsFxaAccountBinding mBinding;
     private Accounts mAccounts;
     private Executor mUIThreadExecutor;
+    private boolean mInitialBookmarksState;
+    private boolean mInitialHistoryState;
 
     public FxAAccountOptionsView(Context aContext, WidgetManagerDelegate aWidgetManager) {
         super(aContext, aWidgetManager);
@@ -62,8 +65,12 @@ class FxAAccountOptionsView extends SettingsView {
         mUIThreadExecutor = ((VRBrowserApplication)getContext().getApplicationContext()).getExecutors().mainThread();
 
         mBinding.signButton.setOnClickListener(view -> mAccounts.logoutAsync());
-        mBinding.bookmarksSyncSwitch.setOnCheckedChangeListener(mBookmarksSyncListener);
+        mBinding.syncButton.setOnClickListener(this::sync);
 
+        mBinding.setIsSyncing(mAccounts.isSyncing());
+        mBinding.setLastSync(mAccounts.lastSync());
+
+        mBinding.bookmarksSyncSwitch.setOnCheckedChangeListener(mBookmarksSyncListener);
         mBinding.historySyncSwitch.setOnCheckedChangeListener(mHistorySyncListener);
 
         updateCurrentAccountState();
@@ -79,10 +86,13 @@ class FxAAccountOptionsView extends SettingsView {
         mAccounts.addAccountListener(mAccountListener);
         mAccounts.addSyncListener(mSyncListener);
 
-        mBinding.bookmarksSyncSwitch.setValue(mAccounts.isEngineEnabled(SyncEngine.Bookmarks.INSTANCE), false);
-        mBinding.historySyncSwitch.setValue(mAccounts.isEngineEnabled(SyncEngine.History.INSTANCE), false);
+        mInitialBookmarksState = mAccounts.isEngineEnabled(SyncEngine.Bookmarks.INSTANCE);
+        mInitialHistoryState = mAccounts.isEngineEnabled(SyncEngine.History.INSTANCE);
 
-        mBinding.setIsSyncing(mAccounts.isSyncing());
+        mBinding.bookmarksSyncSwitch.setValue(mInitialBookmarksState, false);
+        mBinding.historySyncSwitch.setValue(mInitialHistoryState, false);
+
+        updateSyncBindings(mAccounts.isSyncing());
     }
 
     @Override
@@ -91,49 +101,59 @@ class FxAAccountOptionsView extends SettingsView {
 
         mAccounts.removeAccountListener(mAccountListener);
         mAccounts.removeSyncListener(mSyncListener);
+
+        // We only sync engines in case the user has changed the sync engines since previous sync
+        if (mBinding.bookmarksSyncSwitch.isChecked() != mInitialBookmarksState ||
+                mBinding.historySyncSwitch.isChecked() != mInitialHistoryState) {
+            mAccounts.syncNowAsync(SyncReason.EngineChange.INSTANCE, false);
+        }
     }
 
     private SwitchSetting.OnCheckedChangeListener mBookmarksSyncListener = (compoundButton, value, apply) -> {
         mAccounts.setSyncStatus(SyncEngine.Bookmarks.INSTANCE, value);
-        mAccounts.syncNowAsync(SyncReason.EngineChange.INSTANCE, false);
     };
 
     private SwitchSetting.OnCheckedChangeListener mHistorySyncListener = (compoundButton, value, apply) -> {
         mAccounts.setSyncStatus(SyncEngine.History.INSTANCE, value);
-        mAccounts.syncNowAsync(SyncReason.EngineChange.INSTANCE, false);
     };
 
     private void resetOptions() {
-        mAccounts.setSyncStatus(SyncEngine.Bookmarks.INSTANCE, SettingsStore.BOOKMARKS_SYNC_DEFAULT);
-        mAccounts.setSyncStatus(SyncEngine.History.INSTANCE, SettingsStore.HISTORY_SYNC_DEFAULT);
-        mAccounts.syncNowAsync(SyncReason.EngineChange.INSTANCE, false);
+        mBinding.bookmarksSyncSwitch.setValue(SettingsStore.BOOKMARKS_SYNC_DEFAULT, true);
+        mBinding.historySyncSwitch.setValue(SettingsStore.HISTORY_SYNC_DEFAULT, true);
     }
 
     private SyncStatusObserver mSyncListener = new SyncStatusObserver() {
         @Override
         public void onStarted() {
-            mBinding.setIsSyncing(true);
+            updateSyncBindings(true);
         }
 
         @Override
         public void onIdle() {
-            mBinding.setIsSyncing(false);
+            updateSyncBindings(false);
 
             mBinding.bookmarksSyncSwitch.setValue(mAccounts.isEngineEnabled(SyncEngine.Bookmarks.INSTANCE), false);
             mBinding.historySyncSwitch.setValue(mAccounts.isEngineEnabled(SyncEngine.History.INSTANCE), false);
 
             // This shouldn't be necessary but for some reason the buttons stays hovered after the sync.
-            // I guess Android is after enabling it it's state is restored to the latest one (hovered)
+            // I guess Android restoring it to the latest state (hovered) before being disabled
             // Probably an Android bindings bug.
             mBinding.bookmarksSyncSwitch.setHovered(false);
             mBinding.historySyncSwitch.setHovered(false);
+            mBinding.syncButton.setHovered(false);
         }
 
         @Override
         public void onError(@Nullable Exception e) {
-            mBinding.setIsSyncing(false);
+            updateSyncBindings(false);
         }
     };
+
+    private void updateSyncBindings(boolean isSyncing) {
+        mBinding.setIsSyncing(isSyncing);
+        mBinding.setLastSync(mAccounts.lastSync());
+        mBinding.executePendingBindings();
+    }
 
     void updateCurrentAccountState() {
         switch(mAccounts.getAccountStatus()) {
@@ -171,6 +191,10 @@ class FxAAccountOptionsView extends SettingsView {
         if (profile != null) {
             mBinding.accountEmail.setText(profile.getEmail());
         }
+    }
+
+    private void sync(View view) {
+        mAccounts.syncNowAsync(SyncReason.User.INSTANCE, true);
     }
 
     private AccountObserver mAccountListener = new AccountObserver() {

--- a/app/src/main/res/drawable/main_button_text_color.xml
+++ b/app/src/main/res/drawable/main_button_text_color.xml
@@ -1,0 +1,11 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:enterFadeDuration="@integer/ui_fadeAnimTime"
+    android:exitFadeDuration="@integer/ui_fadeAnimTime">
+    <item android:state_enabled="false"
+        android:color="@color/rhino"/>
+    <item android:state_pressed="true"
+        android:color="@color/fog"/>
+    <item android:state_hovered="true"
+        android:color="@color/asphalt"/>
+    <item android:color="@color/fog"/>
+</selector>

--- a/app/src/main/res/drawable/rectangle_button_background.xml
+++ b/app/src/main/res/drawable/rectangle_button_background.xml
@@ -5,7 +5,7 @@
     <item android:state_enabled="false">
         <shape android:shape="rectangle">
             <corners android:radius="5dp" />
-            <solid android:color="@color/asphalt" />
+            <solid android:color="@color/iron" />
         </shape>
     </item>
     <item android:state_pressed="true">

--- a/app/src/main/res/layout/bookmarks.xml
+++ b/app/src/main/res/layout/bookmarks.xml
@@ -7,6 +7,10 @@
         <import type="android.view.View"/>
 
         <variable
+            name="isAccountsUIEnabled"
+            type="boolean" />
+
+        <variable
             name="isLoading"
             type="boolean" />
 
@@ -54,6 +58,7 @@
             android:layout_marginStart="30dp"
             android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
+            app:isAccountsUIEnabled="@{isAccountsUIEnabled}"
             app:isEmpty="@{isEmpty}"
             app:isSignedIn="@{isSignedIn}"
             app:isSyncEnabled="@{isSyncEnabled}"
@@ -69,6 +74,7 @@
             android:layout_marginStart="30dp"
             android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
+            app:isAccountsUIEnabled="@{isAccountsUIEnabled}"
             app:isEmpty="@{isEmpty}"
             app:isSignedIn="@{isSignedIn}"
             app:isSyncEnabled="@{isSyncEnabled}"

--- a/app/src/main/res/layout/bookmarks.xml
+++ b/app/src/main/res/layout/bookmarks.xml
@@ -91,8 +91,8 @@
             app:visibleGone="@{!isLoading &amp;&amp; isEmpty}">
 
             <ImageView
-                android:layout_width="75dp"
-                android:layout_height="75dp"
+                android:layout_width="@{isNarrow ? @dimen/library_icon_size_narrow : @dimen/library_icon_size_wide, default=wrap_content}"
+                android:layout_height="@{isNarrow ? @dimen/library_icon_size_narrow : @dimen/library_icon_size_wide, default=wrap_content}"
                 android:src="@drawable/ic_icon_bookmarks"
                 app:srcCompat="@drawable/ic_icon_bookmarks" />
 

--- a/app/src/main/res/layout/bookmarks_narrow.xml
+++ b/app/src/main/res/layout/bookmarks_narrow.xml
@@ -4,6 +4,10 @@
 
     <data>
         <variable
+            name="isAccountsUIEnabled"
+            type="boolean" />
+
+        <variable
             name="isEmpty"
             type="boolean" />
 
@@ -71,7 +75,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:gravity="center_vertical">
+            android:gravity="center_vertical"
+            visibleGone="@{isAccountsUIEnabled}">
 
             <FrameLayout
                 android:id="@+id/buttons_layout"

--- a/app/src/main/res/layout/bookmarks_wide.xml
+++ b/app/src/main/res/layout/bookmarks_wide.xml
@@ -4,6 +4,10 @@
 
     <data>
         <variable
+            name="isAccountsUIEnabled"
+            type="boolean" />
+
+        <variable
             name="isEmpty"
             type="boolean" />
 
@@ -42,7 +46,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true">
+            android:layout_centerVertical="true"
+            visibleGone="@{isAccountsUIEnabled}">
 
             <Button
                 android:id="@+id/syncButton"
@@ -132,7 +137,7 @@
             android:textSize="@dimen/text_medium_size"
             android:textStyle="italic"
             app:lastSync="@{lastSync}"
-            app:visibleGone="@{isSignedIn &amp;&amp; isSyncEnabled &amp;&amp; !isSyncing}" />
+            app:visibleGone="@{isAccountsUIEnabled &amp;&amp; isSignedIn &amp;&amp; isSyncEnabled &amp;&amp; !isSyncing}" />
 
         <TextView
             android:id="@+id/textView"

--- a/app/src/main/res/layout/history.xml
+++ b/app/src/main/res/layout/history.xml
@@ -6,6 +6,10 @@
         <import type="android.view.View"/>
 
         <variable
+            name="isAccountsUIEnabled"
+            type="boolean" />
+
+        <variable
             name="isLoading"
             type="boolean" />
 
@@ -54,6 +58,7 @@
             android:layout_marginStart="30dp"
             android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
+            app:isAccountsUIEnabled="@{isAccountsUIEnabled}"
             app:isEmpty="@{isEmpty}"
             app:isSignedIn="@{isSignedIn}"
             app:isSyncEnabled="@{isSyncEnabled}"
@@ -70,6 +75,7 @@
             android:layout_marginStart="30dp"
             android:layout_marginEnd="50dp"
             android:layout_marginBottom="20dp"
+            app:isAccountsUIEnabled="@{isAccountsUIEnabled}"
             app:isEmpty="@{isEmpty}"
             app:isSignedIn="@{isSignedIn}"
             app:isSyncEnabled="@{isSyncEnabled}"

--- a/app/src/main/res/layout/history.xml
+++ b/app/src/main/res/layout/history.xml
@@ -92,8 +92,8 @@
             app:visibleGone="@{!isLoading &amp;&amp; isEmpty}">
 
             <ImageView
-                android:layout_width="75dp"
-                android:layout_height="75dp"
+                android:layout_width="@{isNarrow ? @dimen/library_icon_size_narrow : @dimen/library_icon_size_wide, default=wrap_content}"
+                android:layout_height="@{isNarrow ? @dimen/library_icon_size_narrow : @dimen/library_icon_size_wide, default=wrap_content}"
                 android:src="@drawable/ic_icon_history"
                 app:srcCompat="@drawable/ic_icon_history" />
 

--- a/app/src/main/res/layout/history_narrow.xml
+++ b/app/src/main/res/layout/history_narrow.xml
@@ -4,6 +4,10 @@
 
     <data>
         <variable
+            name="isAccountsUIEnabled"
+            type="boolean" />
+
+        <variable
             name="isEmpty"
             type="boolean" />
 
@@ -90,7 +94,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        visibleGone="@{isAccountsUIEnabled}">
 
         <FrameLayout
             android:id="@+id/buttons_layout"

--- a/app/src/main/res/layout/history_wide.xml
+++ b/app/src/main/res/layout/history_wide.xml
@@ -4,6 +4,10 @@
 
     <data>
         <variable
+            name="isAccountsUIEnabled"
+            type="boolean" />
+
+        <variable
             name="isEmpty"
             type="boolean" />
 
@@ -79,7 +83,7 @@
                 android:textStyle="italic"
                 android:text="@{!isSyncEnabled ? @string/fxa_account_syncing_off : null}"
                 app:lastSync="@{lastSync}"
-                app:visibleGone="@{isSignedIn &amp;&amp; isSyncEnabled &amp;&amp; !isSyncing}"/>
+                app:visibleGone="@{isAccountsUIEnabled &amp;&amp; isSignedIn &amp;&amp; isSyncEnabled &amp;&amp; !isSyncing}"/>
 
             <FrameLayout
                 android:id="@+id/buttons_layout"
@@ -87,7 +91,8 @@
                 android:layout_height="wrap_content"
                 android:layout_toStartOf="@+id/clearButton"
                 android:layout_centerVertical="true"
-                android:layout_marginEnd="20dp">
+                android:layout_marginEnd="20dp"
+                visibleGone="@{isAccountsUIEnabled}">
                 <Button
                     android:id="@+id/syncButton"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/options_fxa_account.xml
+++ b/app/src/main/res/layout/options_fxa_account.xml
@@ -4,6 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
     <data>
         <variable
+            name="lastSync"
+            type="long" />
+        <variable
             name="isSyncing"
             type="boolean" />
     </data>
@@ -45,6 +48,15 @@
                 android:orientation="vertical">
 
                 <org.mozilla.vrbrowser.ui.views.settings.ButtonSetting
+                    android:id="@+id/sync_button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:enabled="@{!isSyncing}"
+                    app:buttonText="@{isSyncing ? @string/fxa_account_options_syncing : @string/fxa_account_options_sync_now}"
+                    app:description="@string/fxa_account_last_no_synced"
+                    lastSync="@{lastSync}"/>
+
+                <org.mozilla.vrbrowser.ui.views.settings.ButtonSetting
                     android:id="@+id/sign_button"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -54,49 +66,29 @@
                 <TextView
                     android:id="@+id/account_email"
                     style="@style/settingsDescription"
-                    android:layout_below="@+id/backButton"
                     android:gravity="center_vertical"
-                    android:layout_marginLeft="50dp"
+                    android:layout_marginStart="50dp"
                     android:layout_marginBottom="15dp"
                     android:text=""
-                    tools:text="" />
+                    tools:text="mozilla@mozilla.com" />
 
-                <RelativeLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_alignParentStart="true"
-                        android:orientation="vertical">
-                        <TextView
-                            style="@style/settingsDescription"
-                            android:layout_below="@+id/backButton"
-                            android:gravity="center_vertical"
-                            android:text="@string/fxa_account_options_sync_title"
-                            tools:text="@string/fxa_account_options_sync_title" />
-                        <TextView
-                            style="@style/settingsDescriptionText"
-                            android:layout_below="@+id/backButton"
-                            android:gravity="center_vertical"
-                            android:text="@string/fxa_account_options_sync_description"
-                            tools:text="@string/fxa_account_options_sync_description" />
-                    </LinearLayout>
-                    <ProgressBar
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_alignParentEnd="true"
-                        android:layout_centerVertical="true"
-                        android:indeterminate="true"
-                        visibleGone="@{isSyncing}"/>
-                </RelativeLayout>
+                <TextView
+                    style="@style/settingsDescription"
+                    android:gravity="center_vertical"
+                    android:text="@string/fxa_account_options_sync_title"
+                    tools:text="@string/fxa_account_options_sync_title" />
+
+                <TextView
+                    style="@style/settingsDescriptionText"
+                    android:gravity="center_vertical"
+                    android:text="@string/fxa_account_options_sync_description"
+                    tools:text="@string/fxa_account_options_sync_description" />
 
                 <org.mozilla.vrbrowser.ui.views.settings.SwitchSetting
                     android:id="@+id/bookmarks_sync_switch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
-                    android:enabled="@{!isSyncing}"
+                    android:layout_marginStart="50dp"
                     app:description="@string/fxa_account_options_bookmarks_sync"
                     app:on_text="@string/sync"
                     app:off_text="@string/do_not_sync"/>
@@ -105,8 +97,7 @@
                     android:id="@+id/history_sync_switch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="50dp"
-                    android:enabled="@{!isSyncing}"
+                    android:layout_marginStart="50dp"
                     app:description="@string/fxa_account_options_history_sync"
                     app:on_text="@string/sync"
                     app:off_text="@string/do_not_sync"/>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -230,6 +230,8 @@
     <dimen name="library_item_date_text_size">16sp</dimen>
     <dimen name="library_icon_padding_max">10dp</dimen>
     <dimen name="library_icon_padding_min">8dp</dimen>
+    <dimen name="library_icon_size_wide">75dp</dimen>
+    <dimen name="library_icon_size_narrow">65dp</dimen>
 
     <!-- Language -->
     <dimen name="language_row_height">22dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -497,6 +497,14 @@
     <!-- This string is used to in the FxA account manage panel as a header for the sync options. -->
     <string name="fxa_account_options_sync_title">Sync Settings</string>
 
+    <!-- This string is used to in the FxA account manage panel as the description of the Sync button when is not syncing.
+         The sync button will start syncing when pressed-->
+    <string name="fxa_account_options_sync_now">Sync Now</string>
+
+    <!-- This string is used to in the FxA account manage panel as the description of the Sync button while syncon.
+         The sync button will start syncing when pressed-->
+    <string name="fxa_account_options_syncing">Syncing...</string>
+
     <!-- This string is used to in the FxA account manage panel as a description for the sync options. -->
     <string name="fxa_account_options_sync_description">Choose what to synchronize on your devices using Firefox</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -276,7 +276,7 @@
         <item name="android:layout_gravity">center</item>
         <item name="android:gravity">center</item>
         <item name="android:text">@string/developer_options_edit</item>
-        <item name="android:textColor">@drawable/main_button_icon_color</item>
+        <item name="android:textColor">@drawable/main_button_text_color</item>
         <item name="android:textSize">14sp</item>
         <item name="android:typeface">sans</item>
         <item name="android:textStyle">bold</item>


### PR DESCRIPTION
Fixes #2174 Fixes #2155 Fixes #2156 This PR moves all the syncing logic into the FxA panel.
- All the FxA related buttons have been removed from the History/Bookmarks panels.
- Engines are only updated after the user dismisses the panel and only in the case that the state has changed.
- The user can only sync from the FxA panel.