### PR TITLE
Fix the text/link is wrongly pasted at the end of the URL from the Awesomebar

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -140,9 +140,8 @@ public class NavigationURLBar extends FrameLayout {
             mBinding.setIsUrlEmpty(isUrlEmpty);
             if (!focused) {
                 hideSelectionMenu();
-
             } else {
-                mBinding.urlEditText.setSelection(mBinding.urlEditText.length(), 0);
+                mBinding.urlEditText.selectAll();
             }
         });
 


### PR DESCRIPTION
Fixes #2188

It's a regression from #2110