### PR TITLE
Only show login success if account creation was user initiated

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -893,7 +893,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         @Override
         public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
-            if (authType != AuthType.Existing.INSTANCE) {
+            if (authType == AuthType.Signin.INSTANCE || authType == AuthType.Signup.INSTANCE) {
                 Session session = mFocusedWindow.getSession();
                 addTab(mFocusedWindow, mAccounts.getConnectionSuccessURL());
                 onTabsClose(new ArrayList<>(Collections.singletonList(session)));


### PR DESCRIPTION
Fix #2553 Only show the success screen and open login origin if the account creation was user initiated