### PR TITLE
Fixes #2565 Fixes clicks outside key bounds

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/CustomKeyboardView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/CustomKeyboardView.java
@@ -880,6 +880,18 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         mDirtyRect.setEmpty();
     }
 
+    /**
+     * We use our own Key.isInside implementation {@link Keyboard#isInside} as that one assumes that the
+     * motion event is inside the key if it is an edge key.
+     */
+    public boolean isInside(Key key, int x, int y) {
+        if ((x >= key.x) && (x < key.x + key.width) && (y >= key.y) && (y < key.y + key.height)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     private int getKeyIndices(int x, int y, int[] allKeys) {
         final Key[] keys = mKeys;
         int primaryIndex = NOT_A_KEY;
@@ -891,7 +903,7 @@ public class CustomKeyboardView extends View implements View.OnClickListener {
         for (int i = 0; i < keyCount; i++) {
             final Key key = keys[nearestKeyIndices[i]];
             int dist = 0;
-            boolean isInside = key.isInside(x,y);
+            boolean isInside = isInside(key, x,y);
             if (isInside) {
                 primaryIndex = nearestKeyIndices[i];
             }


### PR DESCRIPTION
Fixes #2565 The default Android implementation looks for the closes key when clicking outside of an edge key.