### PR TITLE
Bump GV to v73.0.20191212095326

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
@@ -115,6 +115,11 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
     @Override
     public void onContentPermissionRequest(GeckoSession aSession, String aUri, int aType, Callback callback) {
         Log.d(LOGTAG, "onContentPermissionRequest: " + aUri + " " + aType);
+        if (aType == PERMISSION_XR) {
+            callback.grant();
+            return;
+        }
+
         PermissionWidget.PermissionType type;
         if (aType == PERMISSION_DESKTOP_NOTIFICATION) {
             type = PermissionWidget.PermissionType.Notification;

--- a/app/src/main/cpp/moz_external_vr.h
+++ b/app/src/main/cpp/moz_external_vr.h
@@ -47,8 +47,8 @@ namespace gfx {
 // and mapped files if we have both release and nightlies
 // running at the same time? Or...what if we have multiple
 // release builds running on same machine? (Bug 1563232)
-#define SHMEM_VERSION "0.0.5"
-static const int32_t kVRExternalVersion = 12;
+#define SHMEM_VERSION "0.0.6"
+static const int32_t kVRExternalVersion = 13;
 
 // We assign VR presentations to groups with a bitmask.
 // Currently, we will only display either content or chrome.
@@ -103,30 +103,30 @@ enum class ControllerCapabilityFlags : uint16_t {
   /**
    * Cap_Position is set if the Gamepad is capable of tracking its position.
    */
-      Cap_Position = 1 << 1,
+  Cap_Position = 1 << 1,
   /**
    * Cap_Orientation is set if the Gamepad is capable of tracking its
    * orientation.
    */
-      Cap_Orientation = 1 << 2,
+  Cap_Orientation = 1 << 2,
   /**
    * Cap_AngularAcceleration is set if the Gamepad is capable of tracking its
    * angular acceleration.
    */
-      Cap_AngularAcceleration = 1 << 3,
+  Cap_AngularAcceleration = 1 << 3,
   /**
    * Cap_LinearAcceleration is set if the Gamepad is capable of tracking its
    * linear acceleration.
    */
-      Cap_LinearAcceleration = 1 << 4,
+  Cap_LinearAcceleration = 1 << 4,
   /**
    * Cap_GripSpacePosition is set if the Gamepad has a grip space position.
    */
-      Cap_GripSpacePosition = 1 << 5,
+  Cap_GripSpacePosition = 1 << 5,
   /**
    * Cap_All used for validity checking during IPC serialization
    */
-      Cap_All = (1 << 6) - 1
+  Cap_All = (1 << 6) - 1
 };
 
 #endif  // ifndef MOZILLA_INTERNAL_API
@@ -142,12 +142,12 @@ enum class VRDisplayCapabilityFlags : uint16_t {
   /**
    * Cap_Position is set if the VRDisplay is capable of tracking its position.
    */
-      Cap_Position = 1 << 1,
+  Cap_Position = 1 << 1,
   /**
    * Cap_Orientation is set if the VRDisplay is capable of tracking its
    * orientation.
    */
-      Cap_Orientation = 1 << 2,
+  Cap_Orientation = 1 << 2,
   /**
    * Cap_Present is set if the VRDisplay is capable of presenting content to an
    * HMD or similar device.  Can be used to indicate "magic window" devices that
@@ -155,7 +155,7 @@ enum class VRDisplayCapabilityFlags : uint16_t {
    * meaningful. If false then calls to requestPresent should always fail, and
    * getEyeParameters should return null.
    */
-      Cap_Present = 1 << 3,
+  Cap_Present = 1 << 3,
   /**
    * Cap_External is set if the VRDisplay is separate from the device's
    * primary display. If presenting VR content will obscure
@@ -163,54 +163,54 @@ enum class VRDisplayCapabilityFlags : uint16_t {
    * un-set, the application should not attempt to mirror VR content
    * or update non-VR UI because that content will not be visible.
    */
-      Cap_External = 1 << 4,
+  Cap_External = 1 << 4,
   /**
    * Cap_AngularAcceleration is set if the VRDisplay is capable of tracking its
    * angular acceleration.
    */
-      Cap_AngularAcceleration = 1 << 5,
+  Cap_AngularAcceleration = 1 << 5,
   /**
    * Cap_LinearAcceleration is set if the VRDisplay is capable of tracking its
    * linear acceleration.
    */
-      Cap_LinearAcceleration = 1 << 6,
+  Cap_LinearAcceleration = 1 << 6,
   /**
    * Cap_StageParameters is set if the VRDisplay is capable of room scale VR
    * and can report the StageParameters to describe the space.
    */
-      Cap_StageParameters = 1 << 7,
+  Cap_StageParameters = 1 << 7,
   /**
    * Cap_MountDetection is set if the VRDisplay is capable of sensing when the
    * user is wearing the device.
    */
-      Cap_MountDetection = 1 << 8,
+  Cap_MountDetection = 1 << 8,
   /**
    * Cap_PositionEmulated is set if the VRDisplay is capable of setting a
    * emulated position (e.g. neck model) even if still doesn't support 6DOF
    * tracking.
    */
-      Cap_PositionEmulated = 1 << 9,
+  Cap_PositionEmulated = 1 << 9,
   /**
    * Cap_Inline is set if the device can be used for WebXR inline sessions
    * where the content is displayed within an element on the page.
    */
-      Cap_Inline = 1 << 10,
+  Cap_Inline = 1 << 10,
   /**
    * Cap_ImmersiveVR is set if the device can give exclusive access to the
    * XR device display and that content is not intended to be integrated
    * with the user's environment
    */
-      Cap_ImmersiveVR = 1 << 11,
+  Cap_ImmersiveVR = 1 << 11,
   /**
    * Cap_ImmersiveAR is set if the device can give exclusive access to the
    * XR device display and that content is intended to be integrated with
    * the user's environment.
    */
-      Cap_ImmersiveAR = 1 << 12,
+  Cap_ImmersiveAR = 1 << 12,
   /**
    * Cap_All used for validity checking during IPC serialization
    */
-      Cap_All = (1 << 13) - 1
+  Cap_All = (1 << 13) - 1
 };
 
 #ifdef MOZILLA_INTERNAL_API
@@ -365,12 +365,12 @@ struct VRControllerState {
   // start frame Id of the most recent primary squeeze
   // action, or 0 if the squeeze action has never occurred.
   uint64_t squeezeActionStartFrameId;
-  // End frame Id of the most recent primary squeez
+  // End frame Id of the most recent primary squeeze
   // action, or 0 if action never occurred.
   // If squeezeActionStopFrameId is less than
-  // squeezetActionStartFrameId, then the squeeze
+  // squeezeActionStartFrameId, then the squeeze
   // action has not ended yet.
-  uint64_t squeezeActionEndFrameId;
+  uint64_t squeezeActionStopFrameId;
 
   uint32_t numButtons;
   uint32_t numAxes;

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "73.0.20191211094640"
+versions.gecko_view = "73.0.20191212095326"
 versions.android_components = "21.0.0"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.


### PR DESCRIPTION
WebXR permission are landed (https://bugzilla.mozilla.org/show_bug.cgi?id=1580567 and https://bugzilla.mozilla.org/show_bug.cgi?id=1599927), so we need to bump to a new version of GV.

I also give a quick fix for WebXR permission UI in FxR, the final solution needs to wait for #2413.