### PR TITLE
Close Library panels when clicking on an anchor

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/BookmarksCallback.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/BookmarksCallback.java
@@ -13,4 +13,5 @@ public interface BookmarksCallback {
     default void onFxASynSettings(@NonNull View view) {}
     default void onShowContextMenu(@NonNull View view, Bookmark item, boolean isLastVisibleItem) {}
     default void onHideContextMenu(@NonNull View view) {}
+    default void onClickItem(@NonNull View view, Bookmark item) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/HistoryCallback.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/callbacks/HistoryCallback.java
@@ -13,4 +13,5 @@ public interface HistoryCallback {
     default void onFxASynSettings(@NonNull View view) {}
     default void onShowContextMenu(@NonNull View view, @NonNull VisitInfo item, boolean isLastVisibleItem) {}
     default void onHideContextMenu(@NonNull View view) {}
+    default void onClickItem(@NonNull View view, @NonNull VisitInfo item) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -159,6 +159,8 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
+
+            mBookmarksViewListeners.forEach((listener) -> listener.onClickItem(view, item));
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -160,6 +160,8 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
             Session session = SessionStore.get().getActiveSession();
             session.loadUri(item.getUrl());
+
+            mHistoryViewListeners.forEach((listener) -> listener.onClickItem(view, item));
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1436,6 +1436,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         public void onFxALogin(@NonNull View view) {
             hideBookmarks();
         }
+
+        @Override
+        public void onClickItem(@NonNull View view, Bookmark item) {
+            hideBookmarks();
+        }
     };
 
     private HistoryCallback mHistoryListener = new HistoryCallback() {
@@ -1468,6 +1473,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onFxALogin(@NonNull View view) {
+            hideHistory();
+        }
+
+        @Override
+        public void onClickItem(@NonNull View view, @NonNull VisitInfo item) {
             hideHistory();
         }
     };


### PR DESCRIPTION
GV doesn't generate page load events when loading an anchor of the same page. 

STRs:
- Open a site with anchors
- Click on different icons
 - Open History and click on an anchor history item

Expect:
History panel should be closed

Actual:
The History panel is not closed