### PR TITLE
Fix crash when the preferred language list is empty

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
@@ -123,7 +123,9 @@ class LanguageOptionsView extends SettingsView {
     private SpannableStringBuilder getSpannedLanguageText(@NonNull String language) {
         int end = getLanguageIndex(language);
         SpannableStringBuilder spanned = new SpannableStringBuilder(language);
-        spanned.setSpan(new StyleSpan(Typeface.BOLD), 0, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        if (end > 0) {
+            spanned.setSpan(new StyleSpan(Typeface.BOLD), 0, end, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
         return spanned;
     }
 


### PR DESCRIPTION
Fixes a crash when you remove all the preferred languages.

STRs:
- Open the preferred languages panel
- Remove all the preferred  languages

Result: Crash

Expected: The item should be removed without crashing