### PR TITLE
Making WaveVR app id suffix to be '.dev'.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
+def devSuffix = ".dev"
+
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
@@ -26,7 +28,7 @@ def getCrashRestartDisabled = { ->
 
 def getDevApplicationIdSuffix = { ->
     if (gradle.hasProperty("userProperties.simultaneousDevProduction")) {
-        return gradle."userProperties.simultaneousDevProduction" == "true" ? ".dev" : ""
+        return gradle."userProperties.simultaneousDevProduction" == "true" ? devSuffix : ""
     }
     return ""
 }
@@ -44,6 +46,7 @@ ext.gleanDocsDirectory = "$rootDir/docs"
 
 android {
     compileSdkVersion build_versions.target_sdk
+
     defaultConfig {
         applicationId "org.mozilla.vrbrowser"
         minSdkVersion build_versions.min_sdk
@@ -193,7 +196,7 @@ android {
                     arguments "-DVR_SDK_LIB=wavevr-lib", "-DWAVEVR=ON"
                 }
             }
-            applicationIdSuffix ".wavevr"
+            applicationIdSuffix devSuffix
         }
 
         wavevrStore {


### PR DESCRIPTION
Fixes #2514. We should not have a specific app id for WaveVR. The original purpose at  #1476 is in order to allow developers can deploy their local build into WaveVR devices. However, that will make our application id has an another branch. That will be hard to do data collection.

So, the idea is we should unifiy non `org.mozilla.vrbrowser` application to be `org.mozilla.vrbrowser.dev` includes `simultaneousDevProduction=true` that mean this build is deployed by developers or other unofficial distribution channels.