### PR TITLE
Show the scrollbar when popups view is shown

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/AllowedPopUpsOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/AllowedPopUpsOptionsView.java
@@ -83,6 +83,8 @@ class AllowedPopUpsOptionsView extends SettingsView {
         super.onShown();
 
         mViewModel.getAll().observeForever(mObserver);
+
+        mBinding.siteList.post(() -> mBinding.siteList.scrollToPosition(0));
     }
 
     @Override


### PR DESCRIPTION
Fixes #2122 Show the popups scrollbar and make sure we always scroll to the first row when showing the popups view.