### PR TITLE
Make No internet dialog and transport controls not to collide

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -45,6 +45,7 @@ import org.mozilla.vrbrowser.ui.widgets.menus.BrightnessMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.HamburgerMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.VideoProjectionMenuWidget;
 import org.mozilla.vrbrowser.utils.AnimationHelper;
+import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 import org.mozilla.vrbrowser.utils.ServoUtils;
 
 import java.util.ArrayList;
@@ -326,6 +327,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
         mWidgetManager.addUpdateListener(this);
         mWidgetManager.addWorldClickListener(this);
+        mWidgetManager.addConnectivityListener(mConnectivityDelegate);
 
         mVoiceSearchWidget = createChild(VoiceSearchWidget.class, false);
         mVoiceSearchWidget.getPlacement().parentAnchorY = 0.0f;
@@ -358,6 +360,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     public void releaseWidget() {
         mWidgetManager.removeUpdateListener(this);
         mWidgetManager.removeWorldClickListener(this);
+        mWidgetManager.removeConnectivityListener(mConnectivityDelegate);
         mPrefs.unregisterOnSharedPreferenceChangeListener(this);
         
         if (mAttachedWindow != null && mAttachedWindow.isFullScreen()) {
@@ -1255,5 +1258,11 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
         button.setNotificationMode(false);
     }
+
+    private ConnectivityReceiver.Delegate mConnectivityDelegate = connected -> {
+        if (mMediaControlsWidget != null) {
+            mMediaControlsWidget.setVisible(connected && mMediaControlsWidget.isVisible());
+        }
+    };
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
@@ -11,7 +11,7 @@ import android.widget.Button;
 
 import org.mozilla.vrbrowser.R;
 
-public class NoInternetWidget extends UIWidget {
+public class NoInternetWidget extends UIWidget implements WidgetManagerDelegate.WorldClickListener {
 
     private Button mAcceptButton;
 
@@ -52,6 +52,29 @@ public class NoInternetWidget extends UIWidget {
         aPlacement.parentAnchorY = 0.5f;
         aPlacement.opaque = false;
         aPlacement.visible = false;
+    }
+
+    @Override
+    public void show(int aShowFlags) {
+        super.show(aShowFlags);
+
+        mWidgetManager.addWorldClickListener(this);
+        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
+    }
+
+    @Override
+    public void hide(int aHideFlags) {
+        super.hide(aHideFlags);
+
+        mWidgetManager.popWorldBrightness(this);
+        mWidgetManager.removeWorldClickListener(this);
+    }
+
+    // WidgetManagerDelegate.WorldClickListener
+
+    @Override
+    public void onWorldClick() {
+        onDismiss();
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
@@ -10,10 +10,9 @@ import android.util.AttributeSet;
 import android.widget.Button;
 
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
 
-public class NoInternetWidget extends UIWidget implements WidgetManagerDelegate.WorldClickListener {
-
-    private Button mAcceptButton;
+public class NoInternetWidget extends UIDialog {
 
     public NoInternetWidget(Context aContext) {
         super(aContext);
@@ -33,7 +32,7 @@ public class NoInternetWidget extends UIWidget implements WidgetManagerDelegate.
     private void initialize(Context aContext) {
         inflate(aContext, R.layout.no_internet, this);
 
-        mAcceptButton = findViewById(R.id.acceptButton);
+        Button mAcceptButton = findViewById(R.id.acceptButton);
         mAcceptButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             hide(REMOVE_WIDGET);
@@ -58,7 +57,6 @@ public class NoInternetWidget extends UIWidget implements WidgetManagerDelegate.
     public void show(int aShowFlags) {
         super.show(aShowFlags);
 
-        mWidgetManager.addWorldClickListener(this);
         mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
     }
 
@@ -67,14 +65,6 @@ public class NoInternetWidget extends UIWidget implements WidgetManagerDelegate.
         super.hide(aHideFlags);
 
         mWidgetManager.popWorldBrightness(this);
-        mWidgetManager.removeWorldClickListener(this);
-    }
-
-    // WidgetManagerDelegate.WorldClickListener
-
-    @Override
-    public void onWorldClick() {
-        onDismiss();
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.ui.widgets.menus.VideoProjectionMenuWidget;
+import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 
 public interface WidgetManagerDelegate {
 
@@ -85,4 +86,6 @@ public interface WidgetManagerDelegate {
     void openNewTabForeground(@NonNull String uri);
     WindowWidget getFocusedWindow();
     TrayWidget getTray();
+    void addConnectivityListener(ConnectivityReceiver.Delegate aListener);
+    void removeConnectivityListener(ConnectivityReceiver.Delegate aListener);
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -57,7 +57,7 @@ import org.mozilla.vrbrowser.ui.widgets.prompts.AlertPromptWidget;
 import org.mozilla.vrbrowser.ui.widgets.prompts.ConfirmPromptWidget;
 import org.mozilla.vrbrowser.ui.widgets.prompts.PromptWidget;
 import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
-import org.mozilla.vrbrowser.utils.StringUtils;
+import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
@@ -235,6 +235,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         aSession.addProgressListener(this);
         aSession.setHistoryDelegate(this);
         aSession.addSelectionActionListener(this);
+
+        mWidgetManager.addConnectivityListener(mConnectivityDelegate);
     }
 
     void cleanListeners(Session aSession) {
@@ -245,6 +247,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         aSession.removeProgressListener(this);
         aSession.setHistoryDelegate(null);
         aSession.removeSelectionActionListener(this);
+
+        mWidgetManager.removeConnectivityListener(mConnectivityDelegate);
     }
 
     @Override
@@ -323,6 +327,23 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
         mListeners.clear();
     }
+
+    private ConnectivityReceiver.Delegate mConnectivityDelegate = connected -> {
+        if (mActive) {
+            if (mNoInternetToast == null) {
+                mNoInternetToast = new NoInternetWidget(getContext());
+                mNoInternetToast.mWidgetPlacement.parentHandle = getHandle();
+                mNoInternetToast.mWidgetPlacement.parentAnchorY = 0.0f;
+                mNoInternetToast.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
+            }
+            if (!connected && !mNoInternetToast.isVisible()) {
+                mNoInternetToast.show(REQUEST_FOCUS);
+
+            } else if (connected && mNoInternetToast.isVisible()) {
+                mNoInternetToast.hide(REMOVE_WIDGET);
+            }
+        }
+    };
 
     public void loadHomeIfNotRestored() {
         if (!mIsRestored) {
@@ -1184,20 +1205,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     private void setPrivateBrowsingEnabled(boolean isEnabled) {
-    }
-
-    public void setNoInternetToastVisible(boolean aVisible) {
-        if (mNoInternetToast == null) {
-            mNoInternetToast = new NoInternetWidget(getContext());
-            mNoInternetToast.mWidgetPlacement.parentHandle = getHandle();
-            mNoInternetToast.mWidgetPlacement.parentAnchorY = 0.0f;
-            mNoInternetToast.mWidgetPlacement.translationY = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_y_distance);
-        }
-        if (aVisible && !mNoInternetToast.isVisible()) {
-            mNoInternetToast.show(REQUEST_FOCUS);
-        } else if (!aVisible && mNoInternetToast.isVisible()) {
-            mNoInternetToast.hide(REMOVE_WIDGET);
-        }
     }
 
     public void showAlert(String title, @NonNull String msg, @NonNull PromptWidget.PromptDelegate callback) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
@@ -6,6 +6,7 @@ import android.view.View;
 
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
+import org.mozilla.vrbrowser.utils.ViewUtils;
 
 public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate.FocusChangeListener {
     public UIDialog(Context aContext) {
@@ -42,7 +43,7 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (oldFocus == this && isVisible()) {
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
             onDismiss();
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/ConnectivityReceiver.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/ConnectivityReceiver.java
@@ -14,7 +14,7 @@ import static android.net.ConnectivityManager.CONNECTIVITY_ACTION;
 public class ConnectivityReceiver extends BroadcastReceiver {
 
     public interface Delegate {
-        void OnConnectivityChanged();
+        void OnConnectivityChanged(boolean connected);
     }
 
     private Delegate mDelegate;
@@ -22,7 +22,7 @@ public class ConnectivityReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (mDelegate != null) {
-            mDelegate.OnConnectivityChanged();
+            mDelegate.OnConnectivityChanged(isNetworkAvailable(context));
         }
     }
 


### PR DESCRIPTION
Fixes #1975 Moving the No Internet dialog in front of the transport controls makes it too close to the user. Instead of that we hide the transport controls when the no internet dialog is displayed. If the user clicks in the video while the no internet dialog is visible, it dismisses it and the transport controls are displayed again.

Also added a listener for the connectivity status so we can eventually listen to that events from any widget.