### PR TITLE
Make the base dialog taller to fit all the languages

### DIFF
--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -243,7 +243,7 @@
 
     <!-- Prompt dialog -->
     <dimen name="prompt_dialog_width">450dp</dimen>
-    <dimen name="prompt_dialog_height">340dp</dimen>
+    <dimen name="prompt_dialog_height">365dp</dimen>
     <dimen name="prompt_dialog_padding_top">20dp</dimen>
     <dimen name="prompt_dialog_padding_bottom">42dp</dimen>
     <dimen name="prompt_dialog_padding_sides">64dp</dimen>


### PR DESCRIPTION
Fixes #2519 Fixes #2499 Make the base dialog taller to fit all the languages