### PR TITLE
Fixes #1945 Restore library panels

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -942,6 +942,10 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             }
         }
 
+        if (UrlUtils.isAboutPage(aRequest.uri)) {
+            return GeckoResult.DENY;
+        }
+
         return result;
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -59,6 +59,7 @@ import org.mozilla.vrbrowser.ui.widgets.dialogs.PromptDialogWidget;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.SelectionActionWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.ContextMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.LibraryMenuWidget;
+import org.mozilla.vrbrowser.utils.UrlUtils;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.Arrays;
@@ -438,11 +439,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    public void showBookmarks() {
+    private void showBookmarks() {
         showBookmarks(true);
     }
 
-    public void showBookmarks(boolean switchSurface) {
+    private void showBookmarks(boolean switchSurface) {
         if (mView == null) {
             setView(mBookmarksView, switchSurface);
             mBookmarksView.onShow();
@@ -455,7 +456,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         hideBookmarks(true);
     }
 
-    public void hideBookmarks(boolean switchSurface) {
+    private void hideBookmarks(boolean switchSurface) {
         if (mView != null) {
             unsetView(mBookmarksView, switchSurface);
             mViewModel.setIsBookmarksVisible(false);
@@ -484,11 +485,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
-    public void showHistory() {
+    private void showHistory() {
         showHistory(true);
     }
 
-    public void showHistory(boolean switchSurface) {
+    private void showHistory(boolean switchSurface) {
         if (mView == null) {
             setView(mHistoryView, switchSurface);
             mHistoryView.onShow();
@@ -1554,14 +1555,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String aUri) {
         mCaptureOnPageStop = true;
 
-        if (isHistoryVisible()) {
-            hideHistory();
-        }
-
-        if (isBookmarksVisible()) {
-            hideBookmarks();
-        }
-
         mViewModel.setUrl(aUri);
         mViewModel.setIsLoading(true);
     }
@@ -1600,6 +1593,18 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         final GeckoResult<AllowOrDeny> result = new GeckoResult<>();
 
         Uri uri = Uri.parse(aRequest.uri);
+        if (UrlUtils.isAboutPage(uri.toString())) {
+            if(UrlUtils.isBookmarksUrl(uri.toString())) {
+                showBookmarks();
+
+            } else if (UrlUtils.isHistoryUrl(uri.toString())) {
+                showHistory();
+
+            } else {
+                hideLibraryPanels();
+            }
+        }
+
         if ("file".equalsIgnoreCase(uri.getScheme()) &&
                 !mWidgetManager.isPermissionGranted(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
             mWidgetManager.requestPermission(

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -27,6 +27,7 @@ import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
 import org.mozilla.vrbrowser.utils.BitmapCache;
 import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 import org.mozilla.vrbrowser.utils.SystemUtils;
+import org.mozilla.vrbrowser.utils.UrlUtils;
 
 import java.io.File;
 import java.io.FileReader;
@@ -65,6 +66,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         int textureHeight;
         float worldWidth;
         int tabIndex = -1;
+        PanelType panelType;
 
         public void load(WindowWidget aWindow, WindowsState aState, int aTabIndex) {
             WidgetPlacement widgetPlacement;
@@ -83,6 +85,13 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             textureHeight = widgetPlacement.height;
             worldWidth = widgetPlacement.worldWidth;
             tabIndex = aTabIndex;
+            if (aWindow.isBookmarksVisible()) {
+                panelType = PanelType.BOOKMARKS;
+            } else if (aWindow.isHistoryVisible()) {
+                panelType = PanelType.HISTORY;
+            } else {
+                panelType = PanelType.NONE;
+            }
         }
     }
 
@@ -112,6 +121,12 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     private Accounts mAccounts;
     private Services mServices;
     private PromptDialogWidget mNoInternetDialog;
+
+    private enum PanelType {
+        NONE,
+        BOOKMARKS,
+        HISTORY
+    }
 
     public enum WindowPlacement{
         FRONT(0),
@@ -280,6 +295,16 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         newWindow.getPlacement().worldWidth = aState.worldWidth;
         newWindow.setRestored(true);
         placeWindow(newWindow, aState.placement);
+        if (aState.panelType != null) {
+            switch (aState.panelType) {
+                case BOOKMARKS:
+                    newWindow.getSession().loadUri(UrlUtils.ABOUT_BOOKMARKS);
+                    break;
+                case HISTORY:
+                    newWindow.getSession().loadUri(UrlUtils.ABOUT_HISTORY);
+                    break;
+            }
+        }
         updateCurvedMode(true);
 
         mWidgetManager.addWidget(newWindow);
@@ -873,11 +898,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
                 switch (mAccounts.getLoginOrigin()) {
                     case BOOKMARKS:
-                        getFocusedWindow().showBookmarks();
+                        mFocusedWindow.getSession().loadUri(UrlUtils.ABOUT_BOOKMARKS);
                         break;
 
                     case HISTORY:
-                        getFocusedWindow().showHistory();
+                        mFocusedWindow.getSession().loadUri(UrlUtils.ABOUT_HISTORY);
                         break;
 
                     case SETTINGS:

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
@@ -115,4 +115,38 @@ public class UrlUtils {
             return aUri;
         }
     }
+
+    public static final String ABOUT_HISTORY = "about://history";
+
+    public static boolean isHistoryUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+
+        return url.equalsIgnoreCase(ABOUT_HISTORY);
+    }
+
+    public static final String ABOUT_BOOKMARKS = "about://bookmarks";
+
+    public static boolean isBookmarksUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+
+        return url.equalsIgnoreCase(ABOUT_BOOKMARKS);
+    }
+
+    public static final String ABOUT_PRIVATE = "about://privatebrowsing";
+
+    public static boolean isPrivateUrl(@Nullable String url) {
+        if (url == null) {
+            return false;
+        }
+
+        return url.equalsIgnoreCase(ABOUT_PRIVATE);
+    }
+
+    public static boolean isAboutPage(@Nullable String url) {
+        return isHistoryUrl(url) || isBookmarksUrl(url) || isPrivateUrl(url);
+    }
 }


### PR DESCRIPTION
Fixes #1945 Restore library panels. I really don't like to have a flag to know if the user has initiated the interaction so if there is a better alternative I'd be happy to change this. Without the flag the panels would be closed during the restore when about:blank and home are loaded as we always close them when there is a navigation event.