### PR TITLE
Glean build system update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'com.android.application'
 apply from: "$project.rootDir/tools/gradle/versionCode.gradle"
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()
@@ -37,10 +38,9 @@ def getUseDebugSigningOnRelease = { ->
     return false
 }
 
-// Generate markdown docs for the collected metrics.
+// Glean: Generate markdown docs for the collected metrics.
 ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs"
-apply from: 'https://github.com/mozilla-mobile/android-components/raw/v' + deps.android_components_version + '/components/service/glean/scripts/sdk_generator.gradle'
 
 android {
     compileSdkVersion build_versions.target_sdk

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     addRepos(repositories)
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath "org.mozilla.telemetry:glean-gradle-plugin:$versions.android_components"
         classpath "$deps.kotlin.plugin"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/versions.gradle
+++ b/versions.gradle
@@ -50,6 +50,7 @@ versions.kotlin = "1.3.31"
 versions.kotlin_coroutines = "1.2.1"
 versions.snakeyaml = "1.24"
 versions.gson = "2.8.5"
+ext.versions = versions
 def deps = [:]
 
 def gecko_view = [:]


### PR DESCRIPTION
Closes #2388 This PR migrates to the new Glean build system (as the previous one is tagged as deprecated).

Other than that nothing has changed, we still need to delete the generated Kotlin files and the markdown docs so they get generated again.