### PR TITLE
Rename ping to avoid underscores

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -16,7 +16,7 @@ distribution:
       - baseline
       - events
       - metrics
-      - session_end
+      - session-end
     bugs:
       - https://github.com/MozillaReality/FirefoxReality/issues/1420
     data_reviews:
@@ -30,7 +30,7 @@ url:
   domains:
     type: counter
     send_in_pings:
-      - session_end
+      - session-end
     description: >
       Counting how many domains are visited in a session.
     bugs:
@@ -44,7 +44,7 @@ url:
   visits:
     type: counter
     send_in_pings:
-      - session_end
+      - session-end
     description: >
       Counting how many URL links are visited in a session.
     bugs:
@@ -92,7 +92,7 @@ tabs:
     description: >
       Number of tabs opened during a session
     send_in_pings:
-      - session_end
+      - session-end
     labels:
       - context_menu
       - tabs_dialog
@@ -115,7 +115,7 @@ tabs:
     description: >
       Number of tabs activated during a session
     send_in_pings:
-      - session_end
+      - session-end
     bugs:
       - https://github.com/MozillaReality/FirefoxReality/issues/1609
     data_reviews:
@@ -229,7 +229,7 @@ control:
     description: >
       Counting how many general windows are opened in a session.
     send_in_pings:
-      - session_end
+      - session-end
     bugs:
       - https://github.com/MozillaReality/FirefoxReality/issues/2347
     data_reviews:

--- a/app/pings.yaml
+++ b/app/pings.yaml
@@ -4,7 +4,7 @@
 
 $schema: moz://mozilla.org/schemas/glean/pings/1-0-0
 
-session_end:
+session-end:
   description: >
     This ping is sent at the end of a session (when Firefox Reality switches to the background).
     We usually send search and UI control metrics at the end of a session.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,7 +10,7 @@ This means you might have to go searching through the dependency tree to get a f
  - [baseline](#baseline)
  - [events](#events)
  - [metrics](#metrics)
- - [session_end](#session_end)
+ - [session-end](#session-end)
 
 
 ## baseline
@@ -49,7 +49,7 @@ The following metrics are added to the ping:
 | searches.counts |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counting how many searches are queried in a specific search engine. The search engine `identifier`s are used as keys for this metric.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/2241#issuecomment-557740258)||2020-05-01 |
 | url.query_type |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counting how many URLs are visited in a day, by input method.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/2241#issuecomment-557740258)|<ul><li>type_link</li><li>type_query</li><li>voice_query</li></ul>|2020-05-01 |
 
-## session_end
+## session-end
 This ping is sent at the end of a session (when Firefox Reality switches to the background). We usually send search and UI control metrics at the end of a session.
 
 The following metrics are added to the ping:


### PR DESCRIPTION
Not ready for merge yet.
Requires an upgrade of android-components (for the updated sdk_generator script).
We're landing changes in the pipeline as well first.

There's no data loss. Data will still go to the same table for both `session_end` and `session-end` pings.
I'll come back here and put it out of Draft mode when we're ready to land it.