### PR TITLE
Avoid the FxA crash when reloading the success page after logout

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.launch
 import mozilla.components.concept.sync.*
+import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.fxa.sync.SyncReason
@@ -22,6 +23,7 @@ import mozilla.components.service.fxa.sync.SyncStatusObserver
 import mozilla.components.service.fxa.sync.getLastSynced
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.vrbrowser.VRBrowserApplication
+import org.mozilla.vrbrowser.browser.engine.SessionStore
 import org.mozilla.vrbrowser.utils.SystemUtils
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
@@ -354,6 +356,10 @@ class Accounts constructor(val context: Context) {
                 }
             }
         }
+    }
+
+    fun getConnectionSuccessURL(): String {
+        return (services.accountManager.authenticatedAccount() as FirefoxAccount).getConnectionSuccessURL()
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -34,6 +34,8 @@ import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -889,6 +891,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         @Override
         public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+            Session session = mFocusedWindow.getSession();
+            addTab(mFocusedWindow, mAccounts.getConnectionSuccessURL());
+            onTabsClose(new ArrayList<>(Collections.singletonList(session)));
+
             switch (mAccounts.getLoginOrigin()) {
                 case BOOKMARKS:
                     getFocusedWindow().switchBookmarks();


### PR DESCRIPTION
Fixes #2201 Crash related to this AS issue: https://github.com/mozilla/application-services/issues/2131

To avoid the issue we close the FxA login tab and load the login scuess URL after a successful login.