### PR TITLE
Prevent GeckoSession creation until tab is viewed

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PromptDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PromptDelegate.java
@@ -327,6 +327,9 @@ public class PromptDelegate implements
     private SparseArray<Pair<String, LinkedList<PopUpRequest>>> mPopUpRequests = new SparseArray<>();
 
     public void showPopUps(GeckoSession session) {
+        if (session == null) {
+            return;
+        }
         Pair<String, LinkedList<PopUpRequest>> requests = mPopUpRequests.get(session.hashCode());
         if (requests != null && !requests.second.isEmpty()) {
             showPopUp(session.hashCode(), requests);
@@ -334,9 +337,11 @@ public class PromptDelegate implements
     }
 
     public boolean hasPendingPopUps(GeckoSession session) {
-        Pair<String, LinkedList<PopUpRequest>> requests = mPopUpRequests.get(session.hashCode());
-        if (requests != null) {
-            return !requests.second.isEmpty();
+        if (session != null) {
+            Pair<String, LinkedList<PopUpRequest>> requests = mPopUpRequests.get(session.hashCode());
+            if (requests != null) {
+                return !requests.second.isEmpty();
+            }
         }
 
         return false;

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -74,9 +74,9 @@ class Services(context: Context, places: Places): GeckoSession.NavigationDelegat
         override fun onEvents(events: List<DeviceEvent>) {
             CoroutineScope(Dispatchers.Main).launch {
                 Logger(logTag).info("Received ${events.size} device event(s)")
-                val events = events.filterIsInstance(DeviceEvent.TabReceived::class.java)
-                if (!events.isEmpty()) {
-                    val tabs = events.map { event -> event.entries }.flatten()
+                val filteredEvents = events.filterIsInstance(DeviceEvent.TabReceived::class.java)
+                if (filteredEvents.isNotEmpty()) {
+                    val tabs = filteredEvents.map { event -> event.entries }.flatten()
                     tabReceivedDelegate?.onTabsReceived(tabs)
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
@@ -8,6 +8,7 @@ import org.mozilla.vrbrowser.browser.SettingsStore;
 
 class SessionSettings {
 
+    private boolean isPrivateBrowsingEnabled;
     private boolean isTrackingProtectionEnabled;
     private boolean isSuspendMediaWhenInactiveEnabled;
     private int userAgentMode;
@@ -15,13 +16,19 @@ class SessionSettings {
     private boolean isServoEnabled;
     private String userAgentOverride;
 
-    private SessionSettings(@NotNull Builder builder) {
+    /* package */ SessionSettings(@NotNull Builder builder) {
+        this.isPrivateBrowsingEnabled = builder.isPrivateBrowsingEnabled;
         this.isTrackingProtectionEnabled = builder.isTrackingProtectionEnabled;
         this.isSuspendMediaWhenInactiveEnabled = builder.isSuspendMediaWhenInactiveEnabled;
         this.userAgentMode = builder.userAgentMode;
         this.viewportMode = builder.viewportMode;
         this.isServoEnabled = builder.isServoEnabled;
         this.userAgentOverride = builder.userAgentOverride;
+    }
+
+    public boolean isPrivateBrowsingEnabled() { return isPrivateBrowsingEnabled; }
+    public void setPrivateBrowsingEnabled(boolean enabled) {
+        isPrivateBrowsingEnabled = enabled;
     }
 
     public boolean isTrackingProtectionEnabled() {
@@ -66,6 +73,7 @@ class SessionSettings {
 
     public static class Builder {
 
+        private boolean isPrivateBrowsingEnabled;
         private boolean isTrackingProtectionEnabled;
         private boolean isSuspendMediaWhenInactiveEnabled;
         private int userAgentMode;
@@ -76,6 +84,10 @@ class SessionSettings {
         public Builder() {
         }
 
+        public Builder withPrivateBrowsing(boolean enabled) {
+            isPrivateBrowsingEnabled = enabled;
+            return this;
+        }
 
         public Builder withTrackingProteccion(boolean isTrackingProtectionEnabled){
             this.isTrackingProtectionEnabled = isTrackingProtectionEnabled;
@@ -113,6 +125,7 @@ class SessionSettings {
                     GeckoSessionSettings.VIEWPORT_MODE_DESKTOP : GeckoSessionSettings.VIEWPORT_MODE_MOBILE;
 
             return new SessionSettings.Builder()
+                    .withPrivateBrowsing(false)
                     .withTrackingProteccion(SettingsStore.getInstance(context).isTrackingProtectionEnabled())
                     .withSuspendMediaWhenInactive(true)
                     .withUserAgent(ua)
@@ -124,5 +137,4 @@ class SessionSettings {
             return new SessionSettings(this);
         }
     }
-
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
@@ -15,6 +15,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import org.json.JSONException;
+import org.mozilla.geckoview.GeckoDisplay;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.browser.Media;
 
@@ -24,6 +25,7 @@ import java.util.UUID;
 
 @JsonAdapter(SessionState.SessionStateAdapterFactory.class)
 public class SessionState {
+    public transient boolean mIsActive;
     public boolean mCanGoBack;
     public boolean mCanGoForward;
     public boolean mIsLoading;
@@ -34,6 +36,7 @@ public class SessionState {
     public String mTitle = "";
     public transient boolean mFullScreen;
     public transient GeckoSession mSession;
+    public transient GeckoDisplay mDisplay;
     public SessionSettings mSettings;
     public transient ArrayList<Media> mMediaElements = new ArrayList<>();
     @JsonAdapter(SessionState.GeckoSessionStateAdapter.class)

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
@@ -84,8 +84,8 @@ public class SessionState {
                             out.name("mRegion").value(session.mRegion);
                             out.name("mId").value(session.mId);
                             out.name("mParentId").value(session.mParentId);
-                            if (session.mSession != null) {
-                                if (session.mSession.getSettings().getUsePrivateMode()) {
+                            if (session.mSettings != null) {
+                                if (session.mSettings.isPrivateBrowsingEnabled()) {
                                     out.name("mSessionState").jsonValue(null);
 
                                 } else {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -984,6 +984,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 }
             });
             mWidgetManager.updateWidget(aWindow);
+        } else {
+            // If the new session has a GeckoSession there won't be a first paint event.
+            // So trigger the first paint callback in case the window is grayed out
+            // waiting for the first paint event.
+            aWindow.onFirstContentfulPaint(aSession.getGeckoSession());
         }
     }
 
@@ -1152,9 +1157,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     public void addTab(@NotNull WindowWidget targetWindow, @Nullable String aUri) {
-        Session session = SessionStore.get().createSession(targetWindow.getSession().isPrivateMode());
+        Session session = SessionStore.get().createSuspendedSession(aUri, targetWindow.getSession().isPrivateMode());
         setFirstPaint(targetWindow, session);
         targetWindow.getSession().setActive(false);
+        session.setActive(true);
         targetWindow.setSession(session);
         if (aUri == null || aUri.isEmpty()) {
             session.loadHomePage();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1137,8 +1137,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             // Move session between windows
             Session moveFrom = windowToMove.getSession();
             Session moveTo = targetWindow.getSession();
-            windowToMove.releaseDisplay(moveFrom.getGeckoSession());
-            targetWindow.releaseDisplay(moveTo.getGeckoSession());
+            moveFrom.surfaceDestroyed();
+            moveTo.surfaceDestroyed();
             windowToMove.setSession(moveTo);
             targetWindow.setSession(moveFrom);
             SessionStore.get().setActiveSession(targetWindow.getSession());


### PR DESCRIPTION
Fixes #2227
To prevent memory exhaustion, this patch watches for memory trim system
callbacks and suspends inactive tabs by deleting the GeckoSession.
Additionally, when the application is started or resumed, inactive tabs will
not have a GeckoSession created until they are viewed. Any new background tab
will also not have a GeckoSession created until the tab is viewed.