### PR TITLE
Ensure Sessions are recreated correctly when clearing data

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -345,6 +345,24 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         mState.mSession = null;
     }
 
+    private boolean shouldLoadDefaultPage(@NonNull SessionState aState) {
+        if (aState.mUri != null && aState.mUri.length() != 0 && !aState.mUri.equals(mContext.getString(R.string.about_blank))) {
+            return false;
+        }
+        if (aState.mSessionState != null && aState.mSessionState.size() != 0) {
+            return false;
+        }
+        return true;
+    }
+
+    private void loadDefaultPage() {
+        if (mState.mSettings.isPrivateBrowsingEnabled()) {
+            loadPrivateBrowsingPage();
+        } else {
+            loadHomePage();
+        }
+    }
+
     private void restore() {
         SessionSettings settings = mState.mSettings;
         if (settings == null) {
@@ -364,18 +382,17 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             mState.mUri = null;
         }
 
-        if (mState.mSessionState != null) {
+        if (shouldLoadDefaultPage(mState)) {
+            loadDefaultPage();
+        } else if (mState.mSessionState != null) {
             mState.mSession.restoreState(mState.mSessionState);
+        } else if (mState.mUri != null) {
+            mState.mSession.loadUri(mState.mUri);
+        } else {
+            loadDefaultPage();
         }
 
-        if ((mState.mSessionState == null) && (mState.mUri != null)) {
-            mState.mSession.loadUri(mState.mUri);
-        } else if (mState.mSettings.isPrivateBrowsingEnabled() && mState.mUri == null) {
-            loadPrivateBrowsingPage();
-        } else if(mState.mSessionState == null || ((mState.mUri == null) || mState.mUri.equals(mContext.getResources().getString(R.string.about_blank))) ||
-                (mState.mSessionState != null && mState.mSessionState.size() == 0)) {
-            loadHomePage();
-        } else if (mState.mUri != null && mState.mUri.contains(".youtube.com")) {
+        if (mState.mUri != null && mState.mUri.contains(".youtube.com")) {
             mState.mSession.loadUri(mState.mUri, GeckoSession.LOAD_FLAGS_REPLACE_HISTORY);
         }
 
@@ -419,20 +436,19 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         return session;
     }
 
-    private void recreateSession() {
+    public void recreateSession() {
         SessionState previous = mState;
+        mState = mState.recreate();
+        restore();
 
-        mState = createSession(previous.mSettings, SESSION_OPEN);
-        mState.setActive(true);
-        if (previous.mSessionState != null) {
-            mState.mSession.restoreState(previous.mSessionState);
-        }
+        GeckoSession previousGeckoSession = null;
         if (previous.mSession != null) {
+            previousGeckoSession = previous.mSession;
             closeSession(previous);
         }
 
         for (SessionChangeListener listener : mSessionChangeListeners) {
-            listener.onCurrentSessionChange(previous.mSession, mState.mSession);
+            listener.onCurrentSessionChange(previousGeckoSession, mState.mSession);
         }
     }
 
@@ -444,7 +460,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         aState.mSession.setActive(false);
         aState.mSession.stop();
         if (aState.mDisplay != null) {
-            surfaceDestroyed();
+            aState.mDisplay.surfaceDestroyed();
             aState.mSession.releaseDisplay(aState.mDisplay);
             aState.mDisplay = null;
         }
@@ -785,24 +801,6 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             if (mState.mSession != null) {
                 mState.mSession.getSettings().setUseTrackingProtection(aEnabled);
             }
-        }
-    }
-
-    public void clearCache(final long clearFlags) {
-        if (mRuntime != null) {
-            // Per GeckoView Docs:
-            // Note: Any open session may re-accumulate previously cleared data.
-            // To ensure that no persistent data is left behind, you need to close all sessions prior to clearing data.
-            // https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/StorageController.html#clearData-long-
-            if (mState.mSession != null) {
-                mState.mSession.stop();
-                mState.mSession.close();
-            }
-
-            mRuntime.getStorageController().clearData(clearFlags).then(aVoid -> {
-                recreateSession();
-                return null;
-            });
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -466,6 +466,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
         aState.mSession.close();
         aState.setActive(false);
+        mFirstContentfulPaint = false;
     }
 
     public void captureBitmap() {
@@ -1052,6 +1053,14 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         if (mState.mSession == aSession) {
             for (GeckoSession.ContentDelegate listener : mContentListeners) {
                 listener.onFirstComposite(aSession);
+            }
+            if (mFirstContentfulPaint) {
+                // onFirstContentfulPaint is only called once after a session is opened.
+                // Notify onFirstContentfulPaint after a session is reattached before
+                // being closed ((e.g. tab selected)
+                for (GeckoSession.ContentDelegate listener : mContentListeners) {
+                    listener.onFirstContentfulPaint(aSession);
+                }
             }
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionState.java
@@ -41,6 +41,21 @@ public class SessionState {
     public String mId = UUID.randomUUID().toString();
     public String mParentId; // Parent session stack Id.
 
+    public SessionState recreate() {
+        SessionState result = new SessionState();
+        result.mUri = mUri;
+        result.mPreviousUri = mPreviousUri;
+        result.mTitle = mTitle;
+        result.mSettings = mSettings;
+        result.mSessionState = mSessionState;
+        result.mLastUse = mLastUse;
+        result.mRegion = mRegion;
+        result.mId = mId;
+        result.mParentId = mParentId;
+
+        return result;
+    }
+
     public static class GeckoSessionStateAdapter extends TypeAdapter<GeckoSession.SessionState> {
         @Override
         public void write(JsonWriter out, GeckoSession.SessionState session) throws IOException {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1109,13 +1109,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         } else {
             setPrivateBrowsingEnabled(false);
         }
+        waitForFirstPaint();
     }
 
     @Override
     public void onStackSession(Session aSession) {
         // e.g. tab opened via window.open()
         aSession.updateLastUse();
-        waitForFirstPaint();
         Session current = mSession;
         setSession(aSession);
         SessionStore.get().setActiveSession(aSession);


### PR DESCRIPTION
- Fixes #2356
- Fixes issue where switching Multiprocess in the developer panel would freeze the session.
- Fixes default private browsing page not getting displayed when recreating a private browsing session.