### PR TITLE
Dismiss library panels explicitly

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/BookmarksCallback.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/BookmarksCallback.java
@@ -13,4 +13,5 @@ public interface BookmarksCallback {
     default void onFxASynSettings(@NonNull View view) {}
     default void onShowContextMenu(@NonNull View view, Bookmark item, boolean isLastVisibleItem) {}
     default void onHideContextMenu(@NonNull View view) {}
+    default void onItemClicked(@NonNull View view, Bookmark item) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/HistoryCallback.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/HistoryCallback.java
@@ -13,4 +13,5 @@ public interface HistoryCallback {
     default void onFxASynSettings(@NonNull View view) {}
     default void onShowContextMenu(@NonNull View view, @NonNull VisitInfo item, boolean isLastVisibleItem) {}
     default void onHideContextMenu(@NonNull View view) {}
+    default void onItemClicked(@NonNull View view, VisitInfo item) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -155,6 +155,8 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
+
+            mBookmarksViewListeners.forEach((listener) -> listener.onItemClicked(view, item));
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -158,6 +158,8 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
+
+            mHistoryViewListeners.forEach((listener) -> listener.onItemClicked(view, item));
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1420,6 +1420,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         public void onHideContextMenu(@NonNull View view) {
             hideContextMenus();
         }
+
+        @Override
+        public void onItemClicked(@NonNull View view, Bookmark item) {
+            hideBookmarks();
+        }
     };
 
     private HistoryCallback mHistoryListener = new HistoryCallback() {
@@ -1448,6 +1453,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         @Override
         public void onHideContextMenu(@NonNull View view) {
             hideContextMenus();
+        }
+
+        @Override
+        public void onItemClicked(@NonNull View view, VisitInfo item) {
+            hideHistory();
         }
     };
 
@@ -1546,14 +1556,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     @Override
     public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String s) {
         mCaptureOnPageStop = true;
-
-        if (isHistoryVisible()) {
-            hideHistory();
-        }
-
-        if (isBookmarksVisible()) {
-            hideBookmarks();
-        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #1955 Close the library panels explicitly after clicking on a link instead of using the Progress callbacks. This should speed up the panel dismiss after clicking on a link and also fix the reported issue.