### PR TITLE
Preemptive null checks to avoid crashes in the TitleBar widget

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -1,6 +1,5 @@
 package org.mozilla.vrbrowser.browser.engine;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -10,20 +9,15 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.mozilla.gecko.util.ThreadUtils;
-import org.mozilla.geckoview.ContentBlocking;
 import org.mozilla.geckoview.GeckoRuntime;
-import org.mozilla.geckoview.GeckoRuntimeSettings;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.BookmarksStore;
 import org.mozilla.vrbrowser.browser.HistoryStore;
 import org.mozilla.vrbrowser.browser.PermissionDelegate;
 import org.mozilla.vrbrowser.browser.Services;
-import org.mozilla.vrbrowser.browser.SettingsStore;
-import org.mozilla.vrbrowser.crashreporting.CrashReporterService;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
-import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -73,6 +67,7 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
         mHistoryStore = new HistoryStore(context);
     }
 
+    @NonNull
     private Session addSession(@NonNull Session aSession) {
         aSession.setPermissionDelegate(this);
         aSession.addNavigationListener(mServices);
@@ -81,19 +76,23 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
         return aSession;
     }
 
+    @NonNull
     public Session createSession(boolean aPrivateMode) {
         SessionSettings settings = new SessionSettings(new SessionSettings.Builder().withDefaultSettings(mContext).withPrivateBrowsing(aPrivateMode));
         return createSession(settings, Session.SESSION_OPEN);
     }
 
+    @NonNull
     /* package */ Session createSession(@NonNull SessionSettings aSettings, @Session.SessionOpenModeFlags int aOpenMode) {
         return addSession(new Session(mContext, mRuntime, aSettings, aOpenMode));
     }
 
+    @NonNull
     public Session createSuspendedSession(SessionState aRestoreState) {
         return addSession(new Session(mContext, mRuntime, aRestoreState));
     }
 
+    @NonNull
     public Session createSuspendedSession(final String aUri, final boolean aPrivateMode) {
         SessionState state = new SessionState();
         state.mUri = aUri;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -167,7 +167,8 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
     }
 
     public void setIsInsecure(boolean aIsInsecure) {
-        if (mAttachedWindow.getSession().getCurrentUri() != null &&
+        if (mAttachedWindow != null && mAttachedWindow.getSession() != null &&
+                mAttachedWindow.getSession().getCurrentUri() != null &&
                 !(mAttachedWindow.getSession().getCurrentUri().startsWith("data") &&
                 mAttachedWindow.getSession().isPrivateMode())) {
             mBinding.insecureIcon.setVisibility(aIsInsecure ? View.VISIBLE : View.GONE);
@@ -182,7 +183,7 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
         if (mMedia != null) {
             mMedia.removeMediaListener(mMediaDelegate);
         }
-        if (available) {
+        if (available && mAttachedWindow != null && mAttachedWindow.getSession() != null) {
             mMedia = mAttachedWindow.getSession().getFullScreenVideo();
             if (mMedia != null) {
                 mMedia.addMediaListener(mMediaDelegate);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -681,6 +681,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
+    @Nullable
     public Session getSession() {
         return mSession;
     }


### PR DESCRIPTION
Preemptive null checks for:

https://crash-stats.mozilla.com/signature/?product=FirefoxReality&version=74.0a1&signature=java.lang.NullPointerException%3A%20at%20org.mozilla.vrbrowser.ui.widgets.TitleBarWidget.setIsInsecure%28TitleBarWidget.java%29&date=%3E%3D2020-01-07T15%3A43%3A00.000Z&date=%3C2020-01-14T15%3A43%3A00.000Z&_columns=date&_columns=product&_columns=version&_columns=build_id&_columns=platform&_columns=reason&_columns=address&_columns=install_time&_columns=startup_crash&_sort=-date&page=1