### PR TITLE
Dialog stacking

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -338,18 +338,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             final WhatsNewWidget whatsNew = new WhatsNewWidget(this);
             whatsNew.setLoginOrigin(Accounts.LoginOrigin.NONE);
             whatsNew.getPlacement().parentHandle = mWindows.getFocusedWindow().getHandle();
-            whatsNew.setStartBrowsingCallback(() -> {
-                whatsNew.hide(UIWidget.REMOVE_WIDGET);
-                whatsNew.releaseWidget();
-            });
-            whatsNew.setSignInCallback(() -> {
-                whatsNew.hide(UIWidget.REMOVE_WIDGET);
-                whatsNew.releaseWidget();
-            });
-            whatsNew.setDelegate(() -> {
-                whatsNew.hide(UIWidget.REMOVE_WIDGET);
-                whatsNew.releaseWidget();
-            });
             whatsNew.show(UIWidget.REQUEST_FOCUS);
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -1186,14 +1186,11 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     public void showSendTabDialog() {
-        mSendTabDialog = new SendTabDialogWidget(getContext());
+        if (mSendTabDialog == null) {
+            mSendTabDialog = new SendTabDialogWidget(getContext());
+        }
         mSendTabDialog.mWidgetPlacement.parentHandle = mWidgetManager.getFocusedWindow().getHandle();
         mSendTabDialog.setSessionId(mAttachedWindow.getSession().getId());
-        mSendTabDialog.setDelegate(() -> {
-            mSendTabDialog.releaseWidget();
-            mSendTabDialog = null;
-            NavigationBarWidget.this.show(REQUEST_FOCUS);
-        });
         mSendTabDialog.show(UIWidget.REQUEST_FOCUS);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -158,7 +158,9 @@ public class TabsWidget extends UIDialog {
     @Override
     public void hide(@HideFlags int aHideFlags) {
         super.hide(aHideFlags);
-        mRenderer.clearSurface();
+        if (mRenderer != null) {
+            mRenderer.clearSurface();
+        }
     }
 
     public void setTabDelegate(TabDelegate aDelegate) {
@@ -269,15 +271,11 @@ public class TabsWidget extends UIDialog {
 
                 @Override
                 public void onSend(TabView aSender) {
-                    hide(KEEP_WIDGET);
-                    mSendTabDialog = new SendTabDialogWidget(getContext());
+                    if (mSendTabDialog == null) {
+                        mSendTabDialog = new SendTabDialogWidget(getContext());
+                    }
                     mSendTabDialog.setSessionId(aSender.getSession().getId());
                     mSendTabDialog.mWidgetPlacement.parentHandle = mWidgetManager.getFocusedWindow().getHandle();
-                    mSendTabDialog.setDelegate(() -> {
-                        mSendTabDialog.releaseWidget();
-                        mSendTabDialog = null;
-                        TabsWidget.this.show(REQUEST_FOCUS);
-                    });
                     mSendTabDialog.show(UIWidget.REQUEST_FOCUS);
                 }
             });

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -52,7 +52,6 @@ import org.mozilla.vrbrowser.ui.widgets.dialogs.SelectionActionWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.ContextMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.LibraryMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
-import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
@@ -101,7 +100,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private WidgetManagerDelegate mWidgetManager;
     private PromptDialogWidget mAlertDialog;
     private PromptDialogWidget mConfirmDialog;
-    private PromptDialogWidget mNoInternetDialog;
     private PromptDialogWidget mAppDialog;
     private ClearHistoryDialogWidget mClearHistoryDialog;
     private ContextMenuWidget mContextMenu;
@@ -236,8 +234,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         aSession.addProgressListener(this);
         aSession.setHistoryDelegate(this);
         aSession.addSelectionActionListener(this);
-
-        mWidgetManager.addConnectivityListener(mConnectivityDelegate);
     }
 
     void cleanListeners(Session aSession) {
@@ -248,8 +244,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         aSession.removeProgressListener(this);
         aSession.setHistoryDelegate(null);
         aSession.removeSelectionActionListener(this);
-
-        mWidgetManager.removeConnectivityListener(mConnectivityDelegate);
     }
 
     @Override
@@ -329,31 +323,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
         mListeners.clear();
     }
