### PR TITLE
Fixes UIDialog focus issues

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/RadioGroupSetting.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/RadioGroupSetting.java
@@ -103,7 +103,6 @@ public class RadioGroupSetting extends LinearLayout {
             }
 
             setChecked(checkedId, true);
-            compoundButton.requestFocus();
         }
     };
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NoInternetWidget.java
@@ -53,18 +53,4 @@ public class NoInternetWidget extends UIDialog {
         aPlacement.visible = false;
     }
 
-    @Override
-    public void show(int aShowFlags) {
-        super.show(aShowFlags);
-
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-    }
-
-    @Override
-    public void hide(int aHideFlags) {
-        super.hide(aHideFlags);
-
-        mWidgetManager.popWorldBrightness(this);
-    }
-
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -24,7 +24,7 @@ import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 
-public class TabsWidget extends UIDialog implements WidgetManagerDelegate.WorldClickListener {
+public class TabsWidget extends UIDialog {
     protected BitmapCache mBitmapCache;
     protected RecyclerView mTabsList;
     protected GridLayoutManager mLayoutManager;
@@ -136,8 +136,6 @@ public class TabsWidget extends UIDialog implements WidgetManagerDelegate.WorldC
             mAdapter.notifyDataSetChanged();
             updateSelectionMode();
         });
-
-        mWidgetManager.addWorldClickListener(this);
     }
 
     public void attachToWindow(WindowWidget aWindow) {
@@ -147,9 +145,6 @@ public class TabsWidget extends UIDialog implements WidgetManagerDelegate.WorldC
 
     @Override
     public void releaseWidget() {
-        if (mWidgetManager != null) {
-            mWidgetManager.removeWorldClickListener(this);
-        }
         super.releaseWidget();
     }
 
@@ -158,7 +153,6 @@ public class TabsWidget extends UIDialog implements WidgetManagerDelegate.WorldC
         super.show(aShowFlags);
         refreshTabs();
         invalidate();
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
         mTabsList.requestFocusFromTouch();
     }
 
@@ -166,7 +160,6 @@ public class TabsWidget extends UIDialog implements WidgetManagerDelegate.WorldC
     public void hide(@HideFlags int aHideFlags) {
         super.hide(aHideFlags);
         mRenderer.clearSurface();
-        mWidgetManager.popWorldBrightness(this);
     }
 
     public void setTabDelegate(TabDelegate aDelegate) {
@@ -382,13 +375,6 @@ public class TabsWidget extends UIDialog implements WidgetManagerDelegate.WorldC
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
         if (ViewUtils.isEqualOrChildrenOf(this, oldFocus) && this.isVisible() &&
                 !ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
-            onDismiss();
-        }
-    }
-
-    @Override
-    public void onWorldClick() {
-        if (this.isVisible()) {
             onDismiss();
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -20,7 +20,6 @@ import org.mozilla.vrbrowser.ui.views.UITextButton;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.SendTabDialogWidget;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
 import org.mozilla.vrbrowser.utils.BitmapCache;
-import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 
@@ -368,14 +367,6 @@ public class TabsWidget extends UIDialog {
             outRect.left = mSpacingH / 2;
             outRect.right = mSpacingH / 2;
             outRect.top = row > 0 ? mSpacingV : 0;
-        }
-    }
-
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (ViewUtils.isEqualOrChildrenOf(this, oldFocus) && this.isVisible() &&
-                !ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
-            onDismiss();
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
@@ -318,9 +318,9 @@ public abstract class UIWidget extends FrameLayout implements Widget {
             mWidgetManager.pushBackHandler(mBackHandler);
         }
 
-        setFocusableInTouchMode(false);
+        setFocusableInTouchMode(true);
         if (aShowFlags == REQUEST_FOCUS) {
-            requestFocusFromTouch();
+            post(this::requestFocusFromTouch);
         } else if (aShowFlags == CLEAR_FOCUS) {
             clearFocus();
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/BaseAppDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/BaseAppDialogWidget.java
@@ -80,8 +80,6 @@ public class BaseAppDialogWidget extends UIDialog {
                 MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
         super.show(aShowFlags);
 
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-
         ViewTreeObserver viewTreeObserver = getViewTreeObserver();
         if (viewTreeObserver.isAlive()) {
             viewTreeObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -93,11 +91,6 @@ public class BaseAppDialogWidget extends UIDialog {
                 }
             });
         }
-    }
-
-    public void hide(@HideFlags int aHideFlags) {
-        super.hide(aHideFlags);
-        mWidgetManager.popWorldBrightness(this);
     }
 
     // WidgetManagerDelegate.FocusChangeListener

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/BaseAppDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/BaseAppDialogWidget.java
@@ -93,15 +93,6 @@ public class BaseAppDialogWidget extends UIDialog {
         }
     }
 
