### PR TITLE
Fix intermitted FxA logging issues

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -280,13 +280,13 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
         switch(mAccounts.getAccountStatus()) {
             case SIGNED_OUT:
             case NEEDS_RECONNECT:
+                hide(REMOVE_WIDGET);
                 mAccounts.getAuthenticationUrlAsync().thenAcceptAsync((url) -> {
                     if (url != null) {
                         mAccounts.setLoginOrigin(Accounts.LoginOrigin.SETTINGS);
                         WidgetManagerDelegate widgetManager = ((VRBrowserActivity)getContext());
                         widgetManager.openNewTabForeground(url);
                         widgetManager.getFocusedWindow().getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
-                        hide(REMOVE_WIDGET);
                     }
                 }, mUIThreadExecutor).exceptionally(throwable -> {
                     Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());


### PR DESCRIPTION
Fixes #2142 Calling beginAuthenticationAsync several times in a row seems to mess up FxA. We now avoid this hiding the settings panel right after starting the login flow.

The STRs to reproduce are:
- Launch FxA
- Open settings
- Click on the FxA login button several times in a row before the panel is dismissed
- Complete the login flow

Result:
- Login flow is not completed

Expected:
- Login flow is completed