### PR TITLE
FxA sync fixes

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
@@ -25,8 +25,8 @@ import mozilla.components.service.fxa.sync.SyncStatusObserver
 import mozilla.components.service.fxa.sync.getLastSynced
 import org.mozilla.vrbrowser.R
 import org.mozilla.vrbrowser.VRBrowserApplication
-import org.mozilla.vrbrowser.utils.BitmapCache
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService
+import org.mozilla.vrbrowser.utils.BitmapCache
 import org.mozilla.vrbrowser.utils.SystemUtils
 import org.mozilla.vrbrowser.utils.ViewUtils
 import java.net.URL
@@ -127,8 +127,6 @@ class Accounts constructor(val context: Context) {
             accountStatus = AccountStatus.SIGNED_IN
 
             // Enable syncing after signing in
-            syncStorage.setStatus(SyncEngine.Bookmarks, SettingsStore.getInstance(context).isBookmarksSyncEnabled)
-            syncStorage.setStatus(SyncEngine.History, SettingsStore.getInstance(context).isHistorySyncEnabled)
             services.accountManager.syncNowAsync(SyncReason.EngineChange, true)
 
             // Update device list
@@ -319,11 +317,9 @@ class Accounts constructor(val context: Context) {
         when(engine) {
             SyncEngine.Bookmarks -> {
                 GleanMetricsService.FxA.bookmarksSyncStatus(value)
-                SettingsStore.getInstance(context).isBookmarksSyncEnabled = value
             }
             SyncEngine.History -> {
                 GleanMetricsService.FxA.historySyncStatus(value)
-                SettingsStore.getInstance(context).isHistorySyncEnabled = value
             }
         }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -621,25 +621,6 @@ public class SettingsStore {
         editor.putBoolean(mContext.getString(R.string.settings_key_pop_up_blocking), isEnabled);
         editor.commit();
     }
-    public void setBookmarksSyncEnabled(boolean isEnabled) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putBoolean(mContext.getString(R.string.settings_key_bookmarks_sync), isEnabled);
-        editor.commit();
-    }
-
-    public boolean isBookmarksSyncEnabled() {
-        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_bookmarks_sync), BOOKMARKS_SYNC_DEFAULT);
-    }
-
-    public void setHistorySyncEnabled(boolean isEnabled) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putBoolean(mContext.getString(R.string.settings_key_history_sync), isEnabled);
-        editor.commit();
-    }
-
-    public boolean isHistorySyncEnabled() {
-        return mPrefs.getBoolean(mContext.getString(R.string.settings_key_history_sync), HISTORY_SYNC_DEFAULT);
-    }
 
     public void setWhatsNewDisplayed(boolean isEnabled) {
         SharedPreferences.Editor editor = mPrefs.edit();


### PR DESCRIPTION
Fixes #2411 Fixes #2409 We were syncing only when the user explicitly did it or after exiting the accounts dialog but this has some side effects like the issue one. I've moved this to the same way as Fenix does it, we might encounter past issues like the sync status being reverted if changing it and syncing right away but this is more similar to how Fenix works and users shouldn't be syncing that much so I guess it's better to have real time sync. 