### PR TITLE
Fixes #2408 Fixes #2653 Avoid double removing items when deleting

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -164,13 +164,6 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
         public void onDelete(@NonNull View view, @NonNull Bookmark item) {
             mBinding.bookmarksList.requestFocusFromTouch();
 
-            mBookmarkAdapter.removeItem(item);
-            if (mBookmarkAdapter.itemCount() == 0) {
-                mBinding.setIsEmpty(true);
-                mBinding.setIsLoading(false);
-                mBinding.executePendingBindings();
-            }
-
             SessionStore.get().getBookmarkStore().deleteBookmarkById(item.getGuid());
         }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -167,13 +167,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         public void onDelete(View view, VisitInfo item) {
             mBinding.historyList.requestFocusFromTouch();
 
-            mHistoryAdapter.removeItem(item);
-            if (mHistoryAdapter.itemCount() == 0) {
-                mBinding.setIsEmpty(true);
-                mBinding.setIsLoading(false);
-                mBinding.executePendingBindings();
-            }
-
             SessionStore.get().getHistoryStore().deleteVisitsFor(item.getUrl());
         }
 
@@ -381,7 +374,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
             mBinding.setIsEmpty(false);
             mBinding.setIsLoading(false);
             mHistoryAdapter.setHistoryList(historyItems);
-            mBinding.historyList.post(() -> mBinding.historyList.smoothScrollToPosition(0));
         }
     }
 


### PR DESCRIPTION
Fixes #2408 Fixes #2653 We were removing items from the adapter and also after the history update. Same for Bookmarks.