### PR TITLE
Support for shaped clipped event handler

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/ClippedEventDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/ClippedEventDelegate.java
@@ -15,6 +15,7 @@ public abstract class ClippedEventDelegate implements View.OnHoverListener, View
     private boolean mTouched;
     private OnClickListener mClickListener;
     private View.OnHoverListener mOnHoverListener;
+    private View.OnTouchListener mOnTouchListener;
 
     View mView;
     Region mRegion;
@@ -37,6 +38,10 @@ public abstract class ClippedEventDelegate implements View.OnHoverListener, View
 
     // The region should be recreated in this event based on the current state drawable
     abstract boolean onUpdateRegion();
+
+    public void setOnTouchListener(View.OnTouchListener listener) {
+        mOnTouchListener = listener;
+    }
 
     public void setOnHoverListener(View.OnHoverListener listener) {
         mOnHoverListener = listener;
@@ -93,9 +98,9 @@ public abstract class ClippedEventDelegate implements View.OnHoverListener, View
                     if (mTouched) {
                         v.requestFocus();
                         v.requestFocusFromTouch();
-                        if (mClickListener != null) {
-                            v.performClick();
-                            mClickListener.onClick(v);
+                        event.setAction(MotionEvent.ACTION_CANCEL);
+                        if (mOnTouchListener != null) {
+                            mOnTouchListener.onTouch(v, event);
                         }
                     }
                     v.onHoverChanged(false);
@@ -104,11 +109,18 @@ public abstract class ClippedEventDelegate implements View.OnHoverListener, View
                     mTouched = false;
             }
 
+            if (mOnTouchListener != null) {
+                mOnTouchListener.onTouch(v, event);
+            }
+
             return true;
 
         } else {
             switch (event.getAction()) {
                 case MotionEvent.ACTION_DOWN:
+                    if (mOnTouchListener != null) {
+                        mOnTouchListener.onTouch(v, event);
+                    }
                     v.setPressed(true);
                     mTouched = true;
                     return true;
@@ -121,6 +133,15 @@ public abstract class ClippedEventDelegate implements View.OnHoverListener, View
                             v.performClick();
                             mClickListener.onClick(v);
                         }
+                        if (mOnTouchListener != null) {
+                            mOnTouchListener.onTouch(v, event);
+                        }
+
+                    } else {
+                        event.setAction(MotionEvent.ACTION_CANCEL);
+                        if (mOnTouchListener != null) {
+                            mOnTouchListener.onTouch(v, event);
+                        }
                     }
                     v.setHovered(false);
                     v.onHoverChanged(false);
@@ -129,9 +150,15 @@ public abstract class ClippedEventDelegate implements View.OnHoverListener, View
                     return true;
 
                 case MotionEvent.ACTION_MOVE:
+                    if (mOnTouchListener != null) {
+                        mOnTouchListener.onTouch(v, event);
+                    }
                     return true;
 
                 case MotionEvent.ACTION_CANCEL:
+                    if (mOnTouchListener != null) {
+                        mOnTouchListener.onTouch(v, event);
+                    }
                     v.setPressed(false);
                     mTouched = false;
                     return true;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HoneycombButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HoneycombButton.java
@@ -1,5 +1,6 @@
 package org.mozilla.vrbrowser.ui.views;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.PorterDuff;
