### PR TITLE
Show title media controls only if media has been already started

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
@@ -15,6 +15,7 @@ public class Media implements MediaElement.Delegate {
     private double mPlaybackRate = 1.0f;
     private int mReadyState = MediaElement.MEDIA_READY_STATE_HAVE_NOTHING;
     private boolean mPlaying = false;
+    private boolean mWasPlayed = false;
     private boolean mEnded = false;
     private double mVolume = 1.0f;
     private boolean mIsMuted = false;
@@ -66,6 +67,10 @@ public class Media implements MediaElement.Delegate {
 
     public boolean isPlaying() {
         return mPlaying;
+    }
+
+    public boolean isPlayed() {
+        return mWasPlayed;
     }
 
     public boolean isEnded() {
@@ -133,6 +138,7 @@ public class Media implements MediaElement.Delegate {
     @Override
     public void onPlaybackStateChange(MediaElement mediaElement, int playbackState) {
         if (playbackState == MediaElement.MEDIA_STATE_PLAY) {
+            mWasPlayed = true;
             mPlaying = true;
         } else if (playbackState == MediaElement.MEDIA_STATE_PAUSE) {
             mPlaying = false;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -185,8 +185,6 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
         if (available) {
             mMedia = mAttachedWindow.getSession().getFullScreenVideo();
             if (mMedia != null) {
-                mBinding.setIsMediaAvailable(true);
-                mBinding.setIsMediaPlaying(mMedia.isPlaying());
                 mMedia.addMediaListener(mMediaDelegate);
             }
         } else {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -186,7 +186,7 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
             mMedia = mAttachedWindow.getSession().getFullScreenVideo();
             if (mMedia != null) {
                 mMedia.addMediaListener(mMediaDelegate);
-                if (mMedia.getReadyState() == MediaElement.MEDIA_STATE_SEEKING) {
+                if (mMedia.isPlayed()) {
                     mBinding.setIsMediaAvailable(true);
                     mBinding.setIsMediaPlaying(true);
                 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -186,6 +186,10 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
             mMedia = mAttachedWindow.getSession().getFullScreenVideo();
             if (mMedia != null) {
                 mMedia.addMediaListener(mMediaDelegate);
+                if (mMedia.getReadyState() == MediaElement.MEDIA_STATE_SEEKING) {
+                    mBinding.setIsMediaAvailable(true);
+                    mBinding.setIsMediaPlaying(true);
+                }
             }
         } else {
             mBinding.setIsMediaAvailable(false);


### PR DESCRIPTION
Fixes #2158 Fixes #2160 Only show the media controls if the media has already been played.

We will need to decide if we want to revert this when this bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1524092