### PR TITLE
Do not send stack callbacks for child sessions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -75,7 +75,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     private transient CopyOnWriteArrayList<GeckoSession.SelectionActionDelegate> mSelectionActionListeners;
 
     private SessionState mState;
-    private CopyOnWriteArrayList<Runnable> mQueuedCalls = new CopyOnWriteArrayList<>();
+    private transient CopyOnWriteArrayList<Runnable> mQueuedCalls = new CopyOnWriteArrayList<>();
     private transient GeckoSession.PermissionDelegate mPermissionDelegate;
     private transient GeckoSession.PromptDelegate mPromptDelegate;
     private transient GeckoSession.HistoryDelegate mHistoryDelegate;
@@ -1469,16 +1469,6 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             for (GeckoSession.NavigationDelegate listener : mNavigationListeners) {
                 listener.onCanGoBack(this.getGeckoSession(), canGoBack());
             }
-        }
-    }
-
-    @Override
-    public void onStackSession(Session aSession) {
-        if (aSession.equals(this)) {
-            return;
-        }
-        for (SessionChangeListener listener : mSessionChangeListeners) {
-            listener.onStackSession(aSession);
         }
     }
 


### PR DESCRIPTION
Fixes #2415 Session stacking events are currently sent in cascade for all the children of a session. When any of those children are already attached to a window that triggers the reported issue as the new session is attached to the parent's  and all the attached children's windows. 