### PR TITLE
AC WebExtensions support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,6 +84,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
     buildTypes {
         release {
             minifyEnabled true
@@ -460,6 +464,9 @@ dependencies {
     implementation deps.android_components.support_rustlog
     implementation deps.android_components.support_rusthttp
     implementation deps.android_components.glean
+    implementation deps.android_components.concept_engine
+    implementation deps.android_components.support_webextensions
+    implementation deps.android_components.browser_session
 
     // For production builds, the native code for all `org.mozilla.appservices`
     // dependencies gets compiled together into a single "megazord" build, and

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -62,7 +62,6 @@ import org.mozilla.vrbrowser.ui.widgets.RootWidget;
 import org.mozilla.vrbrowser.ui.widgets.TrayWidget;
 import org.mozilla.vrbrowser.ui.widgets.UISurfaceTextureRenderer;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
-import org.mozilla.vrbrowser.ui.widgets.menus.VideoProjectionMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.Widget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
@@ -70,6 +69,7 @@ import org.mozilla.vrbrowser.ui.widgets.WindowWidget;
 import org.mozilla.vrbrowser.ui.widgets.Windows;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.CrashDialogWidget;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.WhatsNewWidget;
+import org.mozilla.vrbrowser.ui.widgets.menus.VideoProjectionMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.prompts.ConfirmPromptWidget;
 import org.mozilla.vrbrowser.utils.BitmapCache;
 import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
@@ -223,9 +223,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         Bundle extras = getIntent() != null ? getIntent().getExtras() : null;
         SessionStore.get().setContext(this, extras);
-        SessionStore.get().initializeServices();
-        SessionStore.get().initializeStores(this);
-        SessionStore.get().setLocales(LocaleUtils.getPreferredLocales(this));
 
         // Create broadcast receiver for getting crash messages from crash process
         IntentFilter intentFilter = new IntentFilter();

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -29,10 +29,8 @@ import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.vrbrowser.R
 import org.mozilla.vrbrowser.browser.engine.EngineProvider
-import org.mozilla.vrbrowser.browser.engine.GeckoViewFetchClient
-import org.mozilla.vrbrowser.browser.engine.SessionStore
-import org.mozilla.vrbrowser.utils.SystemUtils
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService
+import org.mozilla.vrbrowser.utils.SystemUtils
 
 
 class Services(val context: Context, places: Places): GeckoSession.NavigationDelegate {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionChangeListener.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SessionChangeListener.java
@@ -4,6 +4,8 @@ import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.browser.engine.Session;
 
 public interface SessionChangeListener {
+    default void onSessionOpened(Session aSession) {}
+    default void onSessionClosed(Session aSession) {}
     default void onRemoveSession(Session aSession) {}
     default void onCurrentSessionChange(GeckoSession aOldSession, GeckoSession aSession) {}
     default void onStackSession(Session aSession) {}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -7,6 +7,8 @@ import android.os.StrictMode;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mozilla.geckoview.GeckoSessionSettings;
@@ -14,16 +16,12 @@ import org.mozilla.telemetry.TelemetryHolder;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
-import org.mozilla.vrbrowser.ui.widgets.UISurfaceTextureRenderer;
 import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.utils.LocaleUtils;
 import org.mozilla.vrbrowser.utils.StringUtils;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
-import androidx.annotation.NonNull;
-
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -690,8 +688,6 @@ public class SettingsStore {
         } catch (Exception e) {
             return FXA_LAST_SYNC_NEVER;
         }
-
-
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
@@ -9,7 +9,6 @@ import mozilla.components.concept.fetch.Client
 import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
-import org.mozilla.geckoview.WebExtension
 import org.mozilla.vrbrowser.BuildConfig
 import org.mozilla.vrbrowser.browser.SettingsStore
 import org.mozilla.vrbrowser.crashreporting.CrashReporterService
@@ -50,12 +49,6 @@ object EngineProvider {
             }
 
             runtime = GeckoRuntime.create(context, builder.build())
-            for (extension in WEB_EXTENSIONS) {
-                val path = "resource://android/assets/web_extensions/$extension/"
-                runtime!!.registerWebExtension(WebExtension(path))
-            }
-
-
         }
 
         return runtime!!

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/GeckoViewFetchClient.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/GeckoViewFetchClient.kt
@@ -6,19 +6,10 @@ package org.mozilla.vrbrowser.browser.engine
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import mozilla.components.concept.fetch.Client
-import mozilla.components.concept.fetch.Headers
-import mozilla.components.concept.fetch.MutableHeaders
-import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.Response
-
-import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoWebExecutor
-import org.mozilla.geckoview.WebRequest
+import mozilla.components.concept.fetch.*
+import org.mozilla.geckoview.*
 import org.mozilla.geckoview.WebRequest.CACHE_MODE_DEFAULT
 import org.mozilla.geckoview.WebRequest.CACHE_MODE_RELOAD
-import org.mozilla.geckoview.WebRequestError
-import org.mozilla.geckoview.WebResponse
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.nio.ByteBuffer

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -83,7 +83,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     private transient SharedPreferences mPrefs;
     private transient GeckoRuntime mRuntime;
     private transient byte[] mPrivatePage;
-    private transient boolean mFirstContentFulPaint;
+    private transient boolean mFirstContentfulPaint;
     private transient long mKeepAlive;
     private transient boolean mIsFirstActivation;
 
@@ -465,7 +465,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
         aState.mSession.close();
         aState.setActive(false);
-        mFirstContentFulPaint = false;
+        mFirstContentfulPaint = false;
 
         for (SessionChangeListener listener : mSessionChangeListeners) {
             listener.onSessionClosed(this);
@@ -474,7 +474,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     public void captureBitmap() {
-        if (mState.mDisplay == null || !mFirstContentFulPaint) {
+        if (mState.mDisplay == null || !mFirstContentfulPaint) {
             return;
         }
         try {
@@ -499,7 +499,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     public CompletableFuture<Void> captureBackgroundBitmap(int displayWidth, int displayHeight) {
-        if (mState.mSession == null || !mFirstContentFulPaint) {
+        if (mState.mSession == null || !mFirstContentfulPaint) {
             return CompletableFuture.completedFuture(null);
         }
         Surface captureSurface = BitmapCache.getInstance(mContext).acquireCaptureSurface(displayWidth, displayHeight);
@@ -602,7 +602,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     public boolean isFirstContentfulPaint() {
-        return mFirstContentFulPaint;
+        return mFirstContentfulPaint;
     }
 
     public Media getFullScreenVideo() {
@@ -1096,7 +1096,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             for (GeckoSession.ContentDelegate listener : mContentListeners) {
                 listener.onFirstComposite(aSession);
             }
-            if (mFirstContentFulPaint) {
+            if (mFirstContentfulPaint) {
                 // onFirstContentfulPaint is only called once after a session is opened.
                 // Notify onFirstContentfulPaint after a session is reattached before
                 // being closed ((e.g. tab selected)
@@ -1109,7 +1109,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
     @Override
     public void onFirstContentfulPaint(@NonNull GeckoSession aSession) {
-        mFirstContentFulPaint = true;
+        mFirstContentfulPaint = true;
         if (mState.mSession == aSession) {
             for (GeckoSession.ContentDelegate listener : mContentListeners) {
                 listener.onFirstContentfulPaint(aSession);

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSessionManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSessionManager.java
@@ -1,0 +1,77 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.mozilla.vrbrowser.browser.SessionChangeListener;
+import org.mozilla.vrbrowser.browser.engine.Session;
+import org.mozilla.vrbrowser.browser.engine.SessionStore;
+import org.mozilla.vrbrowser.browser.extensions.VimeoExtensionFeature;
+import org.mozilla.vrbrowser.browser.extensions.YoutubeExtensionFeature;
+import org.mozilla.vrbrowser.utils.SystemUtils;
+
+import mozilla.components.browser.session.LegacySessionManager;
+import mozilla.components.browser.session.SessionManager;
+import mozilla.components.browser.state.store.BrowserStore;
+import mozilla.components.support.base.observer.ObserverRegistry;
+
+public class FxRSessionManager implements SessionChangeListener {
+
+    private static final String LOGTAG = SystemUtils.createLogtag(FxRSessionManager.class);
+
+    private Context mContext;
+    private ObserverRegistry mRegistry;
+    private SessionManager mSessionManager;
+
+    public FxRSessionManager(@NonNull Context context, @NonNull SessionStore store) {
+        mContext = context;
+        BrowserStore browserStore = new BrowserStore();
+        GeckoEngine geckoEngine = new GeckoEngine(context, store);
+        mRegistry = new ObserverRegistry();
+
+        LegacySessionManager legacySessionManager = new LegacySessionManager(
+                geckoEngine,
+                new SessionManager.EngineSessionLinker(browserStore),
+                mRegistry);
+
+        mSessionManager = new SessionManager(
+                geckoEngine,
+                browserStore,
+                legacySessionManager);
+
+        VimeoExtensionFeature.install(geckoEngine);
+        YoutubeExtensionFeature.install(geckoEngine);
+    }
+
+    // SessionChangeListener
+
+    @Override
+    public void onSessionOpened(Session aSession) {
+        mozilla.components.browser.session.Session session = new mozilla.components.browser.session.Session(
+                aSession.getCurrentUri(),
+                aSession.isPrivateMode(),
+                mozilla.components.browser.session.Session.Source.NONE,
+                aSession.getId(),
+                mRegistry);
+        mSessionManager.add(session, aSession.isActive(), new GeckoEngineSession(mContext, aSession), null);
+    }
+
+    @Override
+    public void onSessionClosed(Session aSession) {
+        mozilla.components.browser.session.Session session = mSessionManager.findSessionById(aSession.getId());
+        if (session != null) {
+            mSessionManager.remove(session, false);
+        }
+    }
+
+    @Override
+    public void onActiveStateChange(Session aSession, boolean aActive) {
+        if (aActive) {
+            mozilla.components.browser.session.Session session = mSessionManager.findSessionById(aSession.getId());
+            if (session != null) {
+                mSessionManager.select(session);
+            }
+        }
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSessionSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSessionSettings.java
@@ -1,0 +1,90 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.mozilla.vrbrowser.browser.engine.Session;
+
+import mozilla.components.concept.engine.EngineSession;
+import mozilla.components.concept.engine.Settings;
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate;
+import mozilla.components.concept.engine.request.RequestInterceptor;
+
+public class FxRSessionSettings extends Settings {
+
+    private Session mSession;
+
+    FxRSessionSettings(@NonNull Session session) {
+        mSession = session;
+    }
+
+    @Override
+    public boolean getJavascriptEnabled() {
+        if (mSession.getGeckoSession() != null) {
+            return mSession.getGeckoSession().getSettings().getAllowJavascript();
+
+        } else{
+            return false;
+        }
+    }
+
+    @Override
+    public void setJavascriptEnabled(boolean b) {
+        if (mSession.getGeckoSession() != null) {
+            mSession.getGeckoSession().getSettings().setAllowJavascript(b);
+        }
+    }
+
+    @Nullable
+    @Override
+    public String getUserAgentString() {
+        if (mSession.getGeckoSession() != null) {
+            return mSession.getGeckoSession().getSettings().getUserAgentOverride();
+
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void setUserAgentString(@Nullable String s) {
+        if (mSession.getGeckoSession() != null) {
+            mSession.getGeckoSession().getSettings().setUserAgentOverride(s);
+        }
+    }
+
+    @Override
+    public boolean getSuspendMediaWhenInactive() {
+        if (mSession.getGeckoSession() != null) {
+            return mSession.getGeckoSession().getSettings().getSuspendMediaWhenInactive();
+
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void setSuspendMediaWhenInactive(boolean b) {
+        if (mSession.getGeckoSession() != null) {
+            mSession.getGeckoSession().getSettings().setSuspendMediaWhenInactive(b);
+        }
+    }
+
+    @Nullable
+    @Override
+    public EngineSession.TrackingProtectionPolicy getTrackingProtectionPolicy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public HistoryTrackingDelegate getHistoryTrackingDelegate() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public RequestInterceptor getRequestInterceptor() {
+        return null;
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSettings.java
@@ -140,7 +140,7 @@ public class FxRSettings extends Settings {
 
     @Override
     public boolean getSuspendMediaWhenInactive() {
-        return false;
+        return true;
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/FxRSettings.java
@@ -1,0 +1,233 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.jetbrains.annotations.NotNull;
+import org.mozilla.geckoview.ContentBlocking;
+import org.mozilla.geckoview.GeckoRuntimeSettings;
+import org.mozilla.geckoview.GeckoSession;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import mozilla.components.concept.engine.EngineSession;
+import mozilla.components.concept.engine.Settings;
+import mozilla.components.concept.engine.history.HistoryTrackingDelegate;
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme;
+import mozilla.components.concept.engine.request.RequestInterceptor;
+
+public class FxRSettings extends Settings {
+
+    private GeckoRuntimeSettings mGeckoRuntimeSettings;
+
+    FxRSettings(@NonNull GeckoRuntimeSettings settings) {
+        mGeckoRuntimeSettings = settings;
+    }
+
+    @Override
+    public boolean getJavascriptEnabled() {
+        return mGeckoRuntimeSettings.getJavaScriptEnabled();
+    }
+
+    @Override
+    public void setJavascriptEnabled(boolean b) {
+        mGeckoRuntimeSettings.setJavaScriptEnabled(b);
+    }
+
+    @Override
+    public boolean getWebFontsEnabled() {
+        return mGeckoRuntimeSettings.getWebFontsEnabled();
+    }
+
+    @Override
+    public void setWebFontsEnabled(boolean b) {
+        mGeckoRuntimeSettings.setWebFontsEnabled(b);
+    }
+
+    @Override
+    public boolean getAutomaticFontSizeAdjustment() {
+        return mGeckoRuntimeSettings.getAutomaticFontSizeAdjustment();
+    }
+
+    @Override
+    public void setAutomaticFontSizeAdjustment(boolean b) {
+        mGeckoRuntimeSettings.setAutomaticFontSizeAdjustment(b);
+    }
+
+    @Override
+    public boolean getAutomaticLanguageAdjustment() {
+        return false;
+    }
+
+    @Override
+    public void setAutomaticLanguageAdjustment(boolean b) {
+        // Not yet implemented
+    }
+
+    @NotNull
+    @Override
+    public EngineSession.SafeBrowsingPolicy[] getSafeBrowsingPolicy() {
+        return Stream.of(EngineSession.SafeBrowsingPolicy.RECOMMENDED).toArray(EngineSession.SafeBrowsingPolicy[]::new);
+    }
+
+    @Override
+    public void setSafeBrowsingPolicy(@NotNull EngineSession.SafeBrowsingPolicy[] safeBrowsingPolicies) {
+        int policy = Stream.of(safeBrowsingPolicies).mapToInt(EngineSession.SafeBrowsingPolicy::ordinal).sum();
+        mGeckoRuntimeSettings.getContentBlocking().setSafeBrowsing(policy);
+    }
+
+    @Override
+    public void setTrackingProtectionPolicy(@Nullable EngineSession.TrackingProtectionPolicy trackingProtectionPolicy) {
+        boolean activateStrictSocialTracking = false;
+        if (trackingProtectionPolicy != null) {
+            if (trackingProtectionPolicy.getStrictSocialTrackingProtection() != null) {
+                activateStrictSocialTracking = Stream.of(trackingProtectionPolicy.getTrackingCategories()).anyMatch(item -> item == EngineSession.TrackingProtectionPolicy.TrackingCategory.STRICT);
+            }
+
+            int etpLevel = ContentBlocking.EtpLevel.STRICT;
+            if (Stream.of(trackingProtectionPolicy.getTrackingCategories()).collect(Collectors.toList()).contains(EngineSession.TrackingProtectionPolicy.TrackingCategory.NONE)) {
+                etpLevel = ContentBlocking.EtpLevel.NONE;
+            }
+
+            mGeckoRuntimeSettings.getContentBlocking().setEnhancedTrackingProtectionLevel(etpLevel);
+            mGeckoRuntimeSettings.getContentBlocking().setStrictSocialTrackingProtection(activateStrictSocialTracking);
+            mGeckoRuntimeSettings.getContentBlocking().setCookieBehavior(trackingProtectionPolicy.getCookiePolicy().getId());
+        }
+    }
+
+    @Override
+    public boolean getTestingModeEnabled() {
+        return false;
+    }
+
+    @Override
+    public void setTestingModeEnabled(boolean b) {
+        // Not yet implemented
+    }
+
+    @Nullable
+    @Override
+    public String getUserAgentString() {
+        return GeckoSession.getDefaultUserAgent();
+    }
+
+    @Override
+    public void setUserAgentString(@org.jetbrains.annotations.Nullable String s) {
+        // Not yet implemented
+    }
+
+    @NotNull
+    @Override
+    public PreferredColorScheme getPreferredColorScheme() {
+        return fromGeckoValue(mGeckoRuntimeSettings.getPreferredColorScheme());
+    }
+
+    @Override
+    public void setPreferredColorScheme(@NotNull PreferredColorScheme preferredColorScheme) {
+        mGeckoRuntimeSettings.setPreferredColorScheme(toGeckoValue(preferredColorScheme));
+    }
+
+    @Override
+    public boolean getAllowAutoplayMedia() {
+        return mGeckoRuntimeSettings.getAutoplayDefault() == GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED;
+    }
+
+    @Override
+    public void setAllowAutoplayMedia(boolean b) {
+        mGeckoRuntimeSettings.setAutoplayDefault(b ? GeckoRuntimeSettings.AUTOPLAY_DEFAULT_ALLOWED : GeckoRuntimeSettings.AUTOPLAY_DEFAULT_BLOCKED);
+    }
+
+    @Override
+    public boolean getSuspendMediaWhenInactive() {
+        return false;
+    }
+
+    @Override
+    public void setSuspendMediaWhenInactive(boolean b) {
+        // Not yet implemented
+    }
+
+    @Override
+    public boolean getRemoteDebuggingEnabled() {
+        return mGeckoRuntimeSettings.getRemoteDebuggingEnabled();
+    }
+
+    @Override
+    public void setRemoteDebuggingEnabled(boolean b) {
+        mGeckoRuntimeSettings.setRemoteDebuggingEnabled(b);
+    }
+
+    @Nullable
+    @Override
+    public Boolean getFontInflationEnabled() {
+        return mGeckoRuntimeSettings.getFontInflationEnabled();
+    }
+
+    @Override
+    public void setFontInflationEnabled(@Nullable Boolean aBoolean) {
+        mGeckoRuntimeSettings.setFontInflationEnabled(aBoolean);
+    }
+
+    @Nullable
+    @Override
+    public Float getFontSizeFactor() {
+        return mGeckoRuntimeSettings.getFontSizeFactor();
+    }
+
+    @Override
+    public void setFontSizeFactor(@Nullable Float aFloat) {
+        mGeckoRuntimeSettings.setFontSizeFactor(aFloat);
+    }
+
+    @Override
+    public boolean getForceUserScalableContent() {
+        return mGeckoRuntimeSettings.getForceUserScalableEnabled();
+    }
+
+    @Override
+    public void setForceUserScalableContent(boolean b) {
+        mGeckoRuntimeSettings.setForceUserScalableEnabled(b);
+    }
+
+    @Nullable
+    @Override
+    public EngineSession.TrackingProtectionPolicy getTrackingProtectionPolicy() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public HistoryTrackingDelegate getHistoryTrackingDelegate() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public RequestInterceptor getRequestInterceptor() {
+        return null;
+    }
+
+    private static PreferredColorScheme fromGeckoValue(int geckoValue) {
+        switch (geckoValue) {
+            case GeckoRuntimeSettings.COLOR_SCHEME_DARK: return PreferredColorScheme.Dark.INSTANCE;
+            case GeckoRuntimeSettings.COLOR_SCHEME_LIGHT: return PreferredColorScheme.Light.INSTANCE;
+            case GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM:
+            default: return PreferredColorScheme.System.INSTANCE;
+        }
+    }
+
+    private static int toGeckoValue(PreferredColorScheme scheme) {
+        if (scheme == PreferredColorScheme.Dark.INSTANCE) {
+            return GeckoRuntimeSettings.COLOR_SCHEME_DARK;
+
+        } else if (scheme == PreferredColorScheme.Light.INSTANCE) {
+            return GeckoRuntimeSettings.COLOR_SCHEME_LIGHT;
+
+        } else if (scheme == PreferredColorScheme.System.INSTANCE) {
+            return GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM;
+        }
+
+        return GeckoRuntimeSettings.COLOR_SCHEME_SYSTEM;
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngine.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngine.java
@@ -1,0 +1,255 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
+import org.mozilla.geckoview.ContentBlocking;
+import org.mozilla.geckoview.ContentBlockingController;
+import org.mozilla.geckoview.GeckoResult;
+import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.WebExtensionController;
+import org.mozilla.vrbrowser.browser.engine.Session;
+import org.mozilla.vrbrowser.browser.engine.SessionStore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
+import kotlin.jvm.functions.Function1;
+import kotlin.jvm.functions.Function2;
+import mozilla.components.concept.engine.Engine;
+import mozilla.components.concept.engine.EngineSession;
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy;
+import mozilla.components.concept.engine.EngineSessionState;
+import mozilla.components.concept.engine.EngineView;
+import mozilla.components.concept.engine.Settings;
+import mozilla.components.concept.engine.content.blocking.TrackerLog;
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage;
+import mozilla.components.concept.engine.utils.EngineVersion;
+import mozilla.components.concept.engine.webextension.WebExtension;
+import mozilla.components.concept.engine.webextension.WebExtensionDelegate;
+import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate;
+import mozilla.components.concept.engine.webpush.WebPushDelegate;
+import mozilla.components.concept.engine.webpush.WebPushHandler;
+
+import static org.mozilla.geckoview.BuildConfig.MOZILLA_VERSION;
+
+public class GeckoEngine implements Engine {
+
+    private Context mContext;
+    private SessionStore mSessionStore;
+    private WebExtensionDelegate mWebExtensionDelegate;
+    private Settings mSettings;
+
+    GeckoEngine(@NonNull Context context, @NonNull SessionStore sessionstore) {
+        mContext = context;
+        mSessionStore = sessionstore;
+        mSettings = new FxRSettings(mSessionStore.getRuntime().getSettings());
+    }
+
+    @NotNull
+    @Override
+    public Settings getSettings() {
+        return mSettings;
+    }
+
+    @NotNull
+    @Override
+    public TrackingProtectionExceptionStorage getTrackingProtectionExceptionStore() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public EngineVersion getVersion() {
+        EngineVersion version = EngineVersion.Companion.parse(MOZILLA_VERSION);
+        if (version != null) {
+            return version;
+        }
+
+        throw new IllegalStateException("Could not determine engine version");
+    }
+
+    @Override
+    public void clearData(@NotNull BrowsingData browsingData, @Nullable String host, @NotNull Function0<Unit> onSuccess, @NotNull Function1<? super Throwable, Unit> onError) {
+        long types = (long) browsingData.getTypes();
+        if (host != null) {
+            mSessionStore.getRuntime().getStorageController().clearDataFromHost(host, types).then(aVoid -> {
+                onSuccess.invoke();
+                return null;
+            }, throwable -> {
+                onError.invoke(throwable);
+                return null;
+            });
+
+        } else {
+            mSessionStore.getRuntime().getStorageController().clearData(types).then(aVoid -> {
+                onSuccess.invoke();
+                return null;
+            }, throwable -> {
+                onError.invoke(throwable);
+                return null;
+            });
+        }
+
+    }
+
+    @NotNull
+    @Override
+    public EngineSession createSession(boolean isPrivate) {
+        return new GeckoEngineSession(mContext, mSessionStore.createSession(isPrivate));
+    }
+
+    @NotNull
+    @Override
+    public EngineSessionState createSessionState(@NotNull JSONObject jsonObject) {
+        return GeckoEngineSessionState.fromJSON(jsonObject);
+    }
+
+    @NotNull
+    @Override
+    public EngineView createView(@NotNull Context context, @Nullable AttributeSet attributeSet) {
+        // We don't support Engine views creation
+        return null;
+    }
+
+    @Override
+    public void getTrackersLog(@NotNull EngineSession engineSession, @NotNull Function1<? super List<TrackerLog>, Unit> onSuccess, @NotNull Function1<? super Throwable, Unit> onError) {
+        GeckoSession session = ((GeckoEngineSession)engineSession).getGeckoSession();
+        mSessionStore.getRuntime().getContentBlockingController().getLog(session).then(logEntries -> {
+            List<ContentBlockingController.LogEntry> list = new ArrayList<>();
+            if (logEntries!= null) {
+                list = logEntries;
+            }
+            List<TrackerLog> logs = list.stream().map(this::toTrackerLog).filter(it -> !(it.getCookiesHasBeenBlocked() && it.getBlockedCategories().isEmpty() && it.getLoadedCategories().isEmpty())).collect(Collectors.toCollection(ArrayList::new));
+
+            onSuccess.invoke(logs);
+            return new GeckoResult<>();
+
+        }, throwable -> {
+            onError.invoke(throwable);
+            return new GeckoResult<>();
+        });
+    }
+
+    @Override
+    public void installWebExtension(@NotNull String id, @NotNull String url, boolean allowContentMessaging, @NotNull Function1<? super WebExtension, Unit> onSuccess, @NotNull Function2<? super String, ? super Throwable, Unit> onError) {
+        final GeckoWebExtension extension = new GeckoWebExtension(id, url, allowContentMessaging);
+        mSessionStore.getRuntime().registerWebExtension(extension.getNativeExtension()).then(aVoid -> {
+            if (mWebExtensionDelegate != null) {
+                mWebExtensionDelegate.onInstalled(extension);
+            }
+
+            onSuccess.invoke(extension);
+
+            return new GeckoResult<>();
+
+        }, throwable -> {
+            onError.invoke(id, throwable);
+
+            return new GeckoResult<>();
+        });
+    }
+
+    @NotNull
+    @Override
+    public String name() {
+        return "Gecko";
+    }
+
+    @Override
+    public void registerWebExtensionDelegate(@NotNull WebExtensionDelegate webExtensionDelegate) {
+        mWebExtensionDelegate = webExtensionDelegate;
+
+        mSessionStore.getRuntime().getWebExtensionController().setTabDelegate(new WebExtensionController.TabDelegate() {
+            @NotNull
+            @Override
+            public GeckoResult<GeckoSession> onNewTab(@androidx.annotation.Nullable org.mozilla.geckoview.WebExtension webExtension, @androidx.annotation.Nullable String url) {
+                Session session = mSessionStore.createSession(mSessionStore.getActiveSession().isPrivateMode());
+                if (webExtension != null) {
+                    GeckoWebExtension extension = new GeckoWebExtension(webExtension.id, webExtension.location, true);
+                    mWebExtensionDelegate.onNewTab(extension, url != null ? url : "", new GeckoEngineSession(mContext, session));
+                }
+
+                return GeckoResult.fromValue(session.getGeckoSession());
+            }
+        });
+    }
+
+    @Override
+    public void registerWebNotificationDelegate(@NotNull WebNotificationDelegate webNotificationDelegate) {
+        // Not yet implemented
+    }
+
+    @NotNull
+    @Override
+    public WebPushHandler registerWebPushDelegate(@NotNull WebPushDelegate webPushDelegate) {
+        // Not yet implemented
+        return null;
+    }
+
+    @Override
+    public void speculativeConnect(@NotNull String s) {
+        // Not yet implemented
+    }
+
+    @Override
+    public void warmUp() {
+
+    }
+
+    private TrackerLog toTrackerLog(ContentBlockingController.LogEntry entry) {
+        boolean cookiesHasBeenBlocked = entry.blockingData.stream().anyMatch(blockingData -> blockingData.blocked);
+        List<TrackingProtectionPolicy.TrackingCategory> loadedCategories = entry.blockingData.stream().map(this::getLoadedCategory).filter(it -> it != TrackingProtectionPolicy.TrackingCategory.NONE).distinct().collect(Collectors.toCollection(ArrayList::new));
+        List<TrackingProtectionPolicy.TrackingCategory> blockedCategories = entry.blockingData.stream().map(this::getBlockedCategory).filter(it -> it != TrackingProtectionPolicy.TrackingCategory.NONE).distinct().collect(Collectors.toCollection(ArrayList::new));
+        entry.blockingData.stream().map(blockingData -> blockingData.category).filter(it -> it != TrackingProtectionPolicy.TrackingCategory.NONE.getId()).distinct().collect(Collectors.toCollection(ArrayList::new));
+        return new TrackerLog(
+                entry.origin,
+                loadedCategories,
+                blockedCategories,
+                cookiesHasBeenBlocked
+        );
+    }
+
+    private TrackingProtectionPolicy.TrackingCategory getLoadedCategory(ContentBlockingController.LogEntry.BlockingData blockingData) {
+        switch (blockingData.category) {
+            case ContentBlockingController.Event.LOADED_FINGERPRINTING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.FINGERPRINTING;
+            case ContentBlockingController.Event.LOADED_CRYPTOMINING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.CRYPTOMINING;
+            case ContentBlockingController.Event.LOADED_SOCIALTRACKING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.MOZILLA_SOCIAL;
+            case ContentBlockingController.Event.LOADED_LEVEL_1_TRACKING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES;
+            case ContentBlockingController.Event.LOADED_LEVEL_2_TRACKING_CONTENT: {
+                // We are making sure that we are only showing trackers that our settings are
+                // taking into consideration.
+                boolean isContentListActive = false;
+                if (mSettings.getTrackingProtectionPolicy() != null) {
+                    isContentListActive = mSettings.getTrackingProtectionPolicy().contains(TrackingProtectionPolicy.TrackingCategory.CONTENT);
+                }
+                boolean isStrictLevelActive = mSessionStore.getRuntime().getSettings().getContentBlocking().getEnhancedTrackingProtectionLevel() == ContentBlocking.EtpLevel.STRICT;
+
+                if (isStrictLevelActive && isContentListActive) {
+                    return TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES;
+                } else {
+                    return TrackingProtectionPolicy.TrackingCategory.NONE;
+                }
+            }
+            default: return TrackingProtectionPolicy.TrackingCategory.NONE;
+        }
+    }
+
+    private TrackingProtectionPolicy.TrackingCategory getBlockedCategory(ContentBlockingController.LogEntry.BlockingData blockingData) {
+        switch (blockingData.category) {
+            case ContentBlockingController.Event.BLOCKED_FINGERPRINTING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.FINGERPRINTING;
+            case ContentBlockingController.Event.BLOCKED_CRYPTOMINING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.CRYPTOMINING;
+            case ContentBlockingController.Event.BLOCKED_SOCIALTRACKING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.MOZILLA_SOCIAL;
+            case ContentBlockingController.Event.BLOCKED_TRACKING_CONTENT: return TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES;
+            default: return TrackingProtectionPolicy.TrackingCategory.NONE;
+        }
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngineSession.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngineSession.java
@@ -139,7 +139,7 @@ public class GeckoEngineSession extends EngineSession {
                     return null;
                 });
             }
-            return new GeckoResult<Void>();
+            return GeckoResult.fromValue(Void.TYPE);
         });
     }
 
@@ -169,7 +169,7 @@ public class GeckoEngineSession extends EngineSession {
                     return null;
                 });
             }
-            return new GeckoResult<Void>();
+            return GeckoResult.fromValue(Void.TYPE);
         });
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngineSession.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngineSession.java
@@ -1,0 +1,574 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
+import org.mozilla.geckoview.AllowOrDeny;
+import org.mozilla.geckoview.ContentBlocking;
+import org.mozilla.geckoview.GeckoResult;
+import org.mozilla.geckoview.GeckoRuntime;
+import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.GeckoSessionSettings;
+import org.mozilla.geckoview.WebRequestError;
+import org.mozilla.vrbrowser.browser.engine.EngineProvider;
+import org.mozilla.vrbrowser.browser.engine.Session;
+import org.mozilla.vrbrowser.utils.StringUtils;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import mozilla.components.concept.engine.EngineSession;
+import mozilla.components.concept.engine.EngineSessionState;
+import mozilla.components.concept.engine.HitResult;
+import mozilla.components.concept.engine.Settings;
+import mozilla.components.concept.engine.manifest.WebAppManifestParser;
+import mozilla.components.concept.engine.request.RequestInterceptor.InterceptionResponse;
+
+public class GeckoEngineSession extends EngineSession {
+
+    private static final String MOZ_NULL_PRINCIPAL = "moz-nullprincipal:";
+    private static final String ABOUT_BLANK = "about:blank";
+    private static final int PROGRESS_START = 25;
+    private static final int PROGRESS_STOP = 100;
+
+    private Session mSession;
+    private GeckoRuntime mRuntime;
+    private boolean mInitialLoad;
+    private Settings mSettings;
+
+    GeckoEngineSession(@NonNull Context context, @NonNull Session session) {
+        mSession = session;
+        mRuntime = EngineProvider.INSTANCE.getOrCreateRuntime(context);
+        mSettings = new FxRSessionSettings(mSession);
+
+        createNavigationDelegate.run();
+        createProgressDelegate.run();
+        createContentDelegate.run();
+    }
+
+    @Nullable
+    public GeckoSession getGeckoSession() {
+        return mSession.getGeckoSession();
+    }
+
+    @NotNull
+    @Override
+    public Settings getSettings() {
+        return mSettings;
+    }
+
+    @Override
+    public void clearFindMatches() {
+        if (getGeckoSession() != null) {
+            getGeckoSession().getFinder().clear();
+        }
+    }
+
+    @Override
+    public void enableTrackingProtection(@NotNull TrackingProtectionPolicy trackingProtectionPolicy) {
+        if (getGeckoSession() == null) {
+            return;
+        }
+
+        boolean enabled;
+        if (mSession.isPrivateMode()) {
+            enabled = trackingProtectionPolicy.getUseForPrivateSessions();
+
+        } else {
+            enabled = trackingProtectionPolicy.getUseForRegularSessions();
+        }
+        /**
+         * As described on https://bugzilla.mozilla.org/show_bug.cgi?id=1579264,useTrackingProtection
+         * is a misleading setting. When is set to true is blocking content (scripts/sub-resources).
+         * Instead of just turn on/off tracking protection. Until, this issue is fixed consumers need
+         * a way to indicate, if they want to block content or not, this is why we use
+         * [TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES].
+         */
+        boolean shouldBlockContent = trackingProtectionPolicy.contains(TrackingProtectionPolicy.TrackingCategory.SCRIPTS_AND_SUB_RESOURCES);
+
+        getGeckoSession().getSettings().setUseTrackingProtection(shouldBlockContent);
+        if (!enabled) {
+            disableTrackingProtectionOnGecko();
+        }
+        notifyObservers(observer -> {
+            observer.onTrackerBlockingEnabledChange(enabled);
+            return null;
+        });
+    }
+
+    @Override
+    public void disableTrackingProtection() {
+        disableTrackingProtectionOnGecko();
+        notifyObservers(observer -> {
+            observer.onTrackerBlockingEnabledChange(false);
+            return null;
+        });
+    }
+
+    @Override
+    public void exitFullScreenMode() {
+        mSession.exitFullScreen();
+    }
+
+    @Override
+    public void findAll(@NotNull String s) {
+        if (getGeckoSession() == null) {
+            return;
+        }
+
+        notifyObservers(observer -> {
+            observer.onFind(s);
+            return null;
+        });
+
+        getGeckoSession().getFinder().find(s, 0).then(finderResult -> {
+            int activeMatchOrdinal;
+            if (finderResult != null) {
+                if (finderResult.current > 0) {
+                    activeMatchOrdinal = finderResult.current - 1;
+
+                } else {
+                    activeMatchOrdinal = finderResult.current;
+                }
+                notifyObservers(observer -> {
+                    observer.onFindResult(activeMatchOrdinal, finderResult.total, true);
+                    return null;
+                });
+            }
+            return new GeckoResult<Void>();
+        });
+    }
+
+    @Override
+    public void findNext(boolean forward) {
+        if (getGeckoSession() == null) {
+            return;
+        }
+
+        int  findFlags;
+        if (forward) {
+            findFlags = 0;
+        } else {
+            findFlags = GeckoSession.FINDER_FIND_BACKWARDS;
+        }
+        getGeckoSession().getFinder().find(null, findFlags).then(finderResult -> {
+            int activeMatchOrdinal;
+            if (finderResult != null) {
+                if (finderResult.current > 0) {
+                    activeMatchOrdinal = finderResult.current - 1;
+
+                } else {
+                    activeMatchOrdinal = finderResult.current;
+                }
+                notifyObservers(observer -> {
+                    observer.onFindResult(activeMatchOrdinal, finderResult.total, true);
+                    return null;
+                });
+            }
+            return new GeckoResult<Void>();
+        });
+    }
+
+    @Override
+    public void goBack() {
+        mSession.goBack();
+    }
+
+    @Override
+    public void goForward() {
+        mSession.goForward();
+    }
+
+    @Override
+    public void loadData(@NotNull String data, @NotNull String mimeType, @NotNull String encoding) {
+        if (getGeckoSession() == null) {
+            return;
+        }
+
+        if ("base64".equals(encoding)) {
+            getGeckoSession().loadData(data.getBytes(), mimeType);
+        } else {
+            getGeckoSession().loadString(data, mimeType);
+        }
+    }
+
+    @Override
+    public void loadUrl(@NotNull String url, @Nullable EngineSession engineSession, @NotNull LoadUrlFlags loadUrlFlags) {
+        if (getGeckoSession() == null || url.isEmpty()) {
+            return;
+        }
+
+        GeckoSession parentSession = engineSession != null ? ((GeckoEngineSession)engineSession).getGeckoSession() : null;
+        getGeckoSession().loadUri(url, parentSession, loadUrlFlags.getValue());
+    }
+
+    @Override
+    public boolean recoverFromCrash() {
+        return false;
+    }
+
+    @Override
+    public void reload() {
+        mSession.reload();
+    }
+
+    @Override
+    public void restoreState(@NotNull EngineSessionState engineSessionState) {
+        if (!(engineSessionState instanceof GeckoEngineSessionState)) {
+            throw new IllegalStateException("Can only restore from GeckoEngineSessionState");
+        }
+
+        if (((GeckoEngineSessionState) engineSessionState).mActualState == null) {
+            return;
+        }
+
+        if (getGeckoSession() != null) {
+            getGeckoSession().restoreState(((GeckoEngineSessionState) engineSessionState).mActualState);
+        }
+    }
+
+    @NotNull
+    @Override
+    public EngineSessionState saveState() {
+        return new GeckoEngineSessionState(mSession.getSessionState().mSessionState);
+    }
+
+    @Override
+    public void stopLoading() {
+        mSession.stop();
+    }
+
+    @Override
+    public void toggleDesktopMode(boolean enable, boolean reload) {
+        mSession.setUaMode(enable ? GeckoSessionSettings.USER_AGENT_MODE_DESKTOP : GeckoSessionSettings.USER_AGENT_MODE_VR);
+
+        if (reload) {
+            reload();
+        }
+    }
+
+    @Override
+    public void close() {
+        super.close();
+    }
+
+    // To fully disable tracking protection we need to change the different tracking protection
+    // variables to none.
+    private void disableTrackingProtectionOnGecko() {
+        if (getGeckoSession() != null) {
+            getGeckoSession().getSettings().setUseTrackingProtection(false);
+        }
+
+        mRuntime.getSettings().getContentBlocking().setAntiTracking(ContentBlocking.AntiTracking.NONE);
+        mRuntime.getSettings().getContentBlocking().setCookieBehavior(ContentBlocking.CookieBehavior.ACCEPT_ALL);
+        mRuntime.getSettings().getContentBlocking().setStrictSocialTrackingProtection(false);
+        mRuntime.getSettings().getContentBlocking().setEnhancedTrackingProtectionLevel(ContentBlocking.EtpLevel.NONE);
+    }
+
+    /**
+     * Indicates if this [EngineSession] should be ignored the tracking protection policies.
+     * @param onResult A callback to inform if this [EngineSession] is in
+     * the exception list, true if it is in, otherwise false.
+     */
+    private void isIgnoredForTrackingProtection(@NonNull Function<Boolean, Void> onResult) {
+        if (getGeckoSession() == null) {
+            onResult.apply(false);
+            return;
+        }
+
+        mRuntime.getContentBlockingController().checkException(getGeckoSession()).accept(aBoolean -> {
+            if (aBoolean != null) {
+                onResult.apply(aBoolean);
+
+            } else {
+                onResult.apply(false);
+            }
+        });
+    }
+
+    private Runnable createProgressDelegate = new Runnable() {
+        @Override
+        public void run() {
+            mSession.addProgressListener(new GeckoSession.ProgressDelegate() {
+                @Override
+                public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String url) {
+                    notifyObservers(observer -> {
+                        observer.onProgress(PROGRESS_START);
+                        observer.onLoadingStateChange(true);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onPageStop(@NonNull GeckoSession geckoSession, boolean success) {
+                    // by the time we reach here, any new request will come from web content.
+                    // If it comes from the chrome, loadUrl(url) or loadData(string) will set it to
+                    // false.
+                    notifyObservers(observer -> {
+                        observer.onProgress(PROGRESS_STOP);
+                        observer.onLoadingStateChange(false);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onProgressChange(@NonNull GeckoSession geckoSession, int progress) {
+                    notifyObservers(observer -> {
+                        observer.onProgress(progress);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onSecurityChange(@NonNull GeckoSession geckoSession, @NonNull SecurityInformation securityInfo) {
+                    // Ignore initial load of about:blank (see https://github.com/mozilla-mobile/android-components/issues/403)
+                    if (mInitialLoad && securityInfo.origin != null && securityInfo.origin.startsWith(MOZ_NULL_PRINCIPAL)) {
+                        return;
+                    }
+
+                    notifyObservers(observer -> {
+                        observer.onSecurityChange(securityInfo.isSecure, securityInfo.host, securityInfo.issuerOrganization);
+                        return null;
+                    });
+                }
+
+            });
+        }
+    };
+
+    private Runnable createNavigationDelegate = new Runnable() {
+        @Override
+        public void run() {
+            mSession.addNavigationListener(new GeckoSession.NavigationDelegate() {
+                @Override
+                public void onLocationChange(@NonNull GeckoSession geckoSession, @Nullable String url) {
+                    if (url == null) {
+                        return; // ¯\_(ツ)_/¯
+                    }
+
+                    // Ignore initial load of about:blank (see https://github.com/mozilla-mobile/android-components/issues/403)
+                    if (mInitialLoad && Objects.equals(url, ABOUT_BLANK)) {
+                        return;
+                    }
+
+                    mInitialLoad = false;
+
+                    isIgnoredForTrackingProtection(aBoolean -> {
+                        notifyObservers(observer -> {
+                            observer.onExcludedOnTrackingProtectionChange(aBoolean);
+                            return null;
+                        });
+                        return null;
+                    });
+
+                    notifyObservers(observer -> {
+                        observer.onLocationChange(url);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onCanGoBack(@NonNull GeckoSession geckoSession, boolean canGoBack) {
+                    notifyObservers(observer -> {
+                        observer.onNavigationStateChange(canGoBack, null);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onCanGoForward(@NonNull GeckoSession geckoSession, boolean canGoForward) {
+                    notifyObservers(observer -> {
+                        observer.onNavigationStateChange(null, canGoForward);
+                        return null;
+                    });
+                }
+
+                @Nullable
+                @Override
+                public GeckoResult<AllowOrDeny> onLoadRequest(@NonNull GeckoSession geckoSession, @NonNull LoadRequest loadRequest) {
+                    if (loadRequest.target == GeckoSession.NavigationDelegate.TARGET_WINDOW_NEW) {
+                        return GeckoResult.fromValue(AllowOrDeny.ALLOW);
+                    }
+
+                    InterceptionResponse response = null;
+                    if (mSettings.getRequestInterceptor() != null) {
+                        response = mSettings.getRequestInterceptor().onLoadRequest(GeckoEngineSession.this, loadRequest.uri);
+                        if (response instanceof InterceptionResponse.Content) {
+                            InterceptionResponse.Content content = (InterceptionResponse.Content) response;
+                            loadData(content.getData(), content.getMimeType(), content.getEncoding());
+
+                        } else {
+                            loadUrl(loadRequest.uri, GeckoEngineSession.this, LoadUrlFlags.Companion.none());
+                        }
+                    }
+
+                    if (response != null) {
+                        return GeckoResult.fromValue(AllowOrDeny.DENY);
+
+                    } else if (!isObserved()) {
+                        return GeckoResult.fromValue(AllowOrDeny.ALLOW);
+
+                    } else {
+                        notifyObservers(observer -> {
+                            // Unlike the name LoadRequest.isRedirect may imply this flag is not about http redirects. The flag
+                            // is "True if and only if the request was triggered by an HTTP redirect."
+                            // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1545170
+                            observer.onLoadRequest(
+                                    loadRequest.uri,
+                                    loadRequest.isRedirect,
+                                    loadRequest.hasUserGesture
+                            );
+                            return null;
+                        });
+
+                        return GeckoResult.fromValue(AllowOrDeny.ALLOW);
+                    }
+                }
+
+                @Nullable
+                @Override
+                public GeckoResult<String> onLoadError(@NonNull GeckoSession geckoSession, @Nullable String s, @NonNull WebRequestError webRequestError) {
+                    return null;
+                }
+            });
+        }
+    };
+
+    private Runnable createContentDelegate = new Runnable() {
+        @Override
+        public void run() {
+            mSession.addContentListener(new GeckoSession.ContentDelegate() {
+                @Override
+                public void onTitleChange(@NonNull GeckoSession geckoSession, @Nullable String title) {
+                    if (!mSession.isPrivateMode()) {
+                        if (mSession.getCurrentUri() != null) {
+                            if (mSettings.getHistoryTrackingDelegate() != null) {
+                                mSettings.getHistoryTrackingDelegate().onTitleChanged(mSession.getCurrentUri(), title, null);
+                            }
+                        }
+                    }
+                    notifyObservers(observer -> {
+                       observer.onTitleChange(title != null ? title : "");
+                       return null;
+                    });
+                }
+
+                @Override
+                public void onFullScreen(@NonNull GeckoSession geckoSession, boolean fullScreen) {
+                    notifyObservers(observer -> {
+                        observer.onFullScreenChange(fullScreen);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onContextMenu(@NonNull GeckoSession geckoSession, int screenX, int screenY, @NonNull ContextElement element) {
+                    HitResult hitResult = handleLongClick(element.srcUri, element.type, element.linkUri, element.title);
+                    notifyObservers(observer -> {
+                       observer.onLongPress(hitResult);
+                       return null;
+                    });
+                }
+
+                @Override
+                public void onExternalResponse(@NonNull GeckoSession geckoSession, @NonNull GeckoSession.WebResponseInfo webResponseInfo) {
+                    notifyObservers(observer -> {
+                        observer.onExternalResource(
+                                webResponseInfo.uri,
+                                webResponseInfo.filename,
+                                webResponseInfo.contentLength,
+                                webResponseInfo.contentType,
+                                null,
+                                null);
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onCrash(@NonNull GeckoSession geckoSession) {
+                    notifyObservers(observer -> {
+                       observer.onCrash();
+                       return null;
+                    });
+                }
+
+                @Override
+                public void onKill(@NonNull GeckoSession geckoSession) {
+                    notifyObservers(observer -> {
+                        observer.onProcessKilled();
+                        return null;
+                    });
+                }
+
+                @Override
+                public void onWebAppManifest(@NonNull GeckoSession geckoSession, @NonNull JSONObject jsonObject) {
+                    WebAppManifestParser.Result parsed = new WebAppManifestParser().parse(jsonObject);
+                    if (parsed instanceof WebAppManifestParser.Result.Success) {
+                        notifyObservers(observer -> {
+                           observer.onWebAppManifestLoaded(((WebAppManifestParser.Result.Success) parsed).getManifest());
+                           return null;
+                        });
+                    }
+                }
+            });
+        }
+    };
+
+    private HitResult handleLongClick(@Nullable String elementSrc, Integer elementType, @Nullable String uri, @Nullable String title) {
+        switch (elementType) {
+            case GeckoSession.ContentDelegate.ContextElement.TYPE_AUDIO: {
+                if (elementSrc != null) {
+                    return new HitResult.AUDIO(elementSrc);
+                }
+            }
+            break;
+            case GeckoSession.ContentDelegate.ContextElement.TYPE_VIDEO: {
+                if (elementSrc != null) {
+                    return new HitResult.VIDEO(elementSrc);
+                }
+            }
+            break;
+            case GeckoSession.ContentDelegate.ContextElement.TYPE_IMAGE: {
+                if (elementSrc != null && uri != null) {
+                    return new HitResult.IMAGE_SRC(elementSrc, uri);
+
+                } else if (elementSrc != null) {
+                    return new HitResult.IMAGE(elementSrc, title);
+
+                }
+            }
+            break;
+            case GeckoSession.ContentDelegate.ContextElement.TYPE_NONE: {
+                if (elementSrc != null) {
+                    if (StringUtils.isPhone(elementSrc)) {
+                        return new HitResult.PHONE(elementSrc);
+
+                    } else if (StringUtils.isEmail(elementSrc)) {
+                        return new HitResult.EMAIL(elementSrc);
+
+                    } else if (StringUtils.isGeolocation(elementSrc)) {
+                        return new HitResult.GEO(elementSrc);
+
+                    } else {
+                        return new HitResult.UNKNOWN("");
+                    }
+
+                } else if (uri != null) {
+                    return new HitResult.UNKNOWN(uri);
+                }
+            }
+            break;
+            default: {
+                return new HitResult.UNKNOWN("");
+            }
+        }
+
+        return new HitResult.UNKNOWN("");
+    }
+
+
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngineSessionState.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoEngineSessionState.java
@@ -1,0 +1,49 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.mozilla.geckoview.GeckoSession;
+
+import mozilla.components.concept.engine.EngineSessionState;
+
+public class GeckoEngineSessionState implements EngineSessionState {
+
+    private static final String GECKO_STATE_KEY = "GECKO_STATE";
+
+    protected GeckoSession.SessionState mActualState;
+
+    public GeckoEngineSessionState(GeckoSession.SessionState state) {
+        mActualState = state;
+    }
+
+    @NotNull
+    @Override
+    public JSONObject toJSON() {
+        JSONObject state = new JSONObject();
+        if (mActualState != null) {
+            try {
+                // GeckoView provides a String representing the entire session state. We
+                // store this String using a single Map entry with key GECKO_STATE_KEY.
+                state.put(GECKO_STATE_KEY, mActualState.toString());
+
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return state;
+    }
+
+    public static GeckoEngineSessionState fromJSON(JSONObject json) {
+        try {
+            String state = json.getString(GECKO_STATE_KEY);
+            new GeckoEngineSessionState(GeckoSession.SessionState.fromString(state));
+
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        return new GeckoEngineSessionState(null);
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoWebExtension.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/gecko/GeckoWebExtension.java
@@ -1,0 +1,222 @@
+package org.mozilla.vrbrowser.browser.engine.gecko;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.json.JSONObject;
+import org.mozilla.geckoview.GeckoResult;
+import org.mozilla.geckoview.GeckoSession;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import mozilla.components.concept.engine.EngineSession;
+import mozilla.components.concept.engine.webextension.MessageHandler;
+import mozilla.components.concept.engine.webextension.Port;
+import mozilla.components.concept.engine.webextension.WebExtension;
+
+public class GeckoWebExtension extends WebExtension {
+
+    private org.mozilla.geckoview.WebExtension mNativeExtension;
+    private Map<PortId, Port> mConnectedPorts = new HashMap<>();
+
+    class PortId {
+
+        public String name;
+        public EngineSession engineSession;
+
+        PortId(@NonNull String name, @Nullable EngineSession engineSession) {
+            this.name = name;
+            this.engineSession = engineSession;
+        }
+
+        PortId(@NonNull String name) {
+            this(name, null);
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(@Nullable Object obj) {
+            if (obj instanceof PortId) {
+                return ((PortId)obj).name.equals(name) && (((PortId)obj).engineSession == engineSession);
+            }
+
+            return false;
+        }
+
+        @NonNull
+        @Override
+        public String toString() {
+            return "PortId(name=" + name + ", engineSession=" + engineSession.toString() + ")";
+        }
+    }
+
+    /**
+     * Represents a browser extension based on the WebExtension API:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions
+     *
+     * @param id  the unique ID of this extension.
+     * @param url the url pointing to a resources path for locating the extension
+     */
+    public GeckoWebExtension(@NonNull String id,
+                             @NonNull String url,
+                             boolean allowContentMessaging) {
+        super(id, url);
+
+        mNativeExtension = new org.mozilla.geckoview.WebExtension(url, id, createWebExtensionFlags(allowContentMessaging));
+    }
+
+    public org.mozilla.geckoview.WebExtension getNativeExtension() {
+        return mNativeExtension;
+    }
+
+    /**
+     * See [WebExtension.registerBackgroundMessageHandler].
+     */
+    @Override
+    public void registerBackgroundMessageHandler(@NonNull String name, @NonNull MessageHandler messageHandler) {
+        org.mozilla.geckoview.WebExtension.PortDelegate portDelegate = new org.mozilla.geckoview.WebExtension.PortDelegate() {
+            @Override
+            public void onPortMessage(@NonNull Object message, @NonNull org.mozilla.geckoview.WebExtension.Port port) {
+                messageHandler.onPortMessage(message, new GeckoPort(port));
+            }
+
+            @NonNull
+            @Override
+            public void onDisconnect(@NonNull org.mozilla.geckoview.WebExtension.Port port) {
+                mConnectedPorts.remove(new PortId(name));
+                messageHandler.onPortDisconnected(new GeckoPort(port));
+            }
+        };
+
+        org.mozilla.geckoview.WebExtension.MessageDelegate messageDelegate = new org.mozilla.geckoview.WebExtension.MessageDelegate() {
+
+            @Nullable
+            @Override
+            public void onConnect(@NonNull org.mozilla.geckoview.WebExtension.Port port) {
+                port.setDelegate(portDelegate);
+                GeckoPort geckoPort = new GeckoPort(port);
+                mConnectedPorts.put(new PortId(name),  geckoPort);
+                messageHandler.onPortConnected(geckoPort);
+            }
+
+            @Nullable
+            @Override
+            public GeckoResult<Object> onMessage(@NonNull String name, @NonNull Object message, @NonNull org.mozilla.geckoview.WebExtension.MessageSender messageSender) {
+                Object response = messageHandler.onMessage(message, null);
+                return GeckoResult.fromValue(response);
+            }
+        };
+
+        mNativeExtension.setMessageDelegate(messageDelegate, name);
+    }
+
+    /**
+     * See [WebExtension.registerContentMessageHandler].
+     */
+    @Override
+    public void registerContentMessageHandler(@NonNull EngineSession session, @NonNull String name, @NonNull MessageHandler messageHandler) {
+        org.mozilla.geckoview.WebExtension.PortDelegate portDelegate = new org.mozilla.geckoview.WebExtension.PortDelegate() {
+            @Override
+            public void onPortMessage(@NonNull Object message, @NonNull org.mozilla.geckoview.WebExtension.Port port) {
+                messageHandler.onPortMessage(message, new GeckoPort(port, session));
+            }
+
+            @NonNull
+            @Override
+            public void onDisconnect(@NonNull org.mozilla.geckoview.WebExtension.Port port) {
+                mConnectedPorts.remove(new PortId(name, session));
+                messageHandler.onPortDisconnected(new GeckoPort(port, session));
+            }
+        };
+
+        org.mozilla.geckoview.WebExtension.MessageDelegate messageDelegate = new org.mozilla.geckoview.WebExtension.MessageDelegate() {
+
+            @Nullable
+            @Override
+            public void onConnect(@NonNull org.mozilla.geckoview.WebExtension.Port port) {
+                port.setDelegate(portDelegate);
+                GeckoPort geckoPort = new GeckoPort(port,session);
+                mConnectedPorts.put(new PortId(name, session),  geckoPort);
+                messageHandler.onPortConnected(geckoPort);
+            }
+
+            @Nullable
+            @Override
+            public GeckoResult<Object> onMessage(@NonNull String name, @NonNull Object message, @NonNull org.mozilla.geckoview.WebExtension.MessageSender messageSender) {
+                Object response = messageHandler.onMessage(message, session);
+                return GeckoResult.fromValue(response);
+            }
+        };
+
+        GeckoSession geckoSession = ((GeckoEngineSession)session).getGeckoSession();
+        geckoSession.setMessageDelegate(mNativeExtension, messageDelegate, name);
+    }
+
+    @Override
+    public boolean hasContentMessageHandler(@NonNull EngineSession session, @NonNull String name) {
+        GeckoSession geckoSession = ((GeckoEngineSession)session).getGeckoSession();
+        return geckoSession.getMessageDelegate(mNativeExtension, name) != null;
+    }
+
+    @Nullable
+    @Override
+    public Port getConnectedPort(@NonNull String name, @Nullable EngineSession session) {
+        return mConnectedPorts.get(new PortId(name, session));
+    }
+
+    @Override
+    public void disconnectPort(@NonNull String name, @Nullable EngineSession session) {
+        PortId portId = new PortId(name, session);
+        Port port = mConnectedPorts.get(portId);
+        if (port != null) {
+            port.disconnect();
+            mConnectedPorts.remove(portId);
+        }
+    }
+
+    private long createWebExtensionFlags(boolean allowContentMessaging) {
+        if (allowContentMessaging) {
+            return org.mozilla.geckoview.WebExtension.Flags.ALLOW_CONTENT_MESSAGING;
+
+        } else {
+            return org.mozilla.geckoview.WebExtension.Flags.NONE;
+        }
+    }
+
+    /**
+     * Gecko-based implementation of [Port], wrapping the native port provided by GeckoView.
+     */
+    class GeckoPort extends Port {
+
+        private org.mozilla.geckoview.WebExtension.Port mNativePort;
+
+        GeckoPort(@NonNull org.mozilla.geckoview.WebExtension.Port port,
+                  @Nullable EngineSession session) {
+            super(session);
+
+            mNativePort = port;
+        }
+
+        GeckoPort(@NonNull org.mozilla.geckoview.WebExtension.Port port) {
+            this(port, null);
+        }
+
+        public void postMessage(@NonNull JSONObject message) {
+            mNativePort.postMessage(message);
+        }
+
+        public String name() {
+            return mNativePort.name;
+        }
+
+        public void disconnect() {
+            mNativePort.disconnect();
+        }
+
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/extensions/VimeoExtensionFeature.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/extensions/VimeoExtensionFeature.java
@@ -1,0 +1,26 @@
+package org.mozilla.vrbrowser.browser.extensions;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import org.mozilla.vrbrowser.browser.engine.gecko.GeckoEngine;
+import org.mozilla.vrbrowser.utils.SystemUtils;
+
+public class VimeoExtensionFeature {
+
+    private static final String LOGTAG = SystemUtils.createLogtag(VimeoExtensionFeature.class);
+
+    private static final String EXTENSION_ID = "mozacVimeo";
+    private static final String EXTENSION_URL = "resource://android/assets/web_extensions/webcompat_vimeo/";
+
+    public static void install(@NonNull GeckoEngine engine) {
+        engine.installWebExtension(EXTENSION_ID, EXTENSION_URL, false, webExtension -> {
+            Log.i(LOGTAG, "Vimeo Web Extension successfully installed");
+            return null;
+        }, (s, throwable) -> {
+            Log.e(LOGTAG, "Error installing the Vimeo Web Extension: " + throwable.getLocalizedMessage());
+            return null;
+        });
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/extensions/YoutubeExtensionFeature.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/extensions/YoutubeExtensionFeature.java
@@ -1,0 +1,26 @@
+package org.mozilla.vrbrowser.browser.extensions;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import org.mozilla.vrbrowser.browser.engine.gecko.GeckoEngine;
+import org.mozilla.vrbrowser.utils.SystemUtils;
+
+public class YoutubeExtensionFeature {
+
+    private static final String LOGTAG = SystemUtils.createLogtag(YoutubeExtensionFeature.class);
+
+    private static final String EXTENSION_ID = "mozacYoutube";
+    private static final String EXTENSION_URL = "resource://android/assets/web_extensions/webcompat_youtube/";
+
+    public static void install(@NonNull GeckoEngine engine) {
+        engine.installWebExtension(EXTENSION_ID, EXTENSION_URL, false, webExtension -> {
+            Log.i(LOGTAG, "Youtube Web Extension successfully installed");
+            return null;
+        }, (s, throwable) -> {
+            Log.e(LOGTAG, "Error installing the Youtube Web Extension: " + throwable.getLocalizedMessage());
+            return null;
+        });
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1151,7 +1151,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     public void addTab(@NotNull WindowWidget targetWindow, @Nullable String aUri) {
-        Session session = SessionStore.get().createSuspendedSession(aUri, targetWindow.getSession().isPrivateMode());
+        Session session = SessionStore.get().createSession(targetWindow.getSession().isPrivateMode());
         setFirstPaint(targetWindow, session);
         targetWindow.getSession().setActive(false);
         session.setActive(true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/StringUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/StringUtils.java
@@ -13,6 +13,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class StringUtils {
     @NonNull
@@ -113,5 +114,24 @@ public class StringUtils {
     @NonNull
     public static String capitalize(@NonNull String input) {
         return input.substring(0, 1).toUpperCase() + input.substring(1);
+    }
+
+    /**
+     * A collection of regular expressions used in the `is*` methods below.
+     */
+    private static Pattern phoneish = Pattern.compile("^\\s*tel:\\S?\\d+\\S*\\s*$");
+    private static Pattern emailish = Pattern.compile("^\\s*mailto:\\w+\\S*\\s*$");
+    private static Pattern geoish = Pattern.compile("^\\s*geo:\\S*\\d+\\S*\\s*$");
+
+    public static boolean isPhone(@NonNull String text) {
+        return phoneish.matcher(text).find();
+    }
+
+    public static boolean isEmail(@NonNull String text) {
+        return emailish.matcher(text).find();
+    }
+
+    public static boolean isGeolocation(@NonNull String text) {
+        return geoish.matcher(text).find();
     }
 }

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -51,6 +51,7 @@
     <string name="settings_key_whats_new_displayed" translatable="false">settings_key_whats_new_displayed</string>
     <string name="settings_key_ui_hardware_acceleration" translatable="false">settings_key_ui_hardware_acceleration</string>
     <string name="settings_key_fxa_last_sync" translatable="false">settings_key_fxa_last_sync</string>
+    <string name="settings_key_webchannels_enabled" translatable="false">settings_key_webchannels_enabled</string>
     <string name="environment_override_help_url" translatable="false">https://github.com/MozillaReality/FirefoxReality/wiki/Environments</string>
     <string name="private_policy_url" translatable="false">https://www.mozilla.org/privacy/firefox/</string>
     <string name="private_report_url" translatable="false">https://mixedreality.mozilla.org/fxr/report?src=browser-fxr&amp;label=browser-firefox-reality&amp;url=%1$s</string>

--- a/versions.gradle
+++ b/versions.gradle
@@ -71,6 +71,9 @@ android_components.concept_fetch = "org.mozilla.components:concept-fetch:$versio
 android_components.lib_fetch = "org.mozilla.components:lib-fetch-httpurlconnection:$versions.android_components"
 android_components.support_rustlog = "org.mozilla.components:support-rustlog:$versions.android_components"
 android_components.support_rusthttp = "org.mozilla.components:support-rusthttp:$versions.android_components"
+android_components.concept_engine = "org.mozilla.components:concept-engine:$versions.android_components"
+android_components.support_webextensions = "org.mozilla.components:support-webextensions:$versions.android_components"
+android_components.browser_session = "org.mozilla.components:browser-session:$versions.android_components"
 deps.android_components = android_components
 
 def app_services = [:]


### PR DESCRIPTION
This was initially part of the FxA WebChannels migration work. This adds support for AC WebExtensions inside FxR.

The AC browser-session/browser-state bridge is not complete, we just implement what we need at the moment.