### PR TITLE
Use LoadRequest event to close library panels

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/BookmarksCallback.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/BookmarksCallback.java
@@ -13,5 +13,4 @@ public interface BookmarksCallback {
     default void onFxASynSettings(@NonNull View view) {}
     default void onShowContextMenu(@NonNull View view, Bookmark item, boolean isLastVisibleItem) {}
     default void onHideContextMenu(@NonNull View view) {}
-    default void onItemClicked(@NonNull View view, Bookmark item) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/HistoryCallback.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/HistoryCallback.java
@@ -13,5 +13,4 @@ public interface HistoryCallback {
     default void onFxASynSettings(@NonNull View view) {}
     default void onShowContextMenu(@NonNull View view, @NonNull VisitInfo item, boolean isLastVisibleItem) {}
     default void onHideContextMenu(@NonNull View view) {}
-    default void onItemClicked(@NonNull View view, VisitInfo item) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -156,8 +156,6 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
-
-            mBookmarksViewListeners.forEach((listener) -> listener.onItemClicked(view, item));
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -159,8 +159,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
-
-            mHistoryViewListeners.forEach((listener) -> listener.onItemClicked(view, item));
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -27,6 +27,7 @@ import androidx.annotation.StringRes;
 import androidx.annotation.UiThread;
 
 import org.jetbrains.annotations.NotNull;
+import org.mozilla.geckoview.AllowOrDeny;
 import org.mozilla.geckoview.GeckoResult;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.geckoview.PanZoomController;
@@ -67,7 +68,6 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 
 import mozilla.components.concept.storage.PageObservation;
 import mozilla.components.concept.storage.PageVisit;
@@ -1425,11 +1425,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
 
         @Override
-        public void onItemClicked(@NonNull View view, Bookmark item) {
-            hideBookmarks();
-        }
-
-        @Override
         public void onFxALogin(@NonNull View view) {
             hideBookmarks();
         }
@@ -1461,11 +1456,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         @Override
         public void onHideContextMenu(@NonNull View view) {
             hideContextMenus();
-        }
-
-        @Override
-        public void onItemClicked(@NonNull View view, VisitInfo item) {
-            hideHistory();
         }
 
         @Override
@@ -1581,6 +1571,22 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     public void captureImage() {
         mSession.captureBitmap();
+    }
+
+    // GeckoSession.NavigationDelegate
+
+    @Nullable
+    @Override
+    public GeckoResult<AllowOrDeny> onLoadRequest(@NonNull GeckoSession geckoSession, @NonNull LoadRequest loadRequest) {
+        if (isHistoryVisible()) {
+            hideHistory();
+        }
+
+        if (isBookmarksVisible()) {
+            hideBookmarks();
+        }
+
+        return GeckoResult.ALLOW;
     }
 
     @Override


### PR DESCRIPTION
Fixes #2366 This reverts https://github.com/MozillaReality/FirefoxReality/pull/2353 and moves the library panels dismiss to the `LoadRequest` event as it's the first event we get when a page load starts. 

This will cause a regression in https://github.com/MozillaReality/FirefoxReality/issues/1955 but there is really no better way of handling this as we need to close the panels with a new URL is loaded and that could happen from multiple places: URL buttons (back, forward, reload), Settings help/survey, history/bookmark links, voice search, etc. So looking again at the problem I think this is still our best option.