### PR TITLE
Fix switch state when syncing in the FxA panel

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -132,9 +132,6 @@ class FxAAccountOptionsView extends SettingsView {
         public void onIdle() {
             updateSyncBindings(false);
 
-            mBinding.bookmarksSyncSwitch.setValue(mAccounts.isEngineEnabled(SyncEngine.Bookmarks.INSTANCE), false);
-            mBinding.historySyncSwitch.setValue(mAccounts.isEngineEnabled(SyncEngine.History.INSTANCE), false);
-
             // This shouldn't be necessary but for some reason the buttons stays hovered after the sync.
             // I guess Android restoring it to the latest state (hovered) before being disabled
             // Probably an Android bindings bug.


### PR DESCRIPTION
Fixes #2203 We are updating the switches state when getting sync callbacks. As we only change the sync state when dismissing the panel it makes more sense to not update the buttons as if you change them and sync, you are still getting the previous state.