### PR TITLE
Avoid duplicated  GeckoSession setActive calls

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -401,7 +401,9 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             exitImmersiveSync();
         }
         mAudioEngine.pauseEngine();
-        
+
+        mWindows.onPause();
+
         for (Widget widget: mWidgets.values()) {
             widget.onPause();
         }
@@ -422,6 +424,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (mOffscreenDisplay != null) {
             mOffscreenDisplay.onResume();
         }
+
+        mWindows.onResume();
 
         mAudioEngine.resumeEngine();
         for (Widget widget: mWidgets.values()) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -401,9 +401,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             exitImmersiveSync();
         }
         mAudioEngine.pauseEngine();
-
-        mWindows.onPause();
-
+        
         for (Widget widget: mWidgets.values()) {
             widget.onPause();
         }
@@ -424,8 +422,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         if (mOffscreenDisplay != null) {
             mOffscreenDisplay.onResume();
         }
-
-        mWindows.onResume();
 
         mAudioEngine.resumeEngine();
         for (Widget widget: mWidgets.values()) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -658,7 +658,9 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
 
         if (mState.mSession != null) {
-            mState.mSession.setActive(aActive);
+            if (mState.isActive() != aActive) {
+                mState.mSession.setActive(aActive);
+            }
             mState.setActive(aActive);
         } else if (aActive) {
             restore();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -412,23 +412,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         mIsPaused = true;
 
         saveState();
-        for (WindowWidget window: mRegularWindows) {
-            window.onPause();
-        }
-        for (WindowWidget window: mPrivateWindows) {
-            window.onPause();
-        }
     }
 
     public void onResume() {
         mIsPaused = false;
-
-        for (WindowWidget window: mRegularWindows) {
-            window.onResume();
-        }
-        for (WindowWidget window: mPrivateWindows) {
-            window.onResume();
-        }
 
         TelemetryWrapper.resetOpenedWindowsCount(mRegularWindows.size(), false);
         TelemetryWrapper.resetOpenedWindowsCount(mPrivateWindows.size(), true);


### PR DESCRIPTION
Fixes #2373 Fixes #2372 We were calling setActive twice when pausing/resuming the app and that seems to mess up GV state and triggered a JS error in the FxA login page: `throw new Error('submit already in progress');`

This could affect any other website, not only FxA.

STRs:
- SignIn using a non existing account (you can just add a `+n` to an existing account: user+n@mozilla.com)
- Fill the form and continue
- An email with the code should be received in that account
- When checking the code, click on the home button to pause the activity (otherwise it works)
- Resume the app again, put the code and click on Verify

Result: The Verify button doesn't work