### PR TITLE
OVR submit layers to TimeWarp even frames are discarded.

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -65,6 +65,8 @@ protected:
   virtual ~DeviceDelegateOculusVR();
 private:
   State& m;
+  int lastFrameIndex = 0;
+  double lastPredictedDisplayTime = 0.0f;
   VRB_NO_DEFAULTS(DeviceDelegateOculusVR)
 };
 


### PR DESCRIPTION
 Fixes #2320. We will get a discard state [1] when WebVR immersive mode is stuck at the content side. That makes us can't continue to get newest controller states until calling `vrapi_SubmitFrame2`.

[1] https://github.com/MozillaReality/FirefoxReality/blob/9727203eb2521cb854ad007eb57609bf24500373/app/src/main/cpp/BrowserWorld.cpp#L1412