@@ -32,7 +33,7 @@ public class HoneycombButton extends LinearLayout {
     private String mSecondaryButtonText;
     private Drawable mButtonIcon;
     private boolean mButtonIconHover;
-    private VectorClippedEventDelegate mEventDelegate;
+    private VectorClippedEventDelegate mClippedEventDelegate;
 
     public HoneycombButton(Context context, @Nullable AttributeSet attrs) {
         this(context, attrs, R.style.honeycombButtonTheme);
@@ -82,6 +83,7 @@ public class HoneycombButton extends LinearLayout {
         initialize(context);
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private void initialize(Context aContext) {
         inflate(aContext, R.layout.honeycomb_button, this);
 
@@ -109,44 +111,55 @@ public class HoneycombButton extends LinearLayout {
             mSecondaryText.setClickable(false);
         }
 
-        mEventDelegate = new VectorClippedEventDelegate(R.drawable.settings_honeycomb_background, this);
-        setOnHoverListener(mEventDelegate);
-        setOnTouchListener(mEventDelegate);
+        mClippedEventDelegate = new VectorClippedEventDelegate(this, R.drawable.settings_honeycomb_background);
+        super.setOnHoverListener(mClippedEventDelegate);
+        super.setOnTouchListener(mClippedEventDelegate);
+    }
+
+    @Override
+    public void setOnHoverListener(OnHoverListener l) {
+        mClippedEventDelegate.setOnHoverListener(l);
     }
 
     @Override
     public void setOnClickListener(@Nullable OnClickListener aListener) {
-        mEventDelegate.setOnClickListener(aListener);
+        mClippedEventDelegate.setOnClickListener(aListener);
     }
 
     @Override
     public boolean onHoverEvent(MotionEvent event) {
         switch (event.getAction()) {
             case MotionEvent.ACTION_HOVER_ENTER:
-                if (mIcon != null && mText != null) {
-                    if (mButtonIconHover) {
-                        mIcon.setColorFilter(new PorterDuffColorFilter(getResources().getColor(R.color.asphalt, getContext().getTheme()), PorterDuff.Mode.MULTIPLY));
-                    }
-                    mText.setTextColor(getContext().getColor(R.color.asphalt));
-                    mSecondaryText.setTextColor(getContext().getColor(R.color.asphalt));
-                }
+                onHoverChanged(true);
                 break;
             case MotionEvent.ACTION_HOVER_EXIT:
-                if (mIcon != null && mText != null) {
-                    if (mButtonIconHover) {
-                        mIcon.setColorFilter(new PorterDuffColorFilter(getResources().getColor(R.color.fog, getContext().getTheme()), PorterDuff.Mode.MULTIPLY));
-                    }
-                    mText.setTextColor(getContext().getColor(R.color.fog));
-                    mSecondaryText.setTextColor(getContext().getColor(R.color.fog));
-                }
+                onHoverChanged(false);
                 break;
         }
 
-        if (mEventDelegate.isInside(event)) {
+        if (mClippedEventDelegate.isInside(event)) {
             return super.onHoverEvent(event);
 
         } else {
-            setHovered(false);
+            onHoverChanged(false);
+            return false;
+        }
+    }
+
+    @Override
+    public void onHoverChanged(boolean hovered) {
+        super.onHoverChanged(hovered);
+
+        if (hovered) {
+            if (mIcon != null && mText != null) {
+                if (mButtonIconHover) {
+                    mIcon.setColorFilter(new PorterDuffColorFilter(getResources().getColor(R.color.asphalt, getContext().getTheme()), PorterDuff.Mode.MULTIPLY));
+                }
+                mText.setTextColor(getContext().getColor(R.color.asphalt));
+                mSecondaryText.setTextColor(getContext().getColor(R.color.asphalt));
+            }
+
+        } else {
             if (mIcon != null && mText != null) {
                 if (mButtonIconHover) {
                     mIcon.setColorFilter(new PorterDuffColorFilter(getResources().getColor(R.color.fog, getContext().getTheme()), PorterDuff.Mode.MULTIPLY));
@@ -154,7 +167,6 @@ public class HoneycombButton extends LinearLayout {
                 mText.setTextColor(getContext().getColor(R.color.fog));
                 mSecondaryText.setTextColor(getContext().getColor(R.color.fog));
             }
-            return false;
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/ShapeClippedEventDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/ShapeClippedEventDelegate.java
@@ -1,0 +1,66 @@
+package org.mozilla.vrbrowser.ui.views;
+
+import android.graphics.Path;
+import android.graphics.RectF;
+import android.graphics.Region;
+import android.graphics.drawable.GradientDrawable;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+
+class ShapeClippedEventDelegate extends ClippedEventDelegate {
+
+    ShapeClippedEventDelegate(@NonNull View view) {
+        super(view);
+    }
+
+    @Override
+    boolean onUpdateRegion() {
+        Path path = null;
+        if (mView.getBackground() != null && mView.getBackground().getCurrent() instanceof GradientDrawable) {
+            GradientDrawable background = (GradientDrawable) mView.getBackground().getCurrent();
+            int shape = background.getShape();
+            RectF bounds = new RectF(background.getBounds());
+            switch (shape) {
+                case GradientDrawable.OVAL:
+                    path = new Path();
+                    path.addOval(bounds, Path.Direction.CCW);
+                    break;
+
+                case GradientDrawable.RECTANGLE:
+                    float[] radii;
+                    try {
+                        radii = background.getCornerRadii();
+
+                    } catch (NullPointerException e) {
+                        radii = new float[]{0, 0, 0, 0, 0, 0, 0, 0};
+                    }
+                    path = new Path();
+                    path.addRoundRect(bounds, radii, Path.Direction.CCW);
+                    break;
+                case GradientDrawable.LINE:
+                case GradientDrawable.RING:
+                    break;
+            }
+
+        } else {
+            if (mView.getBackground() != null) {
+                path = new Path();
+                path.addRect(new RectF(mView.getBackground().getBounds()), Path.Direction.CCW);
+            }
+        }
+
+        if (path != null) {
+            RectF bounds = new RectF();
+            path.computeBounds(bounds, true);
+
+            bounds = new RectF();
+            path.computeBounds(bounds, true);
+            mRegion = new Region();
+            mRegion.setPath(path, new Region((int) bounds.left, (int) bounds.top, (int) bounds.right, (int) bounds.bottom));
+        }
+
+        return true;
+    }
+
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UIButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UIButton.java
@@ -80,6 +80,7 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             TypedArray arr = context.obtainStyledAttributes(attrs, new int [] {android.R.attr.tooltipText});
             mTooltipText = arr.getString(0);
+            arr.recycle();
         }
         mTooltipLayout = attributes.getResourceId(R.styleable.UIButton_tooltipLayout, R.layout.tooltip);
         attributes.recycle();
@@ -88,6 +89,7 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
 
         mClippedEventDelegate = new ShapeClippedEventDelegate(this);
         super.setOnHoverListener(mClippedEventDelegate);
+        super.setOnTouchListener(mClippedEventDelegate);
         super.setOnTouchListener(mClippedEventDelegate);
     }
 
@@ -114,13 +116,18 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
     }
 
     @Override
-    public void setOnHoverListener(OnHoverListener l) {
+    public void setOnHoverListener(@Nullable OnHoverListener l) {
         mClippedEventDelegate.setOnHoverListener(l);
     }
 
     @Override
     public void setOnClickListener(@Nullable OnClickListener l) {
         mClippedEventDelegate.setOnClickListener(l);
+    }
+
+    @Override
+    public void setOnTouchListener(@Nullable OnTouchListener l) {
+        mClippedEventDelegate.setOnTouchListener(l);
     }
 
     public void setCurvedTooltip(boolean aEnabled) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UITextButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UITextButton.java
@@ -5,16 +5,18 @@
 
 package org.mozilla.vrbrowser.ui.views;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 
-import org.mozilla.vrbrowser.R;
-
 import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatButton;
+
+import org.mozilla.vrbrowser.R;
 
 public class UITextButton extends AppCompatButton implements CustomUIButton {
 
@@ -32,6 +34,7 @@ public class UITextButton extends AppCompatButton implements CustomUIButton {
     private @IdRes int mPrivateModeTintColorListRes;
     private @IdRes int mActiveModeTintColorListRes;
     private State mState;
+    private ShapeClippedEventDelegate mClippedEventDelegate;
 
     public UITextButton(Context context) {
         this(context, null);
@@ -41,6 +44,7 @@ public class UITextButton extends AppCompatButton implements CustomUIButton {
         this(context, attrs, R.attr.imageButtonStyle);
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     public UITextButton(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
 
@@ -70,6 +74,26 @@ public class UITextButton extends AppCompatButton implements CustomUIButton {
         mBackground = getBackground();
 
         mState = State.NORMAL;
+
+        mClippedEventDelegate = new ShapeClippedEventDelegate(this);
+        super.setOnHoverListener(mClippedEventDelegate);
+        super.setOnTouchListener(mClippedEventDelegate);
+        super.setOnTouchListener(mClippedEventDelegate);
+    }
+
+    @Override
+    public void setOnHoverListener(@Nullable OnHoverListener l) {
+        mClippedEventDelegate.setOnHoverListener(l);
+    }
+
+    @Override
+    public void setOnClickListener(@Nullable OnClickListener l) {
+        mClippedEventDelegate.setOnClickListener(l);
+    }
+
+    @Override
+    public void setOnTouchListener(@Nullable OnTouchListener l) {
+        mClippedEventDelegate.setOnTouchListener(l);
     }
 
     public void setTintColorList(int aColorListId) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/VectorClippedEventDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/VectorClippedEventDelegate.java
@@ -3,54 +3,35 @@ package org.mozilla.vrbrowser.ui.views;
 import android.graphics.Path;
 import android.graphics.RectF;
 import android.graphics.Region;
-import android.view.MotionEvent;
 import android.view.View;
-import android.view.View.OnClickListener;
-import android.view.ViewTreeObserver;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 
-import org.mozilla.vrbrowser.utils.ViewUtils;
-
 import java.util.Deque;
 
-public class VectorClippedEventDelegate implements View.OnHoverListener, View.OnTouchListener {
+class VectorClippedEventDelegate extends ClippedEventDelegate {
 
-    private View mView;
     private @DrawableRes int mRes;
-    private Region mRegion;
-    private boolean mHovered;
-    private boolean mTouched;
-    private OnClickListener mClickListener;
 
-    VectorClippedEventDelegate(@DrawableRes int res, @NonNull View view) {
-        mView = view;
+    VectorClippedEventDelegate(@NonNull View view, @DrawableRes int res) {
+        super(view);
+
         mRes = res;
-        mHovered = false;
-        mTouched = false;
-
-        view.getViewTreeObserver().addOnGlobalLayoutListener(mLayoutListener);
     }
 
-    private ViewTreeObserver.OnGlobalLayoutListener mLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
-        @Override
-        public void onGlobalLayout() {
-            Path path = createPathFromResource(mRes);
-            RectF bounds = new RectF();
-            path.computeBounds(bounds, true);
+    @Override
+    boolean onUpdateRegion() {
+        Path path = createPathFromResource(mRes);
+        RectF bounds = new RectF();
+        path.computeBounds(bounds, true);
 
-            bounds = new RectF();
-            path.computeBounds(bounds, true);
-            mRegion = new Region();
-            mRegion.setPath(path, new Region((int) bounds.left, (int) bounds.top, (int) bounds.right, (int) bounds.bottom));
+        bounds = new RectF();
+        path.computeBounds(bounds, true);
+        mRegion = new Region();
+        mRegion.setPath(path, new Region((int) bounds.left, (int) bounds.top, (int) bounds.right, (int) bounds.bottom));
 
-            mView.getViewTreeObserver().removeOnGlobalLayoutListener(mLayoutListener);
-        }
-    };
-
-    public void setOnClickListener(OnClickListener listener) {
-        mClickListener = listener;
+        return true;
     }
 
     private Path createPathFromResource(@DrawableRes int res) {
@@ -62,83 +43,6 @@ public class VectorClippedEventDelegate implements View.OnHoverListener, View.On
         // TODO Handle state changes and update the Region based on the new current state shape
 
         return layer.transformedPath;
-    }
-
-    @Override
-    public boolean onHover(View v, MotionEvent event) {
-        if(!isInside(event)) {
-            if (mHovered) {
-                mHovered = false;
-                event.setAction(MotionEvent.ACTION_HOVER_EXIT);
-                return v.onHoverEvent(event);
-            }
-
-            return false;
-
-        } else {
-            if (!mHovered) {
-                mHovered = true;
-                event.setAction(MotionEvent.ACTION_HOVER_ENTER);
-            }
-
-            return v.onHoverEvent(event);
-        }
-    }
-
-    @Override
-    public boolean onTouch(View v, MotionEvent event) {
-        v.getParent().requestDisallowInterceptTouchEvent(true);
-
-        if(!isInside(event)) {
-            switch (event.getAction()) {
-                case MotionEvent.ACTION_UP:
-                    if (mTouched) {
-                        v.requestFocus();
-                        v.requestFocusFromTouch();
-                        if (mClickListener != null) {
-                            mClickListener.onClick(v);
-                        }
-                    }
-                    v.setPressed(false);
-                    mTouched = false;
-            }
-
-            return true;
-
-        } else {
-            switch (event.getAction()) {
-                case MotionEvent.ACTION_DOWN:
-                    v.setPressed(true);
-                    mTouched = true;
-                    return true;
-
-                case MotionEvent.ACTION_UP:
-                    if (mTouched && ViewUtils.isInsideView(v, (int)event.getRawX(), (int)event.getRawY())) {
-                        v.requestFocus();
-                        v.requestFocusFromTouch();
-                        if (mClickListener != null) {
-                            mClickListener.onClick(v);
-                        }
-                    }
-                    v.setPressed(false);
-                    mTouched = false;
-                    return true;
-
-                case MotionEvent.ACTION_MOVE:
-                    return true;
-
-                case MotionEvent.ACTION_CANCEL:
-                    v.setPressed(false);
-                    mTouched = false;
-                    return true;
-            }
-
-            return false;
-        }
-    }
-
-    public boolean isInside(MotionEvent event) {
-        return mRegion.contains((int)event.getX(),(int) event.getY());
     }
 
 }

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -65,26 +65,46 @@
                     app:visibleGone="@{viewmodel.isFocused &amp;&amp; !viewmodel.isUrlEmpty}" />
             </LinearLayout>
 
-            <RelativeLayout
+            <LinearLayout
                 android:id="@+id/iconsLayout"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_alignParentStart="true"
+                android:layout_centerVertical="true"
+                android:paddingStart="@{!isPopUpAvailable &amp;&amp; (isLoading || isInsecure) ? @dimen/url_bar_icons_padding_start : 0}"
+                android:layout_marginTop="2dp"
+                android:layout_marginBottom="2dp"
+                android:layout_marginStart="2dp"
                 android:addStatesFromChildren="true"
                 android:background="@null"
                 app:visibleGone="@{!viewmodel.isLibraryVisible}">
 
-                <LinearLayout
-                    android:id="@+id/startButtonsLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_alignParentStart="true"
-                    android:layout_centerVertical="true"
-                    android:layout_marginTop="2dp"
-                    android:layout_marginBottom="2dp"
-                    android:layout_marginStart="2dp"
-                    android:addStatesFromChildren="true"
-                    android:orientation="horizontal">
+                <org.mozilla.vrbrowser.ui.views.UIButton
+                    android:id="@+id/popup"
+                    style="@style/urlBarIconThemeStart"
+                    android:layout_gravity="center_vertical"
+                    android:paddingStart="5dp"
+                    android:src="@drawable/ic_icon_popup_awesomebar"
+                    android:tint="@color/fog"
+                    android:tooltipText="@string/popup_tooltip"
+                    app:visibleGone="@{isPopUpAvailable}" />
+                <ImageView
+                    android:id="@+id/loadingView"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical"
+                    android:contentDescription="Loading animation"
+                    android:src="@drawable/loading_shape"
+                    app:visibleGone="@{isLoading}" />
+                <ImageView
+                    android:id="@+id/insecureIcon"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical"
+                    android:contentDescription="SSL icon"
+                    android:src="@drawable/ic_icon_security_state_insecure"
+                    app:visibleGone="@{isInsecure &amp;&amp; (urlEditText.length() != 0)}" />
+            </LinearLayout>
 
                     <org.mozilla.vrbrowser.ui.views.UIButton
                         android:id="@+id/popup"
@@ -138,6 +158,7 @@
                 android:id="@+id/urlEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:paddingStart="@{isLibraryVisible ? @dimen/url_bar_url_padding_start : (isLoading || isInsecure || isPopUpAvailable ? @dimen/url_bar_url_icons_padding_start : @dimen/url_bar_url_padding_start)}"
                 android:paddingEnd="10dp"
                 android:layout_toStartOf="@id/endButtonsLayout"
                 android:layout_toEndOf="@id/padding"
@@ -161,5 +182,4 @@
                 app:autocompleteBackgroundColor="@color/azure" />
         </RelativeLayout>
     </FrameLayout>
-
 </layout>

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -65,46 +65,26 @@
                     app:visibleGone="@{viewmodel.isFocused &amp;&amp; !viewmodel.isUrlEmpty}" />
             </LinearLayout>
 
-            <LinearLayout
+            <RelativeLayout
                 android:id="@+id/iconsLayout"
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                android:paddingStart="@{!isPopUpAvailable &amp;&amp; (isLoading || isInsecure) ? @dimen/url_bar_icons_padding_start : 0}"
-                android:layout_marginTop="2dp"
-                android:layout_marginBottom="2dp"
-                android:layout_marginStart="2dp"
                 android:addStatesFromChildren="true"
                 android:background="@null"
                 app:visibleGone="@{!viewmodel.isLibraryVisible}">
 
-                <org.mozilla.vrbrowser.ui.views.UIButton
-                    android:id="@+id/popup"
-                    style="@style/urlBarIconThemeStart"
-                    android:layout_gravity="center_vertical"
-                    android:paddingStart="5dp"
-                    android:src="@drawable/ic_icon_popup_awesomebar"
-                    android:tint="@color/fog"
-                    android:tooltipText="@string/popup_tooltip"
-                    app:visibleGone="@{isPopUpAvailable}" />
-                <ImageView
-                    android:id="@+id/loadingView"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_gravity="center_vertical"
-                    android:contentDescription="Loading animation"
-                    android:src="@drawable/loading_shape"
-                    app:visibleGone="@{isLoading}" />
-                <ImageView
-                    android:id="@+id/insecureIcon"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_gravity="center_vertical"
-                    android:contentDescription="SSL icon"
-                    android:src="@drawable/ic_icon_security_state_insecure"
-                    app:visibleGone="@{isInsecure &amp;&amp; (urlEditText.length() != 0)}" />
-            </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/startButtonsLayout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:layout_alignParentStart="true"
+                    android:layout_centerVertical="true"
+                    android:layout_marginTop="2dp"
+                    android:layout_marginBottom="2dp"
+                    android:layout_marginStart="2dp"
+                    android:addStatesFromChildren="true"
+                    android:orientation="horizontal">
 
                     <org.mozilla.vrbrowser.ui.views.UIButton
                         android:id="@+id/popup"
@@ -158,7 +138,6 @@
                 android:id="@+id/urlEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:paddingStart="@{isLibraryVisible ? @dimen/url_bar_url_padding_start : (isLoading || isInsecure || isPopUpAvailable ? @dimen/url_bar_url_icons_padding_start : @dimen/url_bar_url_padding_start)}"
                 android:paddingEnd="10dp"
                 android:layout_toStartOf="@id/endButtonsLayout"
                 android:layout_toEndOf="@id/padding"
@@ -182,4 +161,5 @@
                 app:autocompleteBackgroundColor="@color/azure" />
         </RelativeLayout>
     </FrameLayout>
+
 </layout>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -171,6 +171,9 @@
     <item name="url_bar_popup_world_x" format="float" type="dimen">1.25</item>
     <item name="url_bar_popup_world_y" format="float" type="dimen">0.15</item>
     <item name="url_bar_popup_world_z" format="float" type="dimen">0.1</item>
+    <dimen name="url_bar_icons_padding_start">5dp</dimen>
+    <dimen name="url_bar_url_padding_start">15dp</dimen>
+    <dimen name="url_bar_url_icons_padding_start">5dp</dimen>
 
     <dimen name="tray_icon_padding_max">10dp</dimen>
     <dimen name="tray_icon_padding_min">8dp</dimen>


### PR DESCRIPTION
Adds a delegate to handle sticky shape clipped events for UI buttons. 

This is a continuation of the work done for the honeycomb buttons input clipping based on the background shape.

You can appreciate the clipping in the URL bar buttons and the back buttons in the panels as they extend from UIBUtton. We can easily extend this to the rest of the UI buttons using the same delegate so all the input is background shape clipped.

Related to: https://github.com/MozillaReality/FirefoxReality/pull/2601