### PR TITLE
Do not let a received tab take ownership of the window when it's full-screened or playing a immersive video

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1227,6 +1227,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     @Override
     public void onTabsReceived(@NotNull List<TabData> aTabs) {
         WindowWidget targetWindow = mFocusedWindow;
+        boolean fullscreen = targetWindow.getSession().isInFullScreen();
         for (int i = aTabs.size() - 1; i >= 0; --i) {
             Session session = SessionStore.get().createSession(targetWindow.getSession().isPrivateMode());
             // Cache the provided data to avoid delays if the tabs are loaded at the same time the
@@ -1235,14 +1236,16 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             session.getSessionState().mUri = aTabs.get(i).getUrl();
             session.loadUri(aTabs.get(i).getUrl());
             session.updateLastUse();
-            if (i == 0) {
+            if (i == 0 && !fullscreen) {
                 // Set the first received tab of the list the current one.
                 SessionStore.get().setActiveSession(session);
                 targetWindow.setSession(session);
             }
         }
 
-        mWidgetManager.getTray().showTabAddedNotification();
+        if (!fullscreen) {
+            mWidgetManager.getTray().showTabAddedNotification();
+        }
 
         if (mTabsWidget != null && mTabsWidget.isVisible()) {
             mTabsWidget.refreshTabs();


### PR DESCRIPTION
Fixes #2244