### PR TITLE
Show Settings instead of toggling after a fxa login

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
@@ -2,7 +2,8 @@ package org.mozilla.vrbrowser.browser.engine;
 
 import android.content.Context;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.browser.SettingsStore;
 
@@ -16,7 +17,7 @@ class SessionSettings {
     private boolean isServoEnabled;
     private String userAgentOverride;
 
-    /* package */ SessionSettings(@NotNull Builder builder) {
+    /* package */ SessionSettings(@NonNull Builder builder) {
         this.isPrivateBrowsingEnabled = builder.isPrivateBrowsingEnabled;
         this.isTrackingProtectionEnabled = builder.isTrackingProtectionEnabled;
         this.isSuspendMediaWhenInactiveEnabled = builder.isSuspendMediaWhenInactiveEnabled;

--- a/app/src/common/shared/org/mozilla/vrbrowser/search/GeolocationLocalizationProvider.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/search/GeolocationLocalizationProvider.java
@@ -1,9 +1,8 @@
 package org.mozilla.vrbrowser.search;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.mozilla.vrbrowser.geolocation.GeolocationData;
 
 import java.util.Locale;
@@ -26,7 +25,7 @@ public class GeolocationLocalizationProvider implements SearchLocalizationProvid
 
     @Nullable
     @Override
-    public SearchLocalization determineRegion(@NotNull Continuation<? super SearchLocalization> continuation) {
+    public SearchLocalization determineRegion(@NonNull Continuation<? super SearchLocalization> continuation) {
         return new SearchLocalization(mLanguage, mCountry, mRegion);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -14,12 +14,11 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserActivity;
@@ -53,8 +52,6 @@ import mozilla.components.concept.sync.Profile;
 import mozilla.components.service.fxa.SyncEngine;
 import mozilla.components.service.fxa.sync.SyncReason;
 import mozilla.components.service.fxa.sync.SyncStatusObserver;
-
-import static org.mozilla.vrbrowser.browser.BookmarksStoreKt.DESKTOP_ROOT;
 
 public class BookmarksView extends FrameLayout implements BookmarksStore.BookmarkListener {
 
@@ -304,12 +301,12 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
     private AccountObserver mAccountListener = new AccountObserver() {
 
         @Override
-        public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+        public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
             mBinding.setIsSignedIn(true);
         }
 
         @Override
-        public void onProfileUpdated(@NotNull Profile profile) {
+        public void onProfileUpdated(@NonNull Profile profile) {
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/CustomInlineAutocompleteEditText.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/CustomInlineAutocompleteEditText.java
@@ -3,8 +3,8 @@ package org.mozilla.vrbrowser.ui.views;
 import android.content.Context;
 import android.util.AttributeSet;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText;
 
@@ -14,15 +14,15 @@ public class CustomInlineAutocompleteEditText extends InlineAutocompleteEditText
         void onSelectionChanged(int selectionStart, int selectionEnd);
     }
 
-    public CustomInlineAutocompleteEditText(@NotNull Context ctx, @Nullable AttributeSet attrs, int defStyleAttr) {
+    public CustomInlineAutocompleteEditText(@NonNull Context ctx, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(ctx, attrs, defStyleAttr);
     }
 
-    public CustomInlineAutocompleteEditText(@NotNull Context ctx, @Nullable AttributeSet attrs) {
+    public CustomInlineAutocompleteEditText(@NonNull Context ctx, @Nullable AttributeSet attrs) {
         super(ctx, attrs);
     }
 
-    public CustomInlineAutocompleteEditText(@NotNull Context ctx) {
+    public CustomInlineAutocompleteEditText(@NonNull Context ctx) {
         super(ctx);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -14,12 +14,11 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserActivity;
@@ -299,12 +298,12 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
     private AccountObserver mAccountListener = new AccountObserver() {
 
         @Override
-        public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+        public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
             mBinding.setIsSignedIn(true);
         }
 
         @Override
-        public void onProfileUpdated(@NotNull Profile profile) {
+        public void onProfileUpdated(@NonNull Profile profile) {
         }
 
         @Override
@@ -318,7 +317,7 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         }
     };
 
-    @NotNull
+    @NonNull
     public static <T> Predicate<T> distinctByUrl(Function<? super T, ?> keyExtractor) {
         Set<Object> seen = ConcurrentHashMap.newKeySet();
         return t -> seen.add(keyExtractor.apply(t));

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/SingleEditSetting.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/settings/SingleEditSetting.java
@@ -11,11 +11,11 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.audio.AudioEngine;
-
-import androidx.annotation.StringRes;
 
 public class SingleEditSetting extends LinearLayout {
 
@@ -162,7 +162,7 @@ public class SingleEditSetting extends LinearLayout {
         return mEdit1.getVisibility() == View.VISIBLE;
     }
 
-    public boolean contains(@NotNull View view) {
+    public boolean contains(@NonNull View view) {
         return findViewById(view.getId()) == view;
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -17,6 +17,7 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 
 import androidx.annotation.NonNull;
 
+import org.jetbrains.annotations.NotNull;
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
@@ -25,7 +26,6 @@ import org.mozilla.vrbrowser.browser.BookmarksStore;
 import org.mozilla.vrbrowser.browser.SessionChangeListener;
 import org.mozilla.vrbrowser.browser.engine.Session;
 import org.mozilla.vrbrowser.browser.engine.SessionStore;
-import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 
@@ -388,7 +388,7 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Windo
         toggleSettingsDialog(SettingsWidget.SettingDialog.MAIN);
     }
 
-    public void toggleSettingsDialog(SettingsWidget.SettingDialog settingDialog) {
+    public void toggleSettingsDialog(@NotNull SettingsWidget.SettingDialog settingDialog) {
         UIWidget widget = getChild(mSettingsDialogHandle);
         if (widget == null) {
             widget = createChild(SettingsWidget.class, false);
@@ -403,6 +403,20 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Windo
         } else {
             ((SettingsWidget)widget).show(REQUEST_FOCUS, settingDialog);
         }
+    }
+
+    public void showSettingsDialog(@NotNull SettingsWidget.SettingDialog settingDialog) {
+        UIWidget widget = getChild(mSettingsDialogHandle);
+        if (widget == null) {
+            widget = createChild(SettingsWidget.class, false);
+            mSettingsDialogHandle = widget.getHandle();
+        }
+
+        if (mAttachedWindow != null) {
+            widget.getPlacement().parentHandle = mAttachedWindow.getHandle();
+        }
+
+        ((SettingsWidget)widget).show(REQUEST_FOCUS, settingDialog);
     }
 
     public void setTrayVisible(boolean aVisible) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -17,7 +17,6 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 
 import androidx.annotation.NonNull;
 
-import org.jetbrains.annotations.NotNull;
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
@@ -388,7 +387,7 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Windo
         toggleSettingsDialog(SettingsWidget.SettingDialog.MAIN);
     }
 
-    public void toggleSettingsDialog(@NotNull SettingsWidget.SettingDialog settingDialog) {
+    public void toggleSettingsDialog(@NonNull SettingsWidget.SettingDialog settingDialog) {
         UIWidget widget = getChild(mSettingsDialogHandle);
         if (widget == null) {
             widget = createChild(SettingsWidget.class, false);
@@ -405,7 +404,7 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Windo
         }
     }
 
-    public void showSettingsDialog(@NotNull SettingsWidget.SettingDialog settingDialog) {
+    public void showSettingsDialog(@NonNull SettingsWidget.SettingDialog settingDialog) {
         UIWidget widget = getChild(mSettingsDialogHandle);
         if (widget == null) {
             widget = createChild(SettingsWidget.class, false);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -27,7 +27,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.UiThread;
 
-import org.jetbrains.annotations.NotNull;
 import org.mozilla.geckoview.GeckoResult;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.geckoview.PanZoomController;
@@ -1343,7 +1342,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return (int) Math.floor(SettingsStore.WINDOW_WIDTH_DEFAULT * aWorldWidth / WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width));
     }
 
-    private void showLibraryItemContextMenu(@NotNull View view, LibraryMenuWidget.LibraryContextMenuItem item, boolean isLastVisibleItem) {
+    private void showLibraryItemContextMenu(@NonNull View view, LibraryMenuWidget.LibraryContextMenuItem item, boolean isLastVisibleItem) {
         view.requestFocusFromTouch();
 
         hideContextMenus();
@@ -1415,7 +1414,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     private BookmarksCallback mBookmarksListener = new BookmarksCallback() {
         @Override
-        public void onShowContextMenu(@NonNull View view, @NotNull Bookmark item, boolean isLastVisibleItem) {
+        public void onShowContextMenu(@NonNull View view, @NonNull Bookmark item, boolean isLastVisibleItem) {
             showLibraryItemContextMenu(
                     view,
                     new LibraryMenuWidget.LibraryContextMenuItem(

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1427,7 +1427,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onFxASynSettings(@NonNull View view) {
-            mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA);
+            mWidgetManager.getTray().showSettingsDialog(SettingsWidget.SettingDialog.FXA);
         }
 
         @Override
@@ -1466,7 +1466,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onFxASynSettings(@NonNull View view) {
-            mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA);
+            mWidgetManager.getTray().showSettingsDialog(SettingsWidget.SettingDialog.FXA);
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -10,7 +10,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
-import org.jetbrains.annotations.NotNull;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserApplication;
@@ -887,7 +886,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
 
         @Override
-        public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+        public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
             if (authType != AuthType.Existing.INSTANCE) {
                 Session session = mFocusedWindow.getSession();
                 addTab(mFocusedWindow, mAccounts.getConnectionSuccessURL());
@@ -910,7 +909,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
 
         @Override
-        public void onProfileUpdated(@NotNull Profile profile) {
+        public void onProfileUpdated(@NonNull Profile profile) {
 
         }
 
@@ -1150,7 +1149,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         addTab(targetWindow, null);
     }
 
-    public void addTab(@NotNull WindowWidget targetWindow, @Nullable String aUri) {
+    public void addTab(@NonNull WindowWidget targetWindow, @Nullable String aUri) {
         Session session = SessionStore.get().createSuspendedSession(aUri, targetWindow.getSession().isPrivateMode());
         setFirstPaint(targetWindow, session);
         targetWindow.getSession().setActive(false);
@@ -1238,7 +1237,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     }
 
     @Override
-    public void onTabsReceived(@NotNull List<TabData> aTabs) {
+    public void onTabsReceived(@NonNull List<TabData> aTabs) {
         WindowWidget targetWindow = mFocusedWindow;
 
         boolean fullscreen = targetWindow.getSession().isInFullScreen();

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -895,15 +895,15 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
                 switch (mAccounts.getLoginOrigin()) {
                     case BOOKMARKS:
-                        getFocusedWindow().switchBookmarks();
+                        getFocusedWindow().showBookmarks();
                         break;
 
                     case HISTORY:
-                        getFocusedWindow().switchHistory();
+                        getFocusedWindow().showHistory();
                         break;
 
                     case SETTINGS:
-                        mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA);
+                        mWidgetManager.getTray().showSettingsDialog(SettingsWidget.SettingDialog.FXA);
                         break;
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
@@ -13,7 +13,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 
-import org.jetbrains.annotations.NotNull;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.Accounts;
@@ -168,7 +167,7 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
     // DeviceConstellationObserver
 
     @Override
-    public void onDevicesUpdate(@NotNull ConstellationState constellationState) {
+    public void onDevicesUpdate(@NonNull ConstellationState constellationState) {
         post(() -> {
             mSendTabsDialogBinding.setIsSyncing(false);
 
@@ -203,14 +202,14 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
     }
 
     @Override
-    public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+    public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
         if (mAccounts.getLoginOrigin() == Accounts.LoginOrigin.SEND_TABS) {
             show(REQUEST_FOCUS);
         }
     }
 
     @Override
-    public void onProfileUpdated(@NotNull Profile profile) {
+    public void onProfileUpdated(@NonNull Profile profile) {
 
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -11,10 +11,10 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.databinding.DataBindingUtil;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.Accounts;
@@ -260,12 +260,12 @@ class FxAAccountOptionsView extends SettingsView {
     private AccountObserver mAccountListener = new AccountObserver() {
 
         @Override
-        public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+        public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
             mBinding.signButton.setButtonText(R.string.settings_fxa_account_sign_out);
         }
 
         @Override
-        public void onProfileUpdated(@NotNull Profile profile) {
+        public void onProfileUpdated(@NonNull Profile profile) {
             mBinding.accountEmail.setText(profile.getEmail());
             mBinding.setLastSync(mAccounts.lastSync());
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -24,7 +24,6 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.databinding.DataBindingUtil;
 
-import org.jetbrains.annotations.NotNull;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
@@ -332,12 +331,12 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     private AccountObserver mAccountObserver = new AccountObserver() {
 
         @Override
-        public void onAuthenticated(@NotNull OAuthAccount oAuthAccount, @NotNull AuthType authType) {
+        public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
 
         }
 
         @Override
-        public void onProfileUpdated(@NotNull Profile profile) {
+        public void onProfileUpdated(@NonNull Profile profile) {
             updateProfile(profile);
         }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -432,7 +432,9 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     }
 
     public void show(@ShowFlags int aShowFlags, @NonNull SettingDialog settingDialog) {
-        show(aShowFlags);
+        if (!isVisible()) {
+            show(aShowFlags);
+        }
 
         switch (settingDialog) {
             case LANGUAGE:

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/ViewUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/ViewUtils.java
@@ -2,7 +2,6 @@ package org.mozilla.vrbrowser.utils;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
@@ -16,7 +15,6 @@ import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
 import android.text.style.URLSpan;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,10 +23,8 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.coordinatorlayout.widget.ViewGroupUtils;
 import androidx.core.text.HtmlCompat;
 
-import org.jetbrains.annotations.NotNull;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 
 public class ViewUtils {
@@ -123,7 +119,7 @@ public class ViewUtils {
         return isChildrenOf(aParent, aView);
     }
 
-    public static boolean isInsideView(@NotNull View view, int rx, int ry) {
+    public static boolean isInsideView(@NonNull View view, int rx, int ry) {
         int[] location = new int[2];
         view.getLocationOnScreen(location);
         int x = location[0];


### PR DESCRIPTION
Fixes #2449 After a successful FxA login if the origin was the Account panel from settings, we were toggling the panel but the user might have it opened already. Now we make sure that if it's opened just transits to the Account panel or we open it otherwise.