### PR TITLE
Ensure parent session is active before setting in Window

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1110,8 +1110,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     @Override
     public void onUnstackSession(Session aSession, Session aParent) {
         if (mSession == aSession) {
-            setSession(aParent);
             aParent.setActive(true);
+            setSession(aParent);
             SessionStore.get().setActiveSession(aParent);
             SessionStore.get().destroySession(aSession);
         }


### PR DESCRIPTION
Fixes crash https://crash-stats.mozilla.com/report/index/0a459b83-67c7-44d3-8d61-5117e0191120