-
-    private ConnectivityReceiver.Delegate mConnectivityDelegate = connected -> {
-        if (mActive) {
-            if (mNoInternetDialog == null) {
-                mNoInternetDialog = new PromptDialogWidget(getContext());
-                mNoInternetDialog.setButtons(new int[] {
-                        R.string.ok_button
-                });
-                mNoInternetDialog.setCheckboxVisible(false);
-                mNoInternetDialog.setDescriptionVisible(false);
-                mNoInternetDialog.setTitle(R.string.no_internet_title);
-                mNoInternetDialog.setBody(R.string.no_internet_message);
-                mNoInternetDialog.setButtonsDelegate(index -> {
-                    mNoInternetDialog.hide(REMOVE_WIDGET);
-                });
-            }
-
-            if (!connected && !mNoInternetDialog.isVisible()) {
-                mNoInternetDialog.show(REQUEST_FOCUS);
-
-            } else if (connected && mNoInternetDialog.isVisible()) {
-                mNoInternetDialog.hide(REMOVE_WIDGET);
-            }
-        }
-    };
 
     public void loadHomeIfNotRestored() {
         if (!mIsRestored) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -22,8 +22,11 @@ import org.mozilla.vrbrowser.browser.engine.SessionState;
 import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
+import org.mozilla.vrbrowser.ui.widgets.dialogs.PromptDialogWidget;
+import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
 import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 import org.mozilla.vrbrowser.utils.BitmapCache;
+import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.io.File;
@@ -103,6 +106,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     private TabsWidget mTabsWidget;
     private Accounts mAccounts;
     private Services mServices;
+    private PromptDialogWidget mNoInternetDialog;
 
     public enum WindowPlacement{
         FRONT(0),
@@ -141,6 +145,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         mAccounts.addAccountListener(mAccountObserver);
         mServices = ((VRBrowserApplication)mContext.getApplicationContext()).getServices();
         mServices.setTabReceivedDelegate(this);
+
+        mWidgetManager.addConnectivityListener(mConnectivityDelegate);
 
         restoreWindows();
     }
@@ -435,6 +441,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         }
         mAccounts.removeAccountListener(mAccountObserver);
         mServices.setTabReceivedDelegate(null);
+        mWidgetManager.removeConnectivityListener(mConnectivityDelegate);
     }
 
     public boolean isInPrivateMode() {
@@ -894,6 +901,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         @Override
         public void onAuthenticated(@NonNull OAuthAccount oAuthAccount, @NonNull AuthType authType) {
             if (authType == AuthType.Signin.INSTANCE || authType == AuthType.Signup.INSTANCE) {
+                UIDialog.closeAllDialogs();
                 Session session = mFocusedWindow.getSession();
                 addTab(mFocusedWindow, mAccounts.getConnectionSuccessURL());
                 onTabsClose(new ArrayList<>(Collections.singletonList(session)));
@@ -1274,4 +1282,27 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mTabsWidget.refreshTabs();
         }
     }
+
+    private ConnectivityReceiver.Delegate mConnectivityDelegate = connected -> {
+        if (mNoInternetDialog == null) {
+            mNoInternetDialog = new PromptDialogWidget(mContext);
+            mNoInternetDialog.setButtons(new int[] {
+                    R.string.ok_button
+            });
+            mNoInternetDialog.setCheckboxVisible(false);
+            mNoInternetDialog.setDescriptionVisible(false);
+            mNoInternetDialog.setTitle(R.string.no_internet_title);
+            mNoInternetDialog.setBody(R.string.no_internet_message);
+            mNoInternetDialog.setButtonsDelegate(index -> {
+                mNoInternetDialog.hide(UIWidget.REMOVE_WIDGET);
+            });
+        }
+
+        if (!connected && !mNoInternetDialog.isVisible()) {
+            mNoInternetDialog.show(UIWidget.REQUEST_FOCUS);
+
+        } else if (connected && mNoInternetDialog.isVisible()) {
+            mNoInternetDialog.hide(UIWidget.REMOVE_WIDGET);
+        }
+    };
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
@@ -61,8 +61,6 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
         mSendTabsDialogBinding.setIsEmpty(false);
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
-        mAccounts.addAccountListener(this);
-        mAccounts.addDeviceConstellationListener(this);
 
         mBinding.headerLayout.setTitle(getResources().getString(R.string.send_tab_dialog_title));
         mBinding.headerLayout.setDescription(R.string.send_tab_dialog_description);
@@ -71,15 +69,10 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
     }
 
     @Override
