### PR TITLE
Omit redirections in history

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/HistoryStore.kt
@@ -73,14 +73,22 @@ class HistoryStore constructor(val context: Context) {
     fun getDetailedHistory(): CompletableFuture<List<VisitInfo>?> = GlobalScope.future {
         storage.getDetailedVisits(0, excludeTypes = listOf(
                 VisitType.NOT_A_VISIT,
+                VisitType.DOWNLOAD,
                 VisitType.REDIRECT_TEMPORARY,
+                VisitType.RELOAD,
+                VisitType.EMBED,
+                VisitType.FRAMED_LINK,
                 VisitType.REDIRECT_PERMANENT))
     }
 
     fun getVisitsPaginated(offset: Long, count: Long): CompletableFuture<List<VisitInfo>?> = GlobalScope.future {
         storage.getVisitsPaginated(offset, count, excludeTypes = listOf(
                 VisitType.NOT_A_VISIT,
+                VisitType.DOWNLOAD,
                 VisitType.REDIRECT_TEMPORARY,
+                VisitType.RELOAD,
+                VisitType.EMBED,
+                VisitType.FRAMED_LINK,
                 VisitType.REDIRECT_PERMANENT))
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
@@ -5,9 +5,9 @@
 
 package org.mozilla.vrbrowser.utils;
 
-import java.util.regex.Pattern;
-
 import androidx.annotation.Nullable;
+
+import java.util.regex.Pattern;
 
 
 // This class refers from mozilla-mobile/focus-android


### PR DESCRIPTION
Fixes #1839 Omit history redirects. Now we should just log the url that initiated the request.