### PR TITLE
Support for clearing bookmarks and history when signing out

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/BookmarksStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/BookmarksStore.kt
@@ -59,7 +59,7 @@ class BookmarksStore constructor(val context: Context) {
     }
 
     private val listeners = ArrayList<BookmarkListener>()
-    private val storage = (context.applicationContext as VRBrowserApplication).places.bookmarks
+    private var storage = (context.applicationContext as VRBrowserApplication).places.bookmarks
     private val titles = rootTitles(context)
     private val accountManager = (context.applicationContext as VRBrowserApplication).services.accountManager
 
@@ -98,6 +98,11 @@ class BookmarksStore constructor(val context: Context) {
 
     fun removeAllListeners() {
         listeners.clear()
+    }
+
+    internal fun updateStorage() {
+        storage = (context.applicationContext as VRBrowserApplication).places.bookmarks
+        notifyListeners()
     }
 
     fun getBookmarks(guid: String): CompletableFuture<List<BookmarkNode>?> = GlobalScope.future {
@@ -157,9 +162,7 @@ class BookmarksStore constructor(val context: Context) {
 
     fun getTree(guid: String, recursive: Boolean): CompletableFuture<List<BookmarkNode>?> = GlobalScope.future {
         storage.getTree(guid, recursive)?.children
-                ?.map {
-                    it.copy(title = titles[it.guid])
-                }
+                ?.map { it.copy(title = titles[it.guid]) }
     }
 
     fun searchBookmarks(query: String, limit: Int): CompletableFuture<List<BookmarkNode>> = GlobalScope.future {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
@@ -23,7 +23,7 @@ class HistoryStore constructor(val context: Context) {
     private val LOGTAG = SystemUtils.createLogtag(HistoryStore::class.java)
 
     private var listeners = ArrayList<HistoryListener>()
-    private val storage = (context.applicationContext as VRBrowserApplication).places.history
+    private var storage = (context.applicationContext as VRBrowserApplication).places.history
 
     // Bookmarks might have changed during sync, so notify our listeners.
     private val syncStatusObserver = object : SyncStatusObserver {
@@ -59,6 +59,11 @@ class HistoryStore constructor(val context: Context) {
 
     fun removeAllListeners() {
         listeners.clear()
+    }
+
+    internal fun updateStorage() {
+        storage = (context.applicationContext as VRBrowserApplication).places.history
+        notifyListeners()
     }
 
     fun getHistory(): CompletableFuture<List<String>?> = GlobalScope.future {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
@@ -8,11 +8,42 @@ package org.mozilla.vrbrowser.browser
 import android.content.Context
 import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.vrbrowser.browser.engine.SessionStore
+import org.mozilla.vrbrowser.utils.SystemUtils
 
 /**
  * Entry point for interacting with places-backed storage layers.
  */
-class Places(context: Context) {
-    val bookmarks by lazy { PlacesBookmarksStorage(context) }
-    val history by lazy { PlacesHistoryStorage(context) }
+class Places(var context: Context) {
+
+    private val LOGTAG = SystemUtils.createLogtag(Places::class.java)
+
+    var bookmarks = PlacesBookmarksStorage(context)
+    var history = PlacesHistoryStorage(context)
+
+    fun clear() {
+        val files = context.filesDir.listFiles { dir, name ->
+            name.matches("places\\.sqlite.*".toRegex())
+        }
+        for (file in files) {
+            if (!file.delete()) {
+                Logger(LOGTAG).debug("Can't remove " + file.absolutePath)
+            }
+        }
+
+        bookmarks.cleanup()
+        // We create a new storage, otherwise we would need to restart the app so it's created in the Application onCreate
+        bookmarks = PlacesBookmarksStorage(context)
+        // Update the storage in the proxy class
+        SessionStore.get().bookmarkStore.updateStorage()
+
+        // We are supposed to call this but it fails internally as apparently the PlacesStorage is common
+        // and it's already being cleaned after bookmarks.cleanup()
+        // history.cleanup()
+        // We create a new storage, otherwise we would need to restart the app so it's created in the Application onCreate
+        history = PlacesHistoryStorage(context)
+        // Update the storage in the proxy class
+        SessionStore.get().historyStore.updateStorage()
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.appservices.Megazord
 import mozilla.components.concept.sync.*
-import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.fxa.*
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
@@ -32,8 +31,13 @@ import org.mozilla.vrbrowser.R
 import org.mozilla.vrbrowser.browser.engine.EngineProvider
 import org.mozilla.vrbrowser.browser.engine.GeckoViewFetchClient
 import org.mozilla.vrbrowser.browser.engine.SessionStore
+import org.mozilla.vrbrowser.utils.SystemUtils
 
-class Services(context: Context, places: Places): GeckoSession.NavigationDelegate {
+
+class Services(val context: Context, places: Places): GeckoSession.NavigationDelegate {
+
+    private val LOGTAG = SystemUtils.createLogtag(Services::class.java)
+
     companion object {
         const val CLIENT_ID = "7ad9917f6c55fb77"
         const val REDIRECT_URL = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/Bookmark.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/Bookmark.java
@@ -104,7 +104,8 @@ public class Bookmark {
         for (BookmarkNode node : bookmarkNodes) {
             if (node.getType() == BookmarkNodeType.FOLDER) {
                 if (openFolderGuid != null && openFolderGuid.contains(node.getGuid())) {
-                    Bookmark bookmark = new Bookmark(node, level, true);
+                    boolean canExpand = node.getChildren() != null && !node.getChildren().isEmpty();
+                    Bookmark bookmark = new Bookmark(node, level, canExpand);
                     children.add(bookmark);
                     if (node.getChildren() != null) {
                         children.addAll(getDisplayListTree(node.getChildren(), level + 1, openFolderGuid));

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -53,6 +53,8 @@ import mozilla.components.service.fxa.SyncEngine;
 import mozilla.components.service.fxa.sync.SyncReason;
 import mozilla.components.service.fxa.sync.SyncStatusObserver;
 
+import static org.mozilla.vrbrowser.browser.BookmarksStoreKt.DESKTOP_ROOT;
+
 public class BookmarksView extends FrameLayout implements BookmarksStore.BookmarkListener {
 
     private static final String LOGTAG = SystemUtils.createLogtag(BookmarksView.class);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CheckboxDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CheckboxDialogWidget.java
@@ -1,0 +1,155 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.ui.widgets.dialogs;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.view.LayoutInflater;
+import android.view.ViewTreeObserver;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.databinding.DataBindingUtil;
+
+import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.databinding.CheckboxDialogBinding;
+import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
+import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
+
+public class CheckboxDialogWidget extends UIDialog {
+
+    public interface Delegate {
+        void onButtonClicked(int index);
+        default void onDismiss() {}
+    }
+
+    public static final int NEGATIVE = 0;
+    public static final int POSITIVE = 1;
+
+    protected CheckboxDialogBinding mBinding;
+    private Delegate mAppDialogDelegate;
+
+    public CheckboxDialogWidget(Context aContext) {
+        super(aContext);
+        initialize(aContext);
+    }
+
+    protected void initialize(Context aContext) {
+        LayoutInflater inflater = LayoutInflater.from(aContext);
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.checkbox_dialog, this, true);
+
+        mBinding.leftButton.setOnClickListener(v ->  {
+            if (mAppDialogDelegate != null) {
+                mAppDialogDelegate.onButtonClicked(NEGATIVE);
+            }
+        });
+        mBinding.rightButton.setOnClickListener(v -> {
+            if (mAppDialogDelegate != null) {
+                mAppDialogDelegate.onButtonClicked(POSITIVE);
+            }
+        });
+    }
+
+    @Override
+    protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
+        aPlacement.visible = false;
+        aPlacement.width =  WidgetPlacement.dpDimension(getContext(), R.dimen.checkbox_dialog_width);
+        aPlacement.height = WidgetPlacement.dpDimension(getContext(), R.dimen.checkbox_dialog_height);
+        aPlacement.parentAnchorX = 0.5f;
+        aPlacement.parentAnchorY = 0.5f;
+        aPlacement.anchorX = 0.5f;
+        aPlacement.anchorY = 0.5f;
+        aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.base_app_dialog_z_distance);
+    }
+
+    @Override
+    public void show(@ShowFlags int aShowFlags) {
+        measure(MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED),
+                MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));
+        super.show(aShowFlags);
+
+        mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
+
+        ViewTreeObserver viewTreeObserver = getViewTreeObserver();
+        if (viewTreeObserver.isAlive()) {
+            viewTreeObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                @Override
+                public void onGlobalLayout() {
+                    getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                    mWidgetPlacement.height = (int)(getHeight()/mWidgetPlacement.density);
+                    mWidgetManager.updateWidget(CheckboxDialogWidget.this);
+                }
+            });
+        }
+    }
+
+    public void hide(@HideFlags int aHideFlags) {
+        super.hide(aHideFlags);
+        mWidgetManager.popWorldBrightness(this);
+    }
+
+    public void setButtonsDelegate(Delegate delegate) {
+        mAppDialogDelegate = delegate;
+    }
+
+    public void setIcon(Drawable icon) {
+        mBinding.icon.setImageDrawable(icon);
+    }
+
+    public void setIcon(@DrawableRes int icon) {
+        mBinding.icon.setImageResource(icon);
+    }
+
+    public void setTitle(@StringRes int title) {
+        mBinding.title.setText(title);
+    }
+
+    public void setTitle(String title) {
+        mBinding.title.setText(title);
+    }
+
+    public void setBody(String body) {
+        mBinding.body.setText(body);
+    }
+
+    public void setBody(@StringRes int title) {
+        mBinding.body.setText(title);
+    }
+
+    public void setCheckboxText(@StringRes int text) {
+        mBinding.checkbox.setText(text);
+    }
+
+    public void setCheckboxText(String text) {
+        mBinding.checkbox.setText(text);
+    }
+
+    public void setButtons(@NonNull @StringRes int[] buttons) {
+        if (buttons.length > 0) {
+            mBinding.leftButton.setText(buttons[NEGATIVE]);
+        }
+        if (buttons.length > 1) {
+            mBinding.rightButton.setText(buttons[POSITIVE]);
+        }
+    }
+
+    public void setButtons(@NonNull String[] buttons) {
+        if (buttons.length > 0) {
+            mBinding.leftButton.setText(buttons[NEGATIVE]);
+        }
+        if (buttons.length > 1) {
+            mBinding.rightButton.setText(buttons[POSITIVE]);
+        }
+    }
+
+    public boolean isChecked() {
+        return mBinding.checkbox.isChecked();
+    }
+
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -10,7 +10,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Point;
-import android.graphics.drawable.Drawable;
+import android.graphics.drawable.BitmapDrawable;
 import android.text.Html;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -25,7 +25,6 @@ import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 
 import org.jetbrains.annotations.NotNull;
-import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
@@ -44,9 +43,7 @@ import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
 import org.mozilla.vrbrowser.ui.widgets.prompts.AlertPromptWidget;
 import org.mozilla.vrbrowser.utils.StringUtils;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -354,18 +351,9 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     };
 
     private void updateProfile(Profile profile) {
-        if (profile != null) {
-            ThreadUtils.postToBackgroundThread(() -> {
-                try {
-                    URL url = new URL(profile.getAvatar().getUrl());
-                    Drawable picture = Drawable.createFromStream(url.openStream(), "src");
-                    post(() -> mBinding.fxaButton.setImageDrawable(picture));
-
-                } catch (IOException e) {
-                    e.printStackTrace();
-
-                }
-            });
+        BitmapDrawable profilePicture = mAccounts.getProfilePicture();
+        if (profile != null && profilePicture != null) {
+            mBinding.fxaButton.setImageDrawable(profilePicture);
 
         } else {
             mBinding.fxaButton.setImageDrawable(getContext().getDrawable(R.drawable.ic_icon_settings_account));

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/ViewUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/ViewUtils.java
@@ -1,6 +1,13 @@
 package org.mozilla.vrbrowser.utils;
 
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.os.Build;
 import android.text.Html;
 import android.text.Layout;
@@ -212,5 +219,27 @@ public class ViewUtils {
 
     public static void setStickyClickListener(@NonNull View aView, View.OnClickListener aCallback) {
         aView.setOnTouchListener(new StickyClickListener(aCallback));
+    }
+
+    @NonNull
+    public static Bitmap getRoundedCroppedBitmap(@NonNull Bitmap bitmap) {
+        int widthLight = bitmap.getWidth();
+        int heightLight = bitmap.getHeight();
+
+        Bitmap output = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
+
+        Canvas canvas = new Canvas(output);
+        Paint paintColor = new Paint();
+        paintColor.setFlags(Paint.ANTI_ALIAS_FLAG);
+
+        RectF rectF = new RectF(new Rect(0, 0, widthLight, heightLight));
+
+        canvas.drawRoundRect(rectF, widthLight / 2 ,heightLight / 2,paintColor);
+
+        Paint paintImage = new Paint();
+        paintImage.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_ATOP));
+        canvas.drawBitmap(bitmap, 0, 0, paintImage);
+
+        return output;
     }
 }

--- a/app/src/main/res/layout/bookmark_item_folder.xml
+++ b/app/src/main/res/layout/bookmark_item_folder.xml
@@ -41,7 +41,6 @@
             android:duplicateParentState="true"
             android:drawableEnd="@{item.isExpanded ? @drawable/ic_baseline_arrow_drop_down_24px : @drawable/ic_baseline_arrow_drop_up_24px}"
             android:drawableTint="@color/fog"
-            android:drawablePadding="10dp"
-            visibleGone="@{item.hasChildren()}"/>
+            android:drawablePadding="10dp"/>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/checkbox_dialog.xml
+++ b/app/src/main/res/layout/checkbox_dialog.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <RelativeLayout
+        android:layout_width="@dimen/checkbox_dialog_width"
+        android:layout_height="@dimen/checkbox_dialog_height"
+        android:background="@drawable/dialog_background"
+        android:paddingStart="@dimen/checkbox_dialog_padding_sides"
+        android:paddingTop="@dimen/checkbox_dialog_padding_top"
+        android:paddingEnd="@dimen/checkbox_dialog_padding_sides"
+        android:paddingBottom="@dimen/checkbox_dialog_padding_bottom">
+
+        <FrameLayout
+            android:id="@+id/imageContainer"
+            android:layout_width="322dp"
+            android:layout_height="60dp"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginBottom="10dp">
+            <ImageView
+                android:id="@+id/icon"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ff_logo" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/titleContainer"
+            android:layout_width="322dp"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@+id/imageContainer">
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center_horizontal"
+                android:gravity="center_horizontal"
+                tools:text="Title"
+                android:textStyle="bold"
+                android:textColor="@color/fog"
+                android:textSize="@dimen/text_bigger_size" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/bodyContainer"
+            android:layout_width="322dp"
+            android:layout_height="80dp"
+            android:layout_centerHorizontal="true"
+            android:layout_below="@+id/titleContainer">
+            <TextView
+                android:id="@+id/body"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center_horizontal"
+                android:gravity="center_horizontal"
+                tools:text="Body"
+                android:textColor="@color/fog"
+                android:textSize="@dimen/text_medium_size" />
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/checkboxContainer"
+            android:layout_width="322dp"
+            android:layout_height="22dp"
+            android:layout_centerHorizontal="true"
+            android:layout_marginBottom="10dp"
+            android:layout_below="@+id/bodyContainer">
+            <CheckBox
+                android:id="@+id/checkbox"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:button="@drawable/checkbox"
+                android:layout_gravity="center_horizontal"
+                android:textSize="@dimen/text_medium_size"
+                tools:text="Checkbox" />
+        </FrameLayout>
+
+        <RelativeLayout
+            android:id="@+id/buttonsLayout"
+            android:layout_width="322dp"
+            android:layout_height="36dp"
+            android:layout_alignParentBottom="true"
+            android:layout_centerHorizontal="true">
+
+            <Button
+                android:id="@+id/leftButton"
+                android:layout_width="156dp"
+                android:layout_height="36dp"
+                android:layout_alignParentStart="true"
+                android:background="@drawable/dialog_regular_button_background"
+                android:fontFamily="sans-serif"
+                android:scaleType="fitCenter"
+                tools:text="Cancel"
+                android:textColor="@drawable/dialog_button_text_color"
+                android:textStyle="bold" />
+
+            <Button
+                android:id="@+id/rightButton"
+                android:layout_width="156dp"
+                android:layout_height="36dp"
+                android:layout_alignParentEnd="true"
+                android:background="@drawable/dialog_highlighted_button_background"
+                android:fontFamily="sans-serif"
+                android:scaleType="fitCenter"
+                tools:text="Accept"
+                android:textColor="@drawable/dialog_button_text_color"
+                android:textStyle="bold" />
+        </RelativeLayout>
+    </RelativeLayout>
+</layout>

--- a/app/src/main/res/layout/honeycomb_button.xml
+++ b/app/src/main/res/layout/honeycomb_button.xml
@@ -10,7 +10,7 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_gravity="center"
-            android:scaleType="fitXY"
+            android:scaleType="fitCenter"
             android:src="@drawable/ic_settings_privacypolicy"
             android:gravity="center" />
 

--- a/app/src/main/res/layout/send_tabs_display.xml
+++ b/app/src/main/res/layout/send_tabs_display.xml
@@ -54,7 +54,7 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:text="@string/send_tab_dialog_syncing"
-                tools:text="@string/send_tab_dialog_syncing "
+                tools:text="@string/send_tab_dialog_syncing"
                 app:visibleGone="@{isSyncing}"/>
 
             <!-- ScrollView doesn't support fast scrollbar so we need to use a custom implementation -->

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -305,4 +305,11 @@
     <!-- Whats new -->
     <dimen name="whats_new_width">450dp</dimen>
     <dimen name="whats_new_height">340dp</dimen>
+
+    <!-- Icon dialog -->
+    <dimen name="checkbox_dialog_width">450dp</dimen>
+    <dimen name="checkbox_dialog_height">340dp</dimen>
+    <dimen name="checkbox_dialog_padding_top">20dp</dimen>
+    <dimen name="checkbox_dialog_padding_bottom">42dp</dimen>
+    <dimen name="checkbox_dialog_padding_sides">64dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -851,6 +851,24 @@
     <!-- This string is displayed is the "Sync" button in the history panel when the sync is in progress. -->
     <string name="fxa_syncing">Syncing…</string>
 
+    <!-- This string is displayed in the title of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
+    <string name="fxa_signout_confirmation_title">Sign out of your Firefox Account?</string>
+
+    <!-- This string is displayed in the body of the FxA sign out dialog displayed when the user clicks on the Sign out button. -->
+    <string name="fxa_signout_confirmation_body">When you sign out, you won\'t be able to send or receive tabs from other devices. Your bookmarks and history will also stop syncing.</string>
+
+    <!-- This string is displayed in the checkbox text of the FxA sign out dialog displayed when the user clicks on the Sign out button.
+         When checked the history and Bookmarks will be deleted from gthe device after signing in. -->
+    <string name="fxa_signout_confirmation_checkbox">Clear history and bookmarks from this device</string>
+
+    <!-- This string is displayed in the cancel button of the FxA sign out dialog displayed when the user clicks on the Sign out button.
+         If clicked the user will be signed out from their FxA account and the dialog will be dismissed. -->
+    <string name="fxa_signout_confirmation_signout">Sign Out</string>
+
+    <!-- This string is displayed in the accept button of the FxA sign out dialog displayed when the user clicks on the Sign out button.
+         If clicked the user will not be signed out from the FxA account and the dialog will be dismissed. -->
+    <string name="fxa_signout_confirmation_cancel">Cancel</string>
+
     <!-- This string is displayed is the "Cancel" button from the clear history dialog.
          When pressed the dialog is closed. -->
     <string name="history_clear_cancel">Cancel</string>


### PR DESCRIPTION
Closes #2309 Adds support for clearing bookmarks and history when signing out from the FxA account.

AC/AS doesn't support clearing History/Bookmarks. Any record deletion is synced back with the account when the user signs-in again. This is a temporary hack until https://github.com/mozilla/application-services/issues/2250 is fixed and we can safely clear the storage after an account is signed-out.