### PR TITLE
Avoid opening the FxA authentication success tab if the account is existing/restored

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
@@ -23,7 +23,6 @@ import mozilla.components.service.fxa.sync.SyncStatusObserver
 import mozilla.components.service.fxa.sync.getLastSynced
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.vrbrowser.VRBrowserApplication
-import org.mozilla.vrbrowser.browser.engine.SessionStore
 import org.mozilla.vrbrowser.utils.SystemUtils
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -28,7 +28,6 @@ import org.mozilla.geckoview.AllowOrDeny
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.vrbrowser.R
-import org.mozilla.vrbrowser.browser.engine.SessionStore
 
 class Services(context: Context, places: Places): GeckoSession.NavigationDelegate {
     companion object {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -34,7 +34,6 @@ import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -891,22 +890,24 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         @Override
         public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
-            Session session = mFocusedWindow.getSession();
-            addTab(mFocusedWindow, mAccounts.getConnectionSuccessURL());
-            onTabsClose(new ArrayList<>(Collections.singletonList(session)));
+            if (authType != AuthType.Existing.INSTANCE) {
+                Session session = mFocusedWindow.getSession();
+                addTab(mFocusedWindow, mAccounts.getConnectionSuccessURL());
+                onTabsClose(new ArrayList<>(Collections.singletonList(session)));
 
-            switch (mAccounts.getLoginOrigin()) {
-                case BOOKMARKS:
-                    getFocusedWindow().switchBookmarks();
-                    break;
+                switch (mAccounts.getLoginOrigin()) {
+                    case BOOKMARKS:
+                        getFocusedWindow().switchBookmarks();
+                        break;
 
-                case HISTORY:
-                    getFocusedWindow().switchHistory();
-                    break;
+                    case HISTORY:
+                        getFocusedWindow().switchHistory();
+                        break;
 
-                case SETTINGS:
-                    mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA);
-                    break;
+                    case SETTINGS:
+                        mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA);
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
STRs:
- Log into FxA
- When the login in flow is finished close all the tabs
- Click back and quit the app
- Open the app

Expected result:
The Content feed is the only opened tab

Actual result:
The FxA authentication tab is opened on top of the content feed one