### PR TITLE
Bump mozilla-speech to v1.0.9

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -60,13 +60,6 @@
 -keep class com.htc.** {*;}
 -keep class com.qualcomm.** {*;}
 
-# --------------------------------------------------------------------
-# Keep rules for mozillaspeechlibrary dependency
-# --------------------------------------------------------------------
--keep class cz.msebera.android.httpclient.** {*;}
--keep class com.loopj.android.http.** {*;}
--keep class com.github.axet.opusjni.Opus {*;}
-
 -dontwarn **
 -target 1.7
 -dontusemixedcaseclassnames

--- a/versions.gradle
+++ b/versions.gradle
@@ -33,7 +33,7 @@ versions.android_components = "21.0.0"
 // forUnitTest variant), and it's important that it be kept in
 // sync with the version used by android-components above.
 versions.mozilla_appservices = "0.42.2"
-versions.mozilla_speech = "1.0.6"
+versions.mozilla_speech = "1.0.9"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"
 versions.room = "2.2.0"


### PR DESCRIPTION
Includes:
- https://github.com/mozilla/androidspeech/pull/17
- https://github.com/mozilla/androidspeech/commit/d2f45141906fadc644d617836e6ae18255c2dfac