### PR TITLE
Fix for disappearing context menus

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -418,7 +418,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
         mAttachedWindow = null;
         if (mAwesomeBar != null && mAwesomeBar.isVisible()) {
-            onHideAwesomeBar();
+            mAwesomeBar.hideNoAnim(UIWidget.KEEP_WIDGET);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
@@ -24,6 +24,7 @@ import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.ui.views.CustomListView;
+import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -125,11 +126,15 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
         mList.startAnimation(mScaleDownAnimation);
     }
 
+    public void hideNoAnim(@HideFlags int aHideFlags) {
+        super.hide(aHideFlags);
+    }
+
     // FocusChangeListener
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (oldFocus != null && isVisible()) {
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
             onDismiss();
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
@@ -184,7 +184,7 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isChildrenOf(getChildAt(0), newFocus)) {
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
             onDismiss();
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/ContextMenuWidget.java
@@ -122,7 +122,7 @@ public class ContextMenuWidget extends MenuWidget implements WidgetManagerDelega
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isChildrenOf(this, newFocus) && isVisible()) {
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
             onDismiss();
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/HamburgerMenuWidget.java
@@ -123,8 +123,8 @@ public class HamburgerMenuWidget extends MenuWidget implements WidgetManagerDele
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isChildrenOf(menuContainer, newFocus)) {
-            hide(KEEP_WIDGET);
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
+            onDismiss();
         }
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/LibraryMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/LibraryMenuWidget.java
@@ -140,8 +140,8 @@ public class LibraryMenuWidget extends MenuWidget implements WidgetManagerDelega
 
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isChildrenOf(menuContainer, newFocus)) {
-            hide(KEEP_WIDGET);
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
+            onDismiss();
         }
     }
 }


### PR DESCRIPTION
Fixes:
- Context menus (window, history/bookmarks) are being hidden right after being displayed. This is probably related to the fact that we are now always forcing the UIWidget to request focus after being shown and we weren't yet checking for `isEqualOrChildrenOf` in some of them.
- The awesome bar hiding animation happens in the new window when detached from a previous window.