-    public void releaseWidget() {
-        mAccounts.removeAccountListener(this);
-        mAccounts.removeDeviceConstellationListener(this);
-
-        super.releaseWidget();
-    }
-
-    @Override
     public void show(int aShowFlags) {
+        mAccounts.addAccountListener(this);
+        mAccounts.addDeviceConstellationListener(this);
+
         if (mAccounts.isSignedIn()) {
             mBinding.footerLayout.setFooterButtonVisibility(View.GONE);
             mAccounts.refreshDevicesAsync();
@@ -96,7 +89,8 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
     public void hide(int aHideFlags) {
         super.hide(aHideFlags);
 
-        mWidgetManager.removeWorldClickListener(this);
+        mAccounts.removeAccountListener(this);
+        mAccounts.removeDeviceConstellationListener(this);
     }
 
     public void setSessionId(@Nullable String sessionId) {
@@ -122,24 +116,6 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
     private void showWhatsNewDialog() {
         mWhatsNew = new WhatsNewWidget(getContext());
         mWhatsNew.setLoginOrigin(Accounts.LoginOrigin.SEND_TABS);
-        mWhatsNew.setStartBrowsingCallback(() -> {
-            mWhatsNew.hide(REMOVE_WIDGET);
-            mWhatsNew.releaseWidget();
-            mWhatsNew = null;
-            onDismiss();
-        });
-        mWhatsNew.setSignInCallback(() -> {
-            mWhatsNew.hide(REMOVE_WIDGET);
-            mWhatsNew.releaseWidget();
-            mWhatsNew = null;
-            hide(KEEP_WIDGET);
-        });
-        mWhatsNew.setDelegate(() -> {
-            mWhatsNew.hide(REMOVE_WIDGET);
-            mWhatsNew.releaseWidget();
-            mWhatsNew = null;
-            onDismiss();
-        });
         mWhatsNew.show(UIWidget.REQUEST_FOCUS);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
@@ -6,7 +6,12 @@ import android.util.AttributeSet;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 
+import java.util.LinkedList;
+
 public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate.WorldClickListener {
+
+    private static LinkedList<UIDialog> mDialogs = new LinkedList<>();
+
     public UIDialog(Context aContext) {
         super(aContext);
         initialize();
@@ -43,6 +48,12 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
             super.show(aShowFlags);
 
             mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
+
+            UIDialog head = mDialogs.peek();
+            if (head != null && head.isVisible()) {
+                head.hide();
+            }
+            mDialogs.push(this);
         }
     }
 
@@ -51,12 +62,36 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
         super.hide(aHideFlags);
 
         mWidgetManager.popWorldBrightness(this);
+
+        mDialogs.remove(this);
+        UIDialog head = mDialogs.peek();
+        if (head != null) {
+            head.show();
+        }
+    }
+
+    private void show() {
+        if (!isVisible()) {
+            super.show(REQUEST_FOCUS);
+
+            mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
+        }
+    }
+
+    private void hide() {
+        super.hide(KEEP_WIDGET);
+
+        mWidgetManager.popWorldBrightness(this);
     }
 
     @Override
     public void onWorldClick() {
-        if (this.isVisible()) {
-            onDismiss();
+        if (isVisible()) {
+            post(() -> hide(REMOVE_WIDGET));
         }
+    }
+
+    public static void closeAllDialogs() {
+        new LinkedList<>(mDialogs).forEach(dialog -> dialog.onDismiss());
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
@@ -8,8 +8,6 @@ package org.mozilla.vrbrowser.ui.widgets.dialogs;
 import android.content.Context;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserApplication;
@@ -23,8 +21,6 @@ import java.util.concurrent.Executor;
 public class WhatsNewWidget extends PromptDialogWidget {
 
     private Accounts mAccounts;
-    private Runnable mSignInCallback;
-    private Runnable mStartBrowsingCallback;
     private Accounts.LoginOrigin mLoginOrigin;
     private Executor mUIThreadExecutor;
 
@@ -32,14 +28,6 @@ public class WhatsNewWidget extends PromptDialogWidget {
         super(aContext);
 
         initialize(aContext);
-    }
-
-    public void setSignInCallback(@NonNull Runnable callback) {
-        mSignInCallback = callback;
-    }
-
-    public void setStartBrowsingCallback(@NonNull Runnable callback) {
-        mStartBrowsingCallback = callback;
     }
 
     @Override
@@ -55,7 +43,7 @@ public class WhatsNewWidget extends PromptDialogWidget {
         });
         setButtonsDelegate(index -> {
             if (index == PromptDialogWidget.NEGATIVE) {
-                startBrowsing();
+                onDismiss();
 
             } else if (index == PromptDialogWidget.POSITIVE) {
                 signIn();
@@ -86,7 +74,7 @@ public class WhatsNewWidget extends PromptDialogWidget {
             mAccounts.logoutAsync();
 
         } else {
-            hide(REMOVE_WIDGET);
+            UIDialog.closeAllDialogs();
 
             CompletableFuture<String> result = mAccounts.authUrlAsync();
             if (result != null) {
@@ -102,22 +90,12 @@ public class WhatsNewWidget extends PromptDialogWidget {
                         GleanMetricsService.Tabs.openedCounter(GleanMetricsService.Tabs.TabSource.FXA_LOGIN);
                     }
 
-                    if (mSignInCallback != null) {
-                        mSignInCallback.run();
-                    }
-
                 }, mUIThreadExecutor).exceptionally(throwable -> {
                     Log.d(LOGTAG, "Error getting the authentication URL: " + throwable.getLocalizedMessage());
                     throwable.printStackTrace();
                     return null;
                 });
             }
-        }
-    }
-
-    private void startBrowsing() {
-        if (mStartBrowsingCallback != null) {
-            mStartBrowsingCallback.run();
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -493,11 +493,8 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
 
     @Override
     public void showRestartDialog() {
-        hide(UIWidget.REMOVE_WIDGET);
-
         if (mRestartDialog == null) {
             mRestartDialog = new RestartDialogWidget(getContext());
-            mRestartDialog.setDelegate(() -> SettingsWidget.this.show(REQUEST_FOCUS));
         }
 
         mRestartDialog.show(REQUEST_FOCUS);
@@ -505,9 +502,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
 
     @Override
     public void showAlert(String aTitle, String aMessage) {
-        hide(UIWidget.KEEP_WIDGET);
-
-        mWidgetManager.getFocusedWindow().showAlert(aTitle, aMessage, index -> show(REQUEST_FOCUS));
+        mWidgetManager.getFocusedWindow().showAlert(aTitle, aMessage, null);
     }
 
     private boolean isLanguagesSubView(View view) {


### PR DESCRIPTION
Fixes #2449 Fixes #2571 Stack dialogs when showing/hiding. Dialogs are pushed when showing and popped when hidden.

STRs:
- Turn Off WiFi
- Open: Settings -> Languages -> Display Languages
- Choose a different language, the restart dialog should appear
- Click on the home button
- Resume FxR

Expected Result:
You should see the connection dialog and dismissing that one should go back to the Restart dialog.