-    // WidgetManagerDelegate.FocusChangeListener
-
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (oldFocus == this && isVisible() && findViewById(newFocus.getId()) == null) {
-            onDismiss();
-        }
-    }
-
     public void setButtonsDelegate(Delegate delegate) {
         mAppDialogDelegate = delegate;
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
@@ -126,20 +126,6 @@ public class CrashDialogWidget extends UIDialog {
         aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.crash_dialog_world_z);
     }
 
-    @Override
-    public void show(@ShowFlags int aShowFlags) {
-        super.show(aShowFlags);
-
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-    }
-
-    @Override
-    public void hide(@HideFlags int aHideFlags) {
-        super.hide(aHideFlags);
-
-        mWidgetManager.popWorldBrightness(this);
-    }
-
     public void setCrashDialogDelegate(CrashDialogDelegate aDelegate) {
         mCrashDialogDelegate = aDelegate;
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
@@ -13,9 +13,8 @@ import android.widget.TextView;
 
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.audio.AudioEngine;
-import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.browser.SettingsStore;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
+import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 
 public class CrashDialogWidget extends UIDialog {
@@ -50,8 +49,6 @@ public class CrashDialogWidget extends UIDialog {
 
     private void initialize(Context aContext) {
         inflate(aContext, R.layout.crash_dialog, this);
-
-        mWidgetManager.addFocusChangeListener(this);
 
         mLearnMoreButton = findViewById(R.id.learnMoreButton);
         mDoNotSendButton = findViewById(R.id.dontSendButton);
@@ -104,13 +101,6 @@ public class CrashDialogWidget extends UIDialog {
         mCrashMessage.setText(getContext().getString(R.string.crash_dialog_message, getContext().getString(R.string.app_name)));
 
         mAudio = AudioEngine.fromContext(aContext);
-    }
-
-    @Override
-    public void releaseWidget() {
-        mWidgetManager.removeFocusChangeListener(this);
-
-        super.releaseWidget();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
@@ -10,21 +10,17 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
-import org.mozilla.vrbrowser.ui.widgets.UIWidget;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
-import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.net.URI;
 
-public class PermissionWidget extends UIDialog implements WidgetManagerDelegate.FocusChangeListener {
+public class PermissionWidget extends UIDialog {
 
     private TextView mPermissionMessage;
     private ImageView mPermissionIcon;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
@@ -80,20 +80,6 @@ public class PermissionWidget extends UIDialog implements WidgetManagerDelegate.
         aPlacement.anchorY = 0.5f;
     }
 
-    @Override
-    public void show(@ShowFlags int aShowFlags) {
-        super.show(aShowFlags);
-
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-    }
-
-    @Override
-    public void hide(@HideFlags int aHideFlag) {
-        super.hide(aHideFlag);
-
-        mWidgetManager.popWorldBrightness(this);
-    }
-
     public void showPrompt(String aUri, PermissionType aType, GeckoSession.PermissionDelegate.Callback aCallback) {
         int messageId;
         int iconId;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/RestartDialogWidget.java
@@ -74,17 +74,4 @@ public class RestartDialogWidget extends UIDialog {
         aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.restart_dialog_world_z);
     }
 
-    @Override
-    public void show(int aShowFlags) {
-        super.show(aShowFlags);
-
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-    }
-
-    @Override
-    public void hide(int aHideFlags) {
-        super.hide(aHideFlags);
-
-        mWidgetManager.popWorldBrightness(this);
-    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
@@ -8,7 +8,7 @@ import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
-public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate.FocusChangeListener {
+public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate.FocusChangeListener, WidgetManagerDelegate.WorldClickListener {
     public UIDialog(Context aContext) {
         super(aContext);
         initialize();
@@ -26,10 +26,12 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
 
     private void initialize() {
         mWidgetManager.addFocusChangeListener(this);
+        mWidgetManager.addWorldClickListener(this);
     }
 
     @Override
     public void releaseWidget() {
+        mWidgetManager.removeWorldClickListener(this);
         mWidgetManager.removeFocusChangeListener(this);
         super.releaseWidget();
     }
@@ -37,6 +39,20 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
     @Override
     public boolean isDialog() {
         return true;
+    }
+
+    @Override
+    public void show(int aShowFlags) {
+        super.show(aShowFlags);
+
+        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
+    }
+
+    @Override
+    public void hide(int aHideFlags) {
+        super.hide(aHideFlags);
+
+        mWidgetManager.popWorldBrightness(this);
     }
 
     // WidgetManagerDelegate.FocusChangeListener
@@ -48,4 +64,10 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
         }
     }
 
+    @Override
+    public void onWorldClick() {
+        if (this.isVisible()) {
+            onDismiss();
+        }
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
@@ -2,13 +2,11 @@ package org.mozilla.vrbrowser.ui.widgets.dialogs;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.view.View;
 
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
-import org.mozilla.vrbrowser.utils.ViewUtils;
 
-public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate.FocusChangeListener, WidgetManagerDelegate.WorldClickListener {
+public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate.WorldClickListener {
     public UIDialog(Context aContext) {
         super(aContext);
         initialize();
@@ -25,14 +23,12 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
     }
 
     private void initialize() {
-        mWidgetManager.addFocusChangeListener(this);
         mWidgetManager.addWorldClickListener(this);
     }
 
     @Override
     public void releaseWidget() {
         mWidgetManager.removeWorldClickListener(this);
-        mWidgetManager.removeFocusChangeListener(this);
         super.releaseWidget();
     }
 
@@ -53,15 +49,6 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
         super.hide(aHideFlags);
 
         mWidgetManager.popWorldBrightness(this);
-    }
-
-    // WidgetManagerDelegate.FocusChangeListener
-
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (oldFocus == this && isVisible()) {
-            onDismiss();
-        }
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
@@ -43,7 +43,7 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
+        if (oldFocus == this && isVisible()) {
             onDismiss();
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
@@ -25,7 +25,7 @@ import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 
 import java.util.concurrent.Executor;
 
-public class WhatsNewWidget extends UIDialog implements WidgetManagerDelegate.WorldClickListener {
+public class WhatsNewWidget extends UIDialog {
 
     private Accounts mAccounts;
     private Runnable mSignInCallback;
@@ -81,21 +81,10 @@ public class WhatsNewWidget extends UIDialog implements WidgetManagerDelegate.Wo
     }
 
     @Override
-    public void show(@ShowFlags int aShowFlags) {
-        super.show(aShowFlags);
-
-        mWidgetManager.addWorldClickListener(this);
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-    }
-
-    @Override
     public void hide(@HideFlags int aHideFlags) {
         super.hide(aHideFlags);
 
         SettingsStore.getInstance(getContext()).setWhatsNewDisplayed(true);
-
-        mWidgetManager.popWorldBrightness(this);
-        mWidgetManager.removeWorldClickListener(this);
     }
 
     private void signIn(View view) {
@@ -122,13 +111,6 @@ public class WhatsNewWidget extends UIDialog implements WidgetManagerDelegate.Wo
         if (mStartBrowsingCallback != null) {
             mStartBrowsingCallback.run();
         }
-    }
-
-    // WidgetManagerDelegate.WorldClickListener
-
-    @Override
-    public void onWorldClick() {
-        onDismiss();
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ChoicePromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ChoicePromptWidget.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
-import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.ChoicePrompt.Choice;
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.ChoicePrompt.Type;
 import org.mozilla.vrbrowser.R;
@@ -60,8 +59,6 @@ public class ChoicePromptWidget extends PromptWidget {
 
     protected void initialize(Context aContext) {
         inflate(aContext, R.layout.prompt_choice, this);
-
-        mWidgetManager.addFocusChangeListener(this);
 
         mAudio = AudioEngine.fromContext(aContext);
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ConfirmPromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/ConfirmPromptWidget.java
@@ -40,8 +40,6 @@ public class ConfirmPromptWidget extends PromptWidget {
     protected void initialize(Context aContext) {
         inflate(aContext, R.layout.prompt_confirm, this);
 
-        mWidgetManager.addFocusChangeListener(this);
-
         mAudio = AudioEngine.fromContext(aContext);
 
         mLayout = findViewById(R.id.layout);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
@@ -10,7 +10,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 
 import org.mozilla.vrbrowser.R;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
 
@@ -106,14 +105,6 @@ public class PromptWidget extends UIDialog {
 
         if (mDelegate != null) {
             mDelegate.onDismiss();
-        }
-    }
-
-    // WidgetManagerDelegate.FocusChangeListener
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (oldFocus == this && isVisible() && findViewById(newFocus.getId()) == null) {
-            onDismiss();
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
@@ -83,8 +83,6 @@ public class PromptWidget extends UIDialog {
                 getMinHeight();
         super.show(aShowFlags);
 
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-
         ViewTreeObserver viewTreeObserver = mLayout.getViewTreeObserver();
         if (viewTreeObserver.isAlive()) {
             viewTreeObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
@@ -96,11 +94,6 @@ public class PromptWidget extends UIDialog {
                 }
             });
         }
-    }
-
-    public void hide(@HideFlags int aHideFlags) {
-        super.hide(aHideFlags);
-        mWidgetManager.popWorldBrightness(this);
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -427,16 +427,6 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
         showView(new FxAAccountOptionsView(getContext(), mWidgetManager));
     }
 
-    // WindowManagerDelegate.FocusChangeListener
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (mCurrentView != null) {
-            mCurrentView.onGlobalFocusChanged(oldFocus, newFocus);
-        } else if (oldFocus == this && isVisible()) {
-            onDismiss();
-        }
-    }
-
     public void show(@ShowFlags int aShowFlags, @NonNull SettingDialog settingDialog) {
         show(aShowFlags);
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -55,7 +55,7 @@ import mozilla.components.concept.sync.AuthType;
 import mozilla.components.concept.sync.OAuthAccount;
 import mozilla.components.concept.sync.Profile;
 
-public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.WorldClickListener, SettingsView.Delegate {
+public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
 
     public enum SettingDialog {
         MAIN, LANGUAGE, DISPLAY, PRIVACY, DEVELOPER, FXA, ENVIRONMENT, CONTROLLER
@@ -106,8 +106,6 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.settings, this, true);
-
-        mWidgetManager.addWorldClickListener(this);
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
         mAccounts.addAccountListener(mAccountObserver);
@@ -225,7 +223,6 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
 
     @Override
     public void releaseWidget() {
-        mWidgetManager.removeWorldClickListener(this);
         mAccounts.removeAccountListener(mAccountObserver);
 
         super.releaseWidget();
@@ -472,22 +469,7 @@ public class SettingsWidget extends UIDialog implements WidgetManagerDelegate.Wo
     public void show(@ShowFlags int aShowFlags) {
         super.show(aShowFlags);
 
-        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
-
         updateCurrentAccountState();
-    }
-
-    @Override
-    public void hide(@HideFlags int aHideFlags) {
-        super.hide(aHideFlags);
-
-        mWidgetManager.popWorldBrightness(this);
-    }
-
-    // WidgetManagerDelegate.WorldClickListener
-    @Override
-    public void onWorldClick() {
-        onDismiss();
     }
 
     // SettingsView.Delegate


### PR DESCRIPTION
Fixes #2329 This PR fixes the following issues:
- The "Send Tab to Device" prompt is auto dismissed when trying to send a tab from the Hamburger menu after the app is resumed issue should be fixed now.
- UIDialog focus. After coming from suspension the focus was being requested too early and for dialogs like the NoInternet dialog (that are shown right after the activity is resumed) the focus request was not being processed. Now we enqueue the focus request so it is correctly processed in those cases.
- Adds a world click listener to the UIDialog. Most dialogs were already adding this so makes sense to refactor it a to a common place. Also there is an issue when resuming the activity twice. In that case the app focus is reset and old focus is null so dialogs couldn't be dismissed clicking in the world. It can be tested in the voice search dialog showing it and going home twice in a row.
- Common behavior for dimming the world. Some dialogs are dimming the world some others aren't. This standardizes that behavior, now all the dialogs dim the world.