### PR TITLE
Replace history when overriding URL for Youtube

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -872,7 +872,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
         String uriOverride = SessionUtils.checkYoutubeOverride(uri);
         if (uriOverride != null) {
-            aSession.loadUri(uriOverride);
+            aSession.loadUri(uriOverride, GeckoSession.LOAD_FLAGS_REPLACE_HISTORY);
             return GeckoResult.DENY;
         }
 


### PR DESCRIPTION
Fixes #1956