### PR TITLE
Fixes #2684 Revert "Enable e10s by default (#2615)"

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -49,7 +49,7 @@ public class SettingsStore {
     public final static boolean REMOTE_DEBUGGING_DEFAULT = false;
     public final static boolean CONSOLE_LOGS_DEFAULT = false;
     public final static boolean ENV_OVERRIDE_DEFAULT = false;
-    public final static boolean MULTIPROCESS_DEFAULT = true;
+    public final static boolean MULTIPROCESS_DEFAULT = false;
     public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT = true;
     public final static boolean PERFORMANCE_MONITOR_DEFAULT = true;
     public final static boolean DRM_PLAYBACK_DEFAULT = false;

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -11,7 +11,7 @@
     <string name="settings_key_remote_debugging" translatable="false">settings_remote_debugging</string>
     <string name="settings_key_console_logs" translatable="false">settings_console_logs</string>
     <string name="settings_key_environment_override" translatable="false">settings_environment_override</string>
-    <string name="settings_key_multiprocess_e10s" translatable="false">settings_environment_multiprocess_e10s_v3</string>
+    <string name="settings_key_multiprocess_e10s" translatable="false">settings_environment_multiprocess_e10s_v2</string>
     <string name="settings_key_performance_monitor" translatable="false">settings_performance_monitor</string>
     <string name="settings_key_servo" translatable="false">settings_environment_servo</string>
     <string name="settings_key_drm_playback" translatable="false">settings_key_drm_playback</string>


### PR DESCRIPTION
This reverts commit 91e3eaac3a5f4c4bf6f5402ed7f31b2ee191ea4c.