### PR TITLE
Fix url bar focus issues

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -366,7 +366,6 @@ public class NavigationURLBar extends FrameLayout {
         }
 
         mBinding.urlEditText.addTextChangedListener(mURLTextWatcher);
-        requestFocus();
     }
 
     private boolean isEmptyUrl(@NonNull String aURL) {
@@ -409,6 +408,7 @@ public class NavigationURLBar extends FrameLayout {
 
     private void setIsBookmarked(boolean aValue) {
         mBinding.setIsBookmarked(aValue);
+        mBinding.bookmarkButton.clearFocus();
     }
 
     public void setPrivateMode(boolean isEnabled) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -366,6 +366,7 @@ public class NavigationURLBar extends FrameLayout {
         }
 
         mBinding.urlEditText.addTextChangedListener(mURLTextWatcher);
+        requestFocus();
     }
 
     private boolean isEmptyUrl(@NonNull String aURL) {


### PR DESCRIPTION
Force URL bar top parent to gain focus after a URL is loaded to avoid children to get it and make the URL bar to look focused.

STRs:
- Login FxA
- Click on the URL bar
- Click on the Hamburger menu
- Share a tab from another device
- Click the home button
- Resume the app

Actual result:
- The URL bar is in a focused state

Expected result:
- The URL bar shouldn't be in a focused state