### PR TITLE
Fix cropped items in Selection Action menu

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
@@ -35,6 +35,7 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
     private Point mPosition;
     private LinearLayout mContainer;
     private int mMinButtonWidth;
+    private int mMaxButtonWidth;
     private Collection<String> mActions;
 
     public SelectionActionWidget(Context aContext) {
@@ -45,7 +46,8 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
     private void initialize() {
         inflate(getContext(), R.layout.selection_action_menu, this);
         mContainer = findViewById(R.id.selectionMenuContainer);
-        mMinButtonWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.autocompletion_widget_min_item_width);
+        mMinButtonWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.selection_action_item_min_width);
+        mMaxButtonWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.selection_action_item_max_width);
         mBackHandler = () -> {
             onDismiss();
         };
@@ -156,6 +158,7 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
         }
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         button.setMinWidth(mMinButtonWidth);
+        button.setMaxWidth(mMaxButtonWidth);
         params.gravity = CENTER_VERTICAL;
         button.setLayoutParams(params);
         button.setTag(aAction);

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -245,6 +245,10 @@
     <dimen name="context_menu_corner_radius">20dp</dimen>
     <item name="context_menu_z_distance" format="float" type="dimen">0.1</item>
 
+    <!-- Selection Action Menu -->
+    <dimen name="selection_action_item_min_width">56dp</dimen>
+    <dimen name="selection_action_item_max_width">300dp</dimen>
+
     <!-- Library Menu -->
     <dimen name="library_menu_width">320dp</dimen>
     <dimen name="library_menu_item_height">60dp</dimen>


### PR DESCRIPTION
In some languages with longer texts the selection menu items are cropped. This PR correctly wraps the content to the text size.