### PR TITLE
Fixes #2693 Fix system language change crash and support for language hot reload

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -81,6 +81,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
@@ -473,6 +474,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
+        getBaseContext().getResources().updateConfiguration(newConfig, getBaseContext().getResources().getDisplayMetrics());
+
+        LocaleUtils.refresh();
+        mWidgets.forEach((i, widget) -> widget.updateUI());
+
         SessionStore.get().onConfigurationChanged(newConfig);
 
         super.onConfigurationChanged(newConfig);
@@ -502,7 +508,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 SettingsStore.getInstance(this).setHomepage(homepageUri.toString());
             }
 
-            // Enable/Disbale e10s
+            // Enable/Disable e10s
             if (extras.containsKey("e10s")) {
                 boolean wasEnabled = SettingsStore.getInstance(this).isMultiprocessEnabled();
                 boolean enabled = extras.getBoolean("e10s", wasEnabled);
@@ -1445,7 +1451,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     @Override
     public void openNewWindow(String uri) {
         WindowWidget newWindow = mWindows.addWindow();
-        if (newWindow != null) {
+        if (newWindow.getSession() != null) {
             newWindow.getSession().loadUri(uri);
         }
     }
@@ -1475,6 +1481,13 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
         mWindows.saveState();
     }
 
+    @Override
+    public void updateLocale(@NonNull Context context) {
+        Configuration configuration = context.getResources().getConfiguration();
+        configuration.setLocale(Locale.forLanguageTag(LocaleUtils.getDisplayLanguage(this).getId()));
+        onConfigurationChanged(new Configuration(context.getResources().getConfiguration()));
+    }
+
     private native void addWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateWidgetNative(int aHandle, WidgetPlacement aPlacement);
     private native void updateVisibleWidgetsNative();
@@ -1483,7 +1496,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     private native void finishWidgetResizeNative(int aHandle);
     private native void startWidgetMoveNative(int aHandle, int aMoveBehaviour);
     private native void finishWidgetMoveNative();
-    private native void setWorldBrightnessNative(float aBrigthness);
+    private native void setWorldBrightnessNative(float aBrightness);
     private native void setTemporaryFilePath(String aPath);
     private native void exitImmersiveNative();
     private native void workaroundGeckoSigAction();

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
@@ -50,6 +50,7 @@ public class VRBrowserApplication extends Application {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
+        LocaleUtils.setDisplayLocale(this, newConfig.getLocales().get(0).toLanguageTag());
         LocaleUtils.setLocale(this);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
@@ -144,6 +144,10 @@ public class Media implements MediaElement.Delegate {
             mPlaying = false;
         } else if (playbackState == MediaElement.MEDIA_STATE_ENDED) {
             mEnded = true;
+        } else if (playbackState == MediaElement.MEDIA_STATE_EMPTIED) {
+            mEnded = true;
+            mPlaying = false;
+            mIsUnloaded = true;
         }
         mMediaListeners.forEach(listener -> listener.onPlaybackStateChange(mediaElement, playbackState));
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PromptDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PromptDelegate.java
@@ -382,6 +382,8 @@ public class PromptDelegate implements
                 }
 
                 mPopUpPrompt.hide(UIWidget.REMOVE_WIDGET);
+                mPopUpPrompt.releaseWidget();
+                mPopUpPrompt = null;
             });
             mPopUpPrompt.setDelegate(() -> mExecutors.mainThread().execute(() -> {
                 if (mPopupDelegate != null) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -43,6 +43,7 @@ import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 import org.mozilla.vrbrowser.utils.BitmapCache;
 import org.mozilla.vrbrowser.utils.InternalPages;
 import org.mozilla.vrbrowser.utils.SystemUtils;
+import org.mozilla.vrbrowser.utils.UrlUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -170,7 +171,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
     }
 
-    protected void dumpAllState() {
+    private void dumpAllState() {
         for (GeckoSession.NavigationDelegate listener: mNavigationListeners) {
             dumpState(listener);
         }
@@ -569,9 +570,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     public Boolean isHomeUri(String aUri) {
-        return aUri != null && aUri.toLowerCase().startsWith(
-          SettingsStore.getInstance(mContext).getHomepage()
-        );
+        return UrlUtils.isHomeUri(mContext, aUri);
     }
 
     public String getCurrentUri() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -170,7 +170,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
     }
 
-    private void dumpAllState() {
+    protected void dumpAllState() {
         for (GeckoSession.NavigationDelegate listener: mNavigationListeners) {
             dumpState(listener);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -241,6 +241,8 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
         if (mRuntime != null) {
             mRuntime.configurationChanged(newConfig);
         }
+
+        mSessions.forEach(Session::dumpAllState);
     }
 
     // Session Settings

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -241,8 +241,6 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
         if (mRuntime != null) {
             mRuntime.configurationChanged(newConfig);
         }
-
-        mSessions.forEach(Session::dumpAllState);
     }
 
     // Session Settings

--- a/app/src/common/shared/org/mozilla/vrbrowser/search/SearchEngineWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/search/SearchEngineWrapper.java
@@ -95,7 +95,10 @@ public class SearchEngineWrapper implements SharedPreferences.OnSharedPreference
 
     public void unregisterForUpdates() {
         if (mContext != null) {
-            mContext.unregisterReceiver(mLocaleChangedReceiver);
+            try {
+                mContext.unregisterReceiver(mLocaleChangedReceiver);
+
+            } catch(IllegalArgumentException ignored) {}
             if (mPrefs != null) {
                 mPrefs.unregisterOnSharedPreferenceChangeListener(this);
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BindingAdapters.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/BindingAdapters.java
@@ -10,15 +10,14 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.annotation.DimenRes;
 import androidx.annotation.Dimension;
-import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
 
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.views.HoneycombButton;
 import org.mozilla.vrbrowser.ui.views.UIButton;
+import org.mozilla.vrbrowser.ui.views.UITextButton;
 import org.mozilla.vrbrowser.ui.views.settings.ButtonSetting;
 import org.mozilla.vrbrowser.ui.views.settings.SwitchSetting;
 
@@ -154,4 +153,15 @@ public class BindingAdapters {
         params.height = (int)dimen;
         view.setLayoutParams(params);
     }
-}
+
+    @BindingAdapter("privateMode")
+    public static void setPrivateMode(@NonNull UIButton button, boolean isPrivateMode) {
+        button.setPrivateMode(isPrivateMode);
+    }
+
+    @BindingAdapter("privateMode")
+    public static void setPrivateMode(@NonNull UITextButton button, boolean isPrivateMode) {
+        button.setPrivateMode(isPrivateMode);
+    }
+
+ }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
@@ -1,0 +1,661 @@
+package org.mozilla.vrbrowser.ui.viewmodel;
+
+import android.app.Application;
+import android.content.res.Resources;
+import android.text.Spannable;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
+import android.util.TypedValue;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.ObservableBoolean;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.MediatorLiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+
+import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.VRBrowserApplication;
+import org.mozilla.vrbrowser.browser.SettingsStore;
+import org.mozilla.vrbrowser.browser.engine.SessionStore;
+import org.mozilla.vrbrowser.ui.widgets.Windows;
+import org.mozilla.vrbrowser.utils.ServoUtils;
+import org.mozilla.vrbrowser.utils.StringUtils;
+import org.mozilla.vrbrowser.utils.UrlUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.concurrent.Executor;
+
+public class WindowViewModel extends AndroidViewModel {
+
+    private Executor mUIThreadExecutor;
+
+    private int mURLProtocolColor;
+    private int mURLWebsiteColor;
+
+    private MutableLiveData<Spannable> url;
+    private MutableLiveData<String> hint;
+    private MutableLiveData<ObservableBoolean> isWindowVisible;
+    private MutableLiveData<Windows.WindowPlacement> placement;
+    private MutableLiveData<ObservableBoolean> isOnlyWindow;
+    private MutableLiveData<ObservableBoolean> isFullscreen;
+    private MediatorLiveData<ObservableBoolean> isTopBarVisible;
+    private MutableLiveData<ObservableBoolean> isResizeMode;
+    private MutableLiveData<ObservableBoolean> isPrivateSession;
+    private MediatorLiveData<ObservableBoolean> showClearButton;
+    private MutableLiveData<ObservableBoolean> isInsecure;
+    private MutableLiveData<ObservableBoolean> isActiveWindow;
+    private MediatorLiveData<ObservableBoolean> isTitleBarVisible;
+    private MutableLiveData<ObservableBoolean> isBookmarksVisible;
+    private MutableLiveData<ObservableBoolean> isHistoryVisible;
+    private MediatorLiveData<ObservableBoolean> isLibraryVisible;
+    private MutableLiveData<ObservableBoolean> isLoading;
+    private MutableLiveData<ObservableBoolean> isMicrophoneEnabled;
+    private MutableLiveData<ObservableBoolean> isBookmarked;
+    private MutableLiveData<ObservableBoolean> isFocused;
+    private MutableLiveData<ObservableBoolean> isSpecialUrl;
+    private MutableLiveData<ObservableBoolean> isUrlEmpty;
+    private MutableLiveData<ObservableBoolean> isPopUpAvailable;
+    private MutableLiveData<ObservableBoolean> canGoForward;
+    private MutableLiveData<ObservableBoolean> canGoBack;
+    private MutableLiveData<ObservableBoolean> isInVRVideo;
+    private MutableLiveData<ObservableBoolean> autoEnteredVRVideo;
+    private MediatorLiveData<ObservableBoolean> isServoAvailable;
+    private MediatorLiveData<String> titleBarUrl;
+    private MediatorLiveData<ObservableBoolean> isInsecureVisible;
+    private MutableLiveData<ObservableBoolean> isMediaAvailable;
+    private MutableLiveData<ObservableBoolean> isMediaPlaying;
+    private MediatorLiveData<String> navigationBarUrl;
+
+
+    public WindowViewModel(Application application) {
+        super(application);
+
+        mUIThreadExecutor = ((VRBrowserApplication)application).getExecutors().mainThread();
+
+        TypedValue typedValue = new TypedValue();
+        Resources.Theme theme = application.getTheme();
+        theme.resolveAttribute(R.attr.urlProtocolColor, typedValue, true);
+        mURLProtocolColor = typedValue.data;
+        theme.resolveAttribute(R.attr.urlWebsiteColor, typedValue, true);
+        mURLWebsiteColor = typedValue.data;
+
+        url = new MutableLiveData<>(new SpannableString(""));
+        hint = new MutableLiveData<>("");
+        isWindowVisible = new MutableLiveData<>(new ObservableBoolean(true));
+        placement = new MutableLiveData<>(Windows.WindowPlacement.FRONT);
+        isOnlyWindow = new MutableLiveData<>(new ObservableBoolean(false));
+        isFullscreen = new MutableLiveData<>(new ObservableBoolean(false));
+        isResizeMode = new MutableLiveData<>(new ObservableBoolean(false));
+        isPrivateSession = new MutableLiveData<>(new ObservableBoolean(false));
+
+        isTopBarVisible = new MediatorLiveData<>();
+        isTopBarVisible.addSource(isOnlyWindow, mIsTopBarVisibleObserver);
+        isTopBarVisible.addSource(isFullscreen, mIsTopBarVisibleObserver);
+        isTopBarVisible.addSource(isResizeMode, mIsTopBarVisibleObserver);
+        isTopBarVisible.addSource(isPrivateSession, mIsTopBarVisibleObserver);
+        isTopBarVisible.addSource(isWindowVisible, mIsTopBarVisibleObserver);
+        isTopBarVisible.setValue(new ObservableBoolean(false));
+
+        showClearButton = new MediatorLiveData<>();
+        showClearButton.addSource(isOnlyWindow, mShowClearButtonObserver);
+        showClearButton.addSource(isPrivateSession, mShowClearButtonObserver);
+        showClearButton.addSource(isResizeMode, mShowClearButtonObserver);
+        showClearButton.addSource(isFullscreen, mShowClearButtonObserver);
+        showClearButton.addSource(isWindowVisible, mShowClearButtonObserver);
+        showClearButton.setValue(new ObservableBoolean(false));
+
+        isInsecure = new MutableLiveData<>(new ObservableBoolean(false));
+        isActiveWindow = new MutableLiveData<>(new ObservableBoolean(false));
+
+        isTitleBarVisible = new MediatorLiveData<>();
+        isTitleBarVisible.addSource(isFullscreen, mIsTitleBarVisibleObserver);
+        isTitleBarVisible.addSource(isResizeMode, mIsTitleBarVisibleObserver);
+        isTitleBarVisible.addSource(isActiveWindow, mIsTitleBarVisibleObserver);
+        isTitleBarVisible.addSource(isWindowVisible, mIsTitleBarVisibleObserver);
+        isTitleBarVisible.addSource(isOnlyWindow, mIsTitleBarVisibleObserver);
+        isTitleBarVisible.setValue(new ObservableBoolean(false));
+
+        isBookmarksVisible = new MutableLiveData<>(new ObservableBoolean(false));
+        isHistoryVisible = new MutableLiveData<>(new ObservableBoolean(false));
+
+        isLibraryVisible = new MediatorLiveData<>();
+        isLibraryVisible.addSource(isBookmarksVisible, mIsLibraryVisibleObserver);
+        isLibraryVisible.addSource(isHistoryVisible, mIsLibraryVisibleObserver);
+        isLibraryVisible.setValue(new ObservableBoolean(false));
+
+        isLoading = new MutableLiveData<>(new ObservableBoolean(false));
+        isMicrophoneEnabled = new MutableLiveData<>(new ObservableBoolean(true));
+        isBookmarked = new MutableLiveData<>(new ObservableBoolean(false));
+        isFocused = new MutableLiveData<>(new ObservableBoolean(false));
+        isSpecialUrl = new MutableLiveData<>(new ObservableBoolean(false));
+        isUrlEmpty = new MutableLiveData<>(new ObservableBoolean(false));
+        isPopUpAvailable = new MutableLiveData<>(new ObservableBoolean(false));
+        canGoForward = new MutableLiveData<>(new ObservableBoolean(false));
+        canGoBack = new MutableLiveData<>(new ObservableBoolean(false));
+        isInVRVideo = new MutableLiveData<>(new ObservableBoolean(false));
+        autoEnteredVRVideo = new MutableLiveData<>(new ObservableBoolean(false));
+
+        isServoAvailable = new MediatorLiveData<>();
+        isServoAvailable.addSource(url, mIsServoAvailableObserver);
+        isServoAvailable.setValue(new ObservableBoolean(false));
+
+        titleBarUrl = new MediatorLiveData<>();
+        titleBarUrl.addSource(url, mTitleBarUrlObserver);
+        titleBarUrl.setValue("");
+
+        isInsecureVisible = new MediatorLiveData<>();
+        isInsecureVisible.addSource(isInsecure, mIsInsecureVisibleObserver);
+        isInsecureVisible.addSource(isPrivateSession, mIsInsecureVisibleObserver);
+        isInsecureVisible.addSource(isLibraryVisible, mIsInsecureVisibleObserver);
+        isInsecureVisible.setValue(new ObservableBoolean(false));
+
+        isMediaAvailable = new MutableLiveData<>(new ObservableBoolean(false));
+        isMediaPlaying = new MutableLiveData<>(new ObservableBoolean(false));
+
+        navigationBarUrl = new MediatorLiveData<>();
+        navigationBarUrl.addSource(url, mNavigationBarUrlObserver);
+        navigationBarUrl.setValue("");
+    }
+
+    private Observer<ObservableBoolean> mIsTopBarVisibleObserver = new Observer<ObservableBoolean>() {
+        @Override
+        public void onChanged(ObservableBoolean o) {
+            if (isFullscreen.getValue().get() || isResizeMode.getValue().get()) {
+                isTopBarVisible.setValue(new ObservableBoolean(false));
+
+            } else if (isPrivateSession.getValue().get() && isOnlyWindow.getValue().get()) {
+                isTopBarVisible.setValue(new ObservableBoolean(true));
+
+            } else {
+                isTopBarVisible.setValue(new ObservableBoolean(isWindowVisible.getValue().get() && !isOnlyWindow.getValue().get()));
+            }
+        }
+    };
+
+    private Observer<ObservableBoolean> mShowClearButtonObserver = new Observer<ObservableBoolean>() {
+        @Override
+        public void onChanged(ObservableBoolean o) {
+            showClearButton.setValue(new ObservableBoolean(isWindowVisible.getValue().get() &&
+                    isPrivateSession.getValue().get() && isOnlyWindow.getValue().get() &&
+                    !isResizeMode.getValue().get() && !isFullscreen.getValue().get()));
+        }
+    };
+
+    private Observer<ObservableBoolean> mIsTitleBarVisibleObserver = new Observer<ObservableBoolean>() {
+        @Override
+        public void onChanged(ObservableBoolean o) {
+            if (isFullscreen.getValue().get() || isResizeMode.getValue().get() || isActiveWindow.getValue().get()) {
+                isTitleBarVisible.setValue(new ObservableBoolean(false));
+
+            } else {
+                isTitleBarVisible.setValue(new ObservableBoolean(isWindowVisible.getValue().get() && !isOnlyWindow.getValue().get()));
+            }
+        }
+    };
+
+    private Observer<ObservableBoolean> mIsLibraryVisibleObserver = new Observer<ObservableBoolean>() {
+        @Override
+        public void onChanged(ObservableBoolean o) {
+            isLibraryVisible.setValue(new ObservableBoolean(isBookmarksVisible.getValue().get() || isHistoryVisible.getValue().get()));
+
+            // We use this to force dispatch a title bar and navigation bar URL refresh when library is opened
+            url.setValue(url.getValue());
+        }
+    };
+
+    private Observer<Spannable> mIsServoAvailableObserver = new Observer<Spannable>() {
+        @Override
+        public void onChanged(Spannable url) {
+            boolean isPrefEnabled = SettingsStore.getInstance(getApplication()).isServoEnabled();
+            boolean isUrlWhiteListed = ServoUtils.isUrlInServoWhiteList(getApplication(), url.toString());
+            isServoAvailable.postValue(new ObservableBoolean(isPrefEnabled && isUrlWhiteListed));
+        }
+    };
+
+    private Observer<Spannable> mTitleBarUrlObserver = new Observer<Spannable>() {
+        @Override
+        public void onChanged(Spannable aUrl) {
+            String url = aUrl.toString();
+            if (isBookmarksVisible.getValue().get()) {
+                url = getApplication().getString(R.string.url_bookmarks_title);
+
+            } else if (isHistoryVisible.getValue().get()) {
+                url = getApplication().getString(R.string.url_history_title);
+
+            } else {
+                if (UrlUtils.isPrivateAboutPage(getApplication(), url) ||
+                        (UrlUtils.isDataUri(url) && isPrivateSession.getValue().get())) {
+                    url = getApplication().getString(R.string.private_browsing_title);
+
+                } else if (UrlUtils.isHomeUri(getApplication(), aUrl.toString())) {
+                    url = getApplication().getString(R.string.url_home_title, getApplication().getString(R.string.app_name));
+
+                } else if (UrlUtils.isBlankUri(getApplication(), aUrl.toString())) {
+                    url = "";
+                }
+            }
+
+            titleBarUrl.setValue(UrlUtils.titleBarUrl(url));
+        }
+    };
+
+    private Observer<ObservableBoolean> mIsInsecureVisibleObserver = new Observer<ObservableBoolean>() {
+        @Override
+        public void onChanged(ObservableBoolean o) {
+            String aUrl = url.getValue().toString();
+            if (isInsecure.getValue().get()) {
+                if (UrlUtils.isPrivateAboutPage(getApplication(), aUrl) ||
+                        (UrlUtils.isDataUri(aUrl) && isPrivateSession.getValue().get()) ||
+                        UrlUtils.isHomeUri(getApplication(), aUrl) ||
+                        isLibraryVisible.getValue().get() ||
+                        UrlUtils.isBlankUri(getApplication(), aUrl)) {
+                    isInsecureVisible.setValue(new ObservableBoolean(false));
+
+                } else {
+                    isInsecureVisible.setValue(new ObservableBoolean(true));
+                }
+
+            } else {
+                isInsecureVisible.setValue(new ObservableBoolean(false));
+            }
+        }
+    };
+
+    private Observer<Spannable> mNavigationBarUrlObserver = new Observer<Spannable>() {
+        @Override
+        public void onChanged(Spannable aUrl) {
+            String url = aUrl.toString();
+            if (UrlUtils.isPrivateAboutPage(getApplication(), url) ||
+                    (UrlUtils.isDataUri(url) && isPrivateSession.getValue().get()) ||
+                    UrlUtils.isHomeUri(getApplication(), aUrl.toString()) ||
+                    isLibraryVisible.getValue().get() ||
+                    UrlUtils.isBlankUri(getApplication(), aUrl.toString())) {
+                navigationBarUrl.setValue("");
+
+            } else {
+                navigationBarUrl.setValue(UrlUtils.titleBarUrl(url));
+            }
+
+            if (isBookmarksVisible.getValue().get()) {
+                hint.setValue(getApplication().getString(R.string.url_bookmarks_title));
+
+            } else if (isHistoryVisible.getValue().get()) {
+                hint.setValue(getApplication().getString(R.string.url_history_title));
+
+            } else {
+                hint.setValue(getApplication().getString(R.string.search_placeholder));
+            }
+        }
+    };
+
+    public void refresh() {
+        url.postValue(url.getValue());
+        isWindowVisible.postValue(isWindowVisible.getValue());
+        placement.postValue(placement.getValue());
+        isOnlyWindow.postValue(isOnlyWindow.getValue());
+        isFullscreen.postValue(isFullscreen.getValue());
+        isResizeMode.postValue(isResizeMode.getValue());
+        isPrivateSession.postValue(isPrivateSession.getValue());
+        isInsecure.postValue(isInsecure.getValue());
+        isLoading.postValue(isLoading.getValue());
+        isMicrophoneEnabled.postValue(isMicrophoneEnabled.getValue());
+        isBookmarked.postValue(isBookmarked.getValue());
+        isFocused.postValue(isFocused.getValue());
+        isSpecialUrl.postValue(isSpecialUrl.getValue());
+        isUrlEmpty.postValue(isUrlEmpty.getValue());
+        isPopUpAvailable.postValue(isPopUpAvailable.getValue());
+        canGoForward.postValue(canGoForward.getValue());
+        canGoBack.postValue(canGoBack.getValue());
+        isInVRVideo.postValue(isInVRVideo.getValue());
+        autoEnteredVRVideo.postValue(autoEnteredVRVideo.getValue());
+        isMediaAvailable.postValue(isMediaAvailable.getValue());
+        isMediaPlaying.postValue(isMediaPlaying.getValue());
+    }
+
+    @NonNull
+    public MutableLiveData<Spannable> getUrl() {
+        if (url == null) {
+            url = new MutableLiveData<>(new SpannableString(""));
+        }
+        return url;
+    }
+
+    public void setUrl(@Nullable String url) {
+        if (url != null) {
+            this.url.setValue(new SpannableString(url));
+        }
+    }
+
+    public void setUrl(@Nullable Spannable url) {
+        if (url == null) {
+            return;
+        }
+
+        String aURL = url.toString();
+
+        if (isLibraryVisible.getValue().get()) {
+            return;
+        }
+
+        if (StringUtils.isEmpty(aURL)) {
+            setIsBookmarked(false);
+
+        } else {
+            SessionStore.get().getBookmarkStore().isBookmarked(aURL).thenAcceptAsync(this::setIsBookmarked, mUIThreadExecutor).exceptionally(throwable -> {
+                throwable.printStackTrace();
+                return null;
+            });
+        }
+
+        int index = -1;
+        try {
+            aURL = URLDecoder.decode(aURL, "UTF-8");
+
+        } catch (UnsupportedEncodingException | IllegalArgumentException e) {
+            e.printStackTrace();
+            aURL = "";
+        }
+        if (aURL.startsWith("jar:")) {
+            return;
+
+        } else if (aURL.startsWith("resource:") || UrlUtils.isHomeUri(getApplication().getBaseContext(), aURL)) {
+            aURL = "";
+
+        } else if (aURL.startsWith("data:") && isPrivateSession.getValue().get()) {
+            aURL = "";
+
+        } else if (aURL.startsWith(getApplication().getBaseContext().getString(R.string.about_blank))) {
+            aURL = "";
+
+        } else {
+            index = aURL.indexOf("://");
+        }
+
+        // Update the URL bar only if the URL is different than the current one and
+        // the URL bar is not focused to avoid override user input
+        if (!getUrl().getValue().toString().equalsIgnoreCase(aURL) && !getIsFocused().getValue().get()) {
+            this.url.setValue(new SpannableString(aURL));
+            if (index > 0) {
+                SpannableString spannable = new SpannableString(aURL);
+                ForegroundColorSpan color1 = new ForegroundColorSpan(mURLProtocolColor);
+                ForegroundColorSpan color2 = new ForegroundColorSpan(mURLWebsiteColor);
+                spannable.setSpan(color1, 0, index + 3, 0);
+                spannable.setSpan(color2, index + 3, aURL.length(), 0);
+                this.url.setValue(url);
+
+            } else {
+                this.url.setValue(url);
+            }
+        }
+
+        setIsSpecialUrl(aURL.isEmpty());
+
+        this.url.setValue(url);
+    }
+
+    @NonNull
+    public MutableLiveData<String> getHint() {
+        if (hint == null) {
+            hint = new MutableLiveData<>("");
+        }
+        return hint;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsWindowVisible() {
+        return isWindowVisible;
+    }
+
+    public void setIsWindowVisible(boolean isWindowVisible) {
+        this.isWindowVisible.postValue(new ObservableBoolean(isWindowVisible));
+    }
+
+    @NonNull
+    public MutableLiveData<Windows.WindowPlacement> getPlacement() {
+        return placement;
+    }
+
+    public void setPlacement(Windows.WindowPlacement placement) {
+        this.placement.postValue(placement);
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsOnlyWindow() {
+        return isOnlyWindow;
+    }
+
+    public void setIsOnlyWindow(boolean isOnlyWindow) {
+        this.isOnlyWindow.postValue(new ObservableBoolean(isOnlyWindow));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsFullscreen() {
+        return isFullscreen;
+    }
+
+    public void setIsFullscreen(boolean isFullscreen) {
+        this.isFullscreen.postValue(new ObservableBoolean(isFullscreen));
+    }
+
+    @NonNull
+    public MediatorLiveData<ObservableBoolean> getIsTopBarVisible() {
+        return isTopBarVisible;
+    }
+
+    public void setIsTopBarVisible(boolean isTopBarVisible) {
+        this.isTopBarVisible.postValue(new ObservableBoolean(isTopBarVisible));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsResizeMode() {
+        return isResizeMode;
+    }
+
+    public void setIsResizeMode(boolean isResizeMode) {
+        this.isResizeMode.postValue(new ObservableBoolean(isResizeMode));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsPrivateSession() {
+        return isPrivateSession;
+    }
+
+    public void setIsPrivateSession(boolean isPrivateSession) {
+        this.isPrivateSession.postValue(new ObservableBoolean(isPrivateSession));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getShowClearButton() {
+        return showClearButton;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsInsecure() {
+        return isInsecure;
+    }
+
+    public void setIsInsecure(boolean isInsecure) {
+        this.isInsecure.postValue(new ObservableBoolean(isInsecure));
+    }
+
+    @NonNull
+    public MediatorLiveData<ObservableBoolean> getIsTitleBarVisible() {
+        return isTitleBarVisible;
+    }
+
+    public void setIsTitleBarVisible(boolean isTitleBarVisible) {
+        this.isTitleBarVisible.postValue(new ObservableBoolean(isTitleBarVisible));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsActiveWindow() {
+        return isActiveWindow;
+    }
+
+    public void setIsActiveWindow(boolean isActiveWindow) {
+        this.isActiveWindow.postValue(new ObservableBoolean(isActiveWindow));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsBookmraksVisible() {
+        return isBookmarksVisible;
+    }
+
+    public void setIsBookmarksVisible(boolean isBookmarksVisible) {
+        this.isBookmarksVisible.postValue(new ObservableBoolean(isBookmarksVisible));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsHistoryVisible() {
+        return isHistoryVisible;
+    }
+
+    public void setIsHistoryVisible(boolean isHistoryVisible) {
+        this.isHistoryVisible.postValue(new ObservableBoolean(isHistoryVisible));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsLibraryVisible() {
+        return isLibraryVisible;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsLoading() {
+        return isLoading;
+    }
+
+    public void setIsLoading(boolean isLoading) {
+        this.isLoading.postValue(new ObservableBoolean(isLoading));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsMicrophoneEnabled() {
+        return isMicrophoneEnabled;
+    }
+
+    public void setIsMicrophoneEnabled(boolean isMicrophoneEnabled) {
+        this.isMicrophoneEnabled.postValue(new ObservableBoolean(isMicrophoneEnabled));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsBookmarked() {
+        return isBookmarked;
+    }
+
+    public void setIsBookmarked(boolean isBookmarked) {
+        this.isBookmarked.setValue(new ObservableBoolean(isBookmarked));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsFocused() {
+        return isFocused;
+    }
+
+    public void setIsFocused(boolean isFocused) {
+        this.isFocused.postValue(new ObservableBoolean(isFocused));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsSpecialUrl() {
+        return isSpecialUrl;
+    }
+
+    public void setIsSpecialUrl(boolean isSpecialUrl) {
+        this.isSpecialUrl.postValue(new ObservableBoolean(isSpecialUrl));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsUrlEmpty() {
+        return isUrlEmpty;
+    }
+
+    public void setIsUrlEmpty(boolean isUrlEmpty) {
+        this.isUrlEmpty.postValue(new ObservableBoolean(isUrlEmpty));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsPopUpAvailable() {
+        return isPopUpAvailable;
+    }
+
+    public void setIsPopUpAvailable(boolean isPopUpAvailable) {
+        this.isPopUpAvailable.postValue(new ObservableBoolean(isPopUpAvailable));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getCanGoForward() {
+        return canGoForward;
+    }
+
+    public void setCanGoForward(boolean canGoForward) {
+        this.canGoForward.postValue(new ObservableBoolean(canGoForward));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getCanGoBack() {
+        return canGoBack;
+    }
+
+    public void setCanGoBack(boolean canGoBack) {
+        this.canGoBack.postValue(new ObservableBoolean(canGoBack));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsInVRVideo() {
+        return isInVRVideo;
+    }
+
+    public void setIsInVRVideo(boolean isInVRVideo) {
+        this.isInVRVideo.postValue(new ObservableBoolean(isInVRVideo));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getAutoEnteredVRVideo() {
+        return autoEnteredVRVideo;
+    }
+
+    public void setAutoEnteredVRVideo(boolean autoEnteredVRVideo) {
+        this.autoEnteredVRVideo.postValue(new ObservableBoolean(autoEnteredVRVideo));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsServoAvailable() {
+        return isServoAvailable;
+    }
+
+    @NonNull
+    public MediatorLiveData<String> getTitleBarUrl() {
+        return titleBarUrl;
+    }
+
+    @NonNull
+    public MediatorLiveData<ObservableBoolean> getIsInsecureVisible() {
+        return isInsecureVisible;
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsMediaAvailable() {
+        return isMediaAvailable;
+    }
+
+    public void setIsMediaAvailable(boolean isMediaAvailable) {
+        this.isMediaAvailable.postValue(new ObservableBoolean(isMediaAvailable));
+    }
+
+    @NonNull
+    public MutableLiveData<ObservableBoolean> getIsMediaPlaying() {
+        return isMediaPlaying;
+    }
+
+    public void setIsMediaPlaying(boolean isMediaPlaying) {
+        this.isMediaPlaying.postValue(new ObservableBoolean(isMediaPlaying));
+    }
+
+    @NonNull
+    public MutableLiveData<String> getNavigationBarUrl() {
+        return navigationBarUrl;
+    }
+}

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -268,6 +268,11 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     @Override
+    public void updateUI() {
+        // Nothing to do here
+    }
+
+    @Override
     public void releaseWidget() {
         detachFromWindow();
         mWidgetManager.removeFocusChangeListener(this);
@@ -1129,7 +1134,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     private void exitVoiceInputMode() {
         if (mIsInVoiceInput && mVoiceSearchWidget != null) {
-            mVoiceSearchWidget.hide(REMOVE_WIDGET);
+            mVoiceSearchWidget.hide(KEEP_WIDGET);
             mWidgetPlacement.visible = true;
             mWidgetManager.updateWidget(this);
             mIsInVoiceInput = false;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -268,11 +268,6 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     @Override
-    public void updateUI() {
-        // Nothing to do here
-    }
-
-    @Override
     public void releaseWidget() {
         detachFromWindow();
         mWidgetManager.removeFocusChangeListener(this);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
@@ -226,6 +226,11 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
     }
 
     @Override
+    public void updateUI() {
+        // Nothing to do
+    }
+
+    @Override
     protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
         Context context = getContext();
         aPlacement.width = WidgetPlacement.dpDimension(context, R.dimen.media_controls_container_width);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
@@ -226,11 +226,6 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
     }
 
     @Override
-    public void updateUI() {
-        // Nothing to do
-    }
-
-    @Override
     protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
         Context context = getContext();
         aPlacement.width = WidgetPlacement.dpDimension(context, R.dimen.media_controls_container_width);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -7,25 +7,27 @@ package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Rect;
-import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.Pair;
+import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
 import android.widget.EditText;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+import androidx.databinding.ObservableBoolean;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
 
-import org.mozilla.geckoview.AllowOrDeny;
-import org.mozilla.geckoview.GeckoResult;
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.audio.AudioEngine;
 import org.mozilla.vrbrowser.browser.Media;
@@ -33,9 +35,10 @@ import org.mozilla.vrbrowser.browser.PromptDelegate;
 import org.mozilla.vrbrowser.browser.SessionChangeListener;
 import org.mozilla.vrbrowser.browser.SettingsStore;
 import org.mozilla.vrbrowser.browser.engine.Session;
+import org.mozilla.vrbrowser.databinding.NavigationBarBinding;
 import org.mozilla.vrbrowser.search.suggestions.SuggestionsProvider;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
-import org.mozilla.vrbrowser.ui.views.CustomUIButton;
+import org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel;
 import org.mozilla.vrbrowser.ui.views.NavigationURLBar;
 import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.views.UITextButton;
@@ -47,54 +50,29 @@ import org.mozilla.vrbrowser.ui.widgets.menus.HamburgerMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.VideoProjectionMenuWidget;
 import org.mozilla.vrbrowser.utils.AnimationHelper;
 import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
-import org.mozilla.vrbrowser.utils.ServoUtils;
 import org.mozilla.vrbrowser.utils.UrlUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mozilla.vrbrowser.ui.widgets.menus.VideoProjectionMenuWidget.VIDEO_PROJECTION_NONE;
 
 public class NavigationBarWidget extends UIWidget implements GeckoSession.NavigationDelegate,
-        GeckoSession.ProgressDelegate, GeckoSession.ContentDelegate, WidgetManagerDelegate.WorldClickListener,
+        GeckoSession.ContentDelegate, WidgetManagerDelegate.WorldClickListener,
         WidgetManagerDelegate.UpdateListener, SessionChangeListener,
         NavigationURLBar.NavigationURLBarDelegate, VoiceSearchWidget.VoiceSearchDelegate,
         SharedPreferences.OnSharedPreferenceChangeListener, SuggestionsWidget.URLBarPopupDelegate,
-        WindowWidget.BookmarksViewDelegate, WindowWidget.HistoryViewDelegate, TrayListener, WindowWidget.WindowListener {
+        TrayListener, WindowWidget.WindowListener {
 
     private static final int NOTIFICATION_DURATION = 3000;
 
+    private WindowViewModel mViewModel;
+    private NavigationBarBinding mBinding;
     private AudioEngine mAudio;
-    private UIButton mBackButton;
-    private UIButton mForwardButton;
-    private UIButton mReloadButton;
-    private UIButton mHomeButton;
-    private UIButton mServoButton;
-    private NavigationURLBar mURLBar;
-    private ViewGroup mNavigationContainer;
-    private ViewGroup mFullScreenModeContainer;
-    private ViewGroup mResizeModeContainer;
     private WindowWidget mAttachedWindow;
-    private boolean mIsLoading;
-    private boolean mIsInVRVideo;
-    private boolean mAutoEnteredVRVideo;
     private Runnable mResizeBackHandler;
     private Runnable mFullScreenBackHandler;
     private Runnable mVRVideoBackHandler;
-    private UIButton mResizeExitButton;
-    private UIButton mMenuButton;
-    private UIButton mFullScreenExitButton;
-    private UIButton mBrightnessButton;
-    private UIButton mFullScreenResizeButton;
-    private UIButton mProjectionButton;
-    private UITextButton mPreset0;
-    private UITextButton mPreset1;
-    private UITextButton mPreset15;
-    private UITextButton mPreset2;
-    private UITextButton mPreset3;
-    private ArrayList<CustomUIButton> mButtons;
     private VoiceSearchWidget mVoiceSearchWidget;
     private Context mAppContext;
     private SharedPreferences mPrefs;
@@ -141,7 +119,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mFullScreenBackHandler = this::exitFullScreenMode;
         mVRVideoBackHandler = () -> {
             exitVRVideo();
-            if (mAutoEnteredVRVideo) {
+            if (mViewModel.getAutoEnteredVRVideo().getValue().get()) {
                 exitFullScreenMode();
             }
         };
@@ -156,27 +134,17 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mPrefs.registerOnSharedPreferenceChangeListener(this);
     }
 
-    @Override
-    public void updateUI() {
+    private void updateUI() {
         removeAllViews();
 
-        inflate(getContext(), R.layout.navigation_bar, this);
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
-        mBackButton = findViewById(R.id.backButton);
-        mForwardButton = findViewById(R.id.forwardButton);
-        mReloadButton = findViewById(R.id.reloadButton);
-        mHomeButton = findViewById(R.id.homeButton);
-        mServoButton = findViewById(R.id.servoButton);
-        mURLBar = findViewById(R.id.urlBar);
-        mNavigationContainer = findViewById(R.id.navigationBarContainer);
-        mFullScreenModeContainer = findViewById(R.id.fullScreenModeContainer);
-        mResizeModeContainer = findViewById(R.id.resizeModeContainer);
-        mFullScreenExitButton = findViewById(R.id.fullScreenExitButton);
-        mBrightnessButton = findViewById(R.id.brightnessButton);
-        mFullScreenResizeButton = findViewById(R.id.fullScreenResizeEnterButton);
-        mProjectionButton = findViewById(R.id.projectionButton);
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.navigation_bar, this, true);
+        mBinding.setLifecycleOwner((VRBrowserActivity)getContext());
+        mBinding.setViewmodel(mViewModel);
 
-        mBackButton.setOnClickListener(v -> {
+        mBinding.navigationBarNavigation.backButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
 
             if (getSession().canGoBack()) {
@@ -188,7 +156,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mForwardButton.setOnClickListener(v -> {
+        mBinding.navigationBarNavigation.forwardButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
             getSession().goForward();
             if (mAudio != null) {
@@ -196,9 +164,9 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mReloadButton.setOnClickListener(v -> {
+        mBinding.navigationBarNavigation.reloadButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
-            if (mIsLoading) {
+            if (mViewModel.getIsLoading().getValue().get()) {
                 getSession().stop();
             } else {
                 getSession().reload();
@@ -208,7 +176,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mHomeButton.setOnClickListener(v -> {
+        mBinding.navigationBarNavigation.homeButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
             getSession().loadUri(getSession().getHomeUri());
             if (mAudio != null) {
@@ -216,7 +184,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mServoButton.setOnClickListener(v -> {
+        mBinding.navigationBarNavigation.servoButton.setOnClickListener(v -> {
             v.requestFocusFromTouch();
             getSession().toggleServo();
             if (mAudio != null) {
@@ -224,15 +192,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mMenuButton = findViewById(R.id.menuButton);
-        mResizeExitButton = findViewById(R.id.resizeExitButton);
-        mPreset0 = findViewById(R.id.resizePreset0);
-        mPreset1 = findViewById(R.id.resizePreset1);
-        mPreset15 = findViewById(R.id.resizePreset15);
-        mPreset2 = findViewById(R.id.resizePreset2);
-        mPreset3 = findViewById(R.id.resizePreset3);
-
-        mMenuButton.setOnClickListener(view -> {
+        mBinding.navigationBarNavigation.menuButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
 
             showMenu();
@@ -242,7 +202,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mResizeExitButton.setOnClickListener(view -> {
+        mBinding.navigationBarMenu.resizeExitButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             exitResizeMode(ResizeAction.KEEP_SIZE);
 
@@ -251,7 +211,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mFullScreenResizeButton.setOnClickListener(view -> {
+        mBinding.navigationBarFullscreen.fullScreenResizeEnterButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             enterResizeMode();
             if (mAudio != null) {
@@ -259,7 +219,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mFullScreenExitButton.setOnClickListener(view -> {
+        mBinding.navigationBarFullscreen.fullScreenExitButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             exitFullScreenMode();
             if (mAudio != null) {
@@ -267,7 +227,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mProjectionButton.setOnClickListener(view -> {
+        mBinding.navigationBarFullscreen.projectionButton.setOnClickListener(view -> {
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -288,7 +248,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mBrightnessButton.setOnClickListener(view -> {
+        mBinding.navigationBarFullscreen.brightnessButton.setOnClickListener(view -> {
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -297,7 +257,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             closeFloatingMenus();
 
             if (!wasVisible) {
-                float anchor = 0.5f + (float)mBrightnessButton.getMeasuredWidth() / (float)NavigationBarWidget.this.getMeasuredWidth();
+                float anchor = 0.5f + (float)mBinding.navigationBarFullscreen.brightnessButton.getMeasuredWidth() / (float)NavigationBarWidget.this.getMeasuredWidth();
                 mBrightnessWidget.getPlacement().parentAnchorX = anchor;
                 mBrightnessWidget.setVisible(true);
             }
@@ -308,7 +268,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         });
 
 
-        mPreset0.setOnClickListener(view -> {
+        mBinding.navigationBarMenu.resizePreset0.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             setResizePreset(0.5f);
             if (mAudio != null) {
@@ -316,7 +276,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mPreset1.setOnClickListener(view -> {
+        mBinding.navigationBarMenu.resizePreset1.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             setResizePreset(1.0f);
             if (mAudio != null) {
@@ -324,7 +284,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mPreset15.setOnClickListener(view -> {
+        mBinding.navigationBarMenu.resizePreset15.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             setResizePreset(1.5f);
             if (mAudio != null) {
@@ -332,7 +292,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mPreset2.setOnClickListener(view -> {
+        mBinding.navigationBarMenu.resizePreset2.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             setResizePreset(2.0f);
             if (mAudio != null) {
@@ -340,7 +300,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mPreset3.setOnClickListener(view -> {
+        mBinding.navigationBarMenu.resizePreset3.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             setResizePreset(3.0f);
             if (mAudio != null) {
@@ -348,26 +308,30 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             }
         });
 
-        mButtons = new ArrayList<>();
-        mButtons.addAll(Arrays.<CustomUIButton>asList(
-                mBackButton, mForwardButton, mReloadButton, mHomeButton, mMenuButton,
-                mServoButton, mPreset0, mPreset1, mPreset15, mPreset2, mPreset3, mResizeExitButton));
+        mBinding.navigationBarNavigation.urlBar.setDelegate(this);
 
-        mURLBar.setDelegate(this);
+        if (mAttachedWindow != null) {
+            mBinding.navigationBarNavigation.urlBar.attachToWindow(mAttachedWindow);
+        }
+    }
 
-        updateState();
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        mURLBar.onPause();
+        mBinding.navigationBarNavigation.urlBar.onPause();
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        mURLBar.onResume();
+        mBinding.navigationBarNavigation.urlBar.onResume();
     }
 
     @Override
@@ -411,7 +375,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void detachFromWindow() {
-        hideNotification(mURLBar.getPopUpButton());
+        hideNotification(mBinding.navigationBarNavigation.urlBar.getPopUpButton());
 
         if (mAttachedWindow != null && mAttachedWindow.isResizing()) {
             exitResizeMode(ResizeAction.RESTORE_SIZE);
@@ -424,14 +388,19 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             cleanSession(getSession());
         }
         if (mAttachedWindow != null) {
-            mAttachedWindow.removeBookmarksViewListener(this);
-            mAttachedWindow.removeHistoryViewListener(this);
             mAttachedWindow.removeWindowListener(this);
             mAttachedWindow.setPopUpDelegate(null);
         }
         mAttachedWindow = null;
         if (mAwesomeBar != null && mAwesomeBar.isVisible()) {
             mAwesomeBar.hideNoAnim(UIWidget.KEEP_WIDGET);
+        }
+
+        mBinding.navigationBarNavigation.urlBar.detachFromWindow();
+
+        if (mViewModel != null) {
+            mViewModel.getIsFullscreen().removeObserver(mIsFullscreenObserver);
+            mViewModel = null;
         }
     }
 
@@ -442,10 +411,19 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
         detachFromWindow();
 
-        mWidgetPlacement.parentHandle = aWindow.getHandle();
         mAttachedWindow = aWindow;
-        mAttachedWindow.addBookmarksViewListener(this);
-        mAttachedWindow.addHistoryViewListener(this);
+        mWidgetPlacement.parentHandle = aWindow.getHandle();
+
+        mViewModel = new ViewModelProvider(
+                (VRBrowserActivity)getContext(),
+                ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
+                .get(String.valueOf(mAttachedWindow.hashCode()), WindowViewModel.class);
+
+        mBinding.setViewmodel(mViewModel);
+
+        mViewModel.getIsFullscreen().observe((VRBrowserActivity)getContext(), mIsFullscreenObserver);
+        mBinding.navigationBarNavigation.urlBar.attachToWindow(mAttachedWindow);
+
         mAttachedWindow.addWindowListener(this);
         mAttachedWindow.setPopUpDelegate(mPopUpDelegate);
 
@@ -455,24 +433,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             setUpSession(getSession());
         }
         handleWindowResize();
-
-        if (mAttachedWindow != null) {
-            mURLBar.setIsLibraryVisible(mAttachedWindow.isBookmarksVisible() || mAttachedWindow.isHistoryVisible());
-            if (mAttachedWindow.isBookmarksVisible()) {
-                mURLBar.setHint(R.string.url_bookmarks_title);
-                mURLBar.setIsLibraryVisible(true);
-
-            } else if (mAttachedWindow.isHistoryVisible()) {
-                mURLBar.setHint(R.string.url_history_title);
-                mURLBar.setIsLibraryVisible(true);
-
-            } else {
-                mURLBar.setURL(mAttachedWindow.getSession().getCurrentUri());
-                mURLBar.setHint(R.string.search_placeholder);
-                mURLBar.setIsLibraryVisible(false);
-            }
-            mURLBar.setIsPopUpAvailable(mAttachedWindow.hasPendingPopUps());
-        }
     }
 
     private Session getSession() {
@@ -485,23 +445,19 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     private void setUpSession(@NonNull Session aSession) {
         aSession.addSessionChangeListener(this);
         aSession.addNavigationListener(this);
-        aSession.addProgressListener(this);
         aSession.addContentListener(this);
-        mURLBar.setSession(getSession());
-        updateServoButton();
-        handleSessionState();
+        mBinding.navigationBarNavigation.urlBar.setSession(getSession());
     }
 
     private void cleanSession(@NonNull Session aSession) {
         aSession.removeSessionChangeListener(this);
         aSession.removeNavigationListener(this);
-        aSession.removeProgressListener(this);
         aSession.removeContentListener(this);
     }
 
     @Override
     public void onSessionChanged(@NonNull Session aOldSession, @NonNull Session aSession) {
-        mURLBar.setIsPopUpAvailable(mAttachedWindow.hasPendingPopUps());
+        mViewModel.setIsPopUpAvailable(mAttachedWindow.hasPendingPopUps());
 
         cleanSession(aOldSession);
         setUpSession(aSession);
@@ -513,15 +469,11 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void enterFullScreenMode() {
-        if (mAttachedWindow.isFullScreen()) {
-            return;
-        }
-
         mWidgetManager.pushBackHandler(mFullScreenBackHandler);
         mAttachedWindow.setIsFullScreen(true);
-        AnimationHelper.fadeIn(mFullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
+        AnimationHelper.fadeIn(mBinding.navigationBarFullscreen.fullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
 
-        AnimationHelper.fadeOut(mNavigationContainer, 0, null);
+        AnimationHelper.fadeOut(mBinding.navigationBarNavigation.navigationBarContainer, 0, null);
 
         mWidgetManager.pushWorldBrightness(this, WidgetManagerDelegate.DEFAULT_DIM_BRIGHTNESS);
 
@@ -533,7 +485,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             mProjectionMenuPlacement = new WidgetPlacement(getContext());
             mWidgetManager.addWidget(mProjectionMenu);
             mProjectionMenu.setDelegate((projection)-> {
-                if (mIsInVRVideo) {
+                if (mViewModel.getIsInVRVideo().getValue().get()) {
                     // Reproject while reproducing VRVideo
                     mWidgetManager.showVRVideo(mAttachedWindow.getHandle(), projection);
                     closeFloatingMenus();
@@ -552,6 +504,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void exitFullScreenMode() {
+        if (mAttachedWindow == null) {
+            return;
+        }
+
         if (!mAttachedWindow.isFullScreen()) {
             mWidgetManager.setTrayVisible(true);
             return;
@@ -570,10 +526,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mAttachedWindow.setIsFullScreen(false);
         mWidgetManager.popBackHandler(mFullScreenBackHandler);
 
-        AnimationHelper.fadeIn(mNavigationContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
+        AnimationHelper.fadeIn(mBinding.navigationBarNavigation.navigationBarContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
 
         mWidgetManager.popWorldBrightness(this);
-        AnimationHelper.fadeOut(mFullScreenModeContainer, 0, null);
+        AnimationHelper.fadeOut(mBinding.navigationBarFullscreen.fullScreenModeContainer, 0, null);
 
         mWidgetManager.setTrayVisible(true);
         closeFloatingMenus();
@@ -587,11 +543,11 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mAttachedWindow.setIsResizing(true);
         mAttachedWindow.saveBeforeResizePlacement();
         startWidgetResize();
-        AnimationHelper.fadeIn(mResizeModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
+        AnimationHelper.fadeIn(mBinding.navigationBarMenu.resizeModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
         if (mAttachedWindow.isFullScreen()) {
-            AnimationHelper.fadeOut(mFullScreenModeContainer, 0, null);
+            AnimationHelper.fadeOut(mBinding.navigationBarFullscreen.fullScreenModeContainer, 0, null);
         } else {
-            AnimationHelper.fadeOut(mNavigationContainer, 0, null);
+            AnimationHelper.fadeOut(mBinding.navigationBarNavigation.navigationBarContainer, 0, null);
         }
         mWidgetManager.pushBackHandler(mResizeBackHandler);
         mWidgetManager.setTrayVisible(false);
@@ -602,12 +558,16 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             maxScale = mAttachedWindow.getMaxWindowScale();
         }
 
-        mPreset3.setVisibility(maxScale >= 3.0f ? View.VISIBLE : View.GONE);
-        mPreset2.setVisibility(maxScale >= 2.0f ? View.VISIBLE : View.GONE);
-        mPreset15.setVisibility(maxScale == 1.5f ? View.VISIBLE: View.GONE);
+        mBinding.navigationBarMenu.resizePreset3.setVisibility(maxScale >= 3.0f ? View.VISIBLE : View.GONE);
+        mBinding.navigationBarMenu.resizePreset2.setVisibility(maxScale >= 2.0f ? View.VISIBLE : View.GONE);
+        mBinding.navigationBarMenu.resizePreset15.setVisibility(maxScale == 1.5f ? View.VISIBLE: View.GONE);
 
         // Update visible presets
-        UITextButton[] presets = { mPreset3, mPreset2, mPreset15, mPreset1};
+        UITextButton[] presets = {
+                mBinding.navigationBarMenu.resizePreset3,
+                mBinding.navigationBarMenu.resizePreset2,
+                mBinding.navigationBarMenu.resizePreset15,
+                mBinding.navigationBarMenu.resizePreset1};
         boolean fistVisible = true;
         for (UITextButton preset: presets) {
             if (fistVisible) {
@@ -646,11 +606,11 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mAttachedWindow.setIsResizing(false);
         finishWidgetResize();
         if (mAttachedWindow.isFullScreen()) {
-            AnimationHelper.fadeIn(mFullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
+            AnimationHelper.fadeIn(mBinding.navigationBarFullscreen.fullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
         } else {
-            AnimationHelper.fadeIn(mNavigationContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
+            AnimationHelper.fadeIn(mBinding.navigationBarNavigation.navigationBarContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
         }
-        AnimationHelper.fadeOut(mResizeModeContainer, 0, () -> onWidgetUpdate(mAttachedWindow));
+        AnimationHelper.fadeOut(mBinding.navigationBarMenu.resizeModeContainer, 0, () -> onWidgetUpdate(mAttachedWindow));
         mWidgetManager.popBackHandler(mResizeBackHandler);
         mWidgetManager.setTrayVisible(!mAttachedWindow.isFullScreen());
         closeFloatingMenus();
@@ -661,10 +621,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void enterVRVideo(@VideoProjectionMenuWidget.VideoProjectionFlags int aProjection) {
-        if (mIsInVRVideo) {
+        if (mViewModel.getIsInVRVideo().getValue().get()) {
             return;
         }
-        mIsInVRVideo = true;
+        mViewModel.setIsInVRVideo(true);
         mWidgetManager.pushBackHandler(mVRVideoBackHandler);
         mProjectionMenu.setSelectedProjection(aProjection);
         // Backup the placement because the same widget is reused in FullScreen & MediaControl menus
@@ -707,13 +667,13 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void exitVRVideo() {
-        if (!mIsInVRVideo) {
+        if (!mViewModel.getIsInVRVideo().getValue().get()) {
             return;
         }
         if (mFullScreenMedia != null) {
             mFullScreenMedia.setResizeDelegate(null);
         }
-        mIsInVRVideo = false;
+        mViewModel.setIsInVRVideo(false);
         mWidgetManager.popBackHandler(mVRVideoBackHandler);
         mWidgetManager.hideVRVideo();
         boolean composited = mProjectionMenu.getPlacement().composited;
@@ -739,31 +699,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     public void showVoiceSearch() {
-        mURLBar.setMicrophoneEnabled(true);
-    }
-
-    public void updateServoButton() {
-        // We show the Servo button if:
-        // 1. the current session is using Servo. No matter what, we need the toggle button to go back to Gecko.
-        // 2. Or, if the pref is enabled and the current url is white listed.
-        boolean show = false;
-        boolean isServoSession = false;
-        if (getSession() != null){
-            GeckoSession currentSession = getSession().getGeckoSession();
-            if (currentSession != null) {
-                String currentUri = getSession().getCurrentUri();
-                boolean isPrefEnabled = SettingsStore.getInstance(mAppContext).isServoEnabled();
-                boolean isUrlWhiteListed = ServoUtils.isUrlInServoWhiteList(mAppContext, currentUri);
-                isServoSession = ServoUtils.isInstanceOfServoSession(currentSession);
-                show = isServoSession || (isPrefEnabled && isUrlWhiteListed);
-            }
-            if (show) {
-                mServoButton.setVisibility(View.VISIBLE);
-                mServoButton.setImageResource(isServoSession ? R.drawable.ic_icon_gecko : R.drawable.ic_icon_servo);
-            } else {
-                mServoButton.setVisibility(View.GONE);
-            }
-        }
+        mViewModel.setIsMicrophoneEnabled(true);
     }
 
     private void closeFloatingMenus() {
@@ -775,121 +711,15 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
     }
 
-    private void updateState() {
-        handleSessionState();
-        updateServoButton();
-        mURLBar.updateState();
-    }
-
-    private void handleSessionState() {
-        if (getSession() != null) {
-            boolean isPrivateMode = getSession().isPrivateMode();
-
-            mURLBar.setPrivateMode(isPrivateMode);
-            for (CustomUIButton button : mButtons) {
-                button.setPrivateMode(isPrivateMode);
-            }
-        }
-    }
-
-    @Override
-    public void onLocationChange(GeckoSession session, String url) {
-        if (mURLBar != null && !mAttachedWindow.isBookmarksVisible() && !mAttachedWindow.isHistoryVisible()) {
-            Log.d(LOGTAG, "Got location change");
-            mURLBar.setURL(url);
-            mURLBar.setHint(R.string.search_placeholder);
-            mReloadButton.setEnabled(true);
-        }
-        updateServoButton();
-    }
-
-    @Override
-    public void onCanGoBack(GeckoSession aSession, boolean canGoBack) {
-        if (mBackButton != null) {
-            Log.d(LOGTAG, "Got onCanGoBack: " + (canGoBack ? "true" : "false"));
-            mBackButton.setEnabled(canGoBack);
-            mBackButton.setHovered(false);
-            mBackButton.setClickable(canGoBack);
-        }
-    }
-
-    @Override
-    public void onCanGoForward(GeckoSession aSession, boolean canGoForward) {
-        if (mForwardButton != null) {
-            Log.d(LOGTAG, "Got onCanGoForward: " + (canGoForward ? "true" : "false"));
-            mForwardButton.setEnabled(canGoForward);
-            mForwardButton.setHovered(false);
-            mForwardButton.setClickable(canGoForward);
-        }
-    }
-
-    @Override
-    public @Nullable GeckoResult<AllowOrDeny> onLoadRequest(GeckoSession aSession, @NonNull LoadRequest aRequest) {
-        final GeckoResult<AllowOrDeny> result = new GeckoResult<>();
-
-        Uri uri = Uri.parse(aRequest.uri);
-        if ("file".equalsIgnoreCase(uri.getScheme()) &&
-                !mWidgetManager.isPermissionGranted(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            mWidgetManager.requestPermission(
-                    aRequest.uri,
-                    android.Manifest.permission.READ_EXTERNAL_STORAGE,
-                    new GeckoSession.PermissionDelegate.Callback() {
-                        @Override
-                        public void grant() {
-                            result.complete(AllowOrDeny.ALLOW);
-                        }
-
-                        @Override
-                        public void reject() {
-                            result.complete(AllowOrDeny.DENY);
-                        }
-                    });
-            return result;
-        }
-
-        result.complete(AllowOrDeny.ALLOW);
-        return result;
-    }
-
-    // Progress Listener
-    @Override
-    public void onPageStart(GeckoSession aSession, String aUri) {
-        if (mURLBar != null) {
-            Log.d(LOGTAG, "Got onPageStart");
-            mURLBar.setURL(aUri);
-            mURLBar.setHint(R.string.search_placeholder);
-        }
-        mIsLoading = true;
-        mURLBar.setIsLoading(true);
-        if (mReloadButton != null) {
-            mReloadButton.setImageResource(R.drawable.ic_icon_exit);
-            mReloadButton.setTooltip(getResources().getString(R.string.stop_tooltip));
-        }
-    }
-
-    @Override
-    public void onPageStop(GeckoSession aSession, boolean b) {
-        mIsLoading = false;
-        mURLBar.setIsLoading(false);
-        if (mReloadButton != null) {
-            mReloadButton.setImageResource(R.drawable.ic_icon_reload);
-            mReloadButton.setTooltip(getResources().getString(R.string.refresh_tooltip));
-        }
-    }
-
-    @Override
-    public void onSecurityChange(GeckoSession geckoSession, SecurityInformation securityInformation) {
-        if (mURLBar != null) {
-            boolean isSecure = securityInformation.isSecure;
-            mURLBar.setIsInsecure(!isSecure);
-        }
-    }
-
     // Content delegate
 
     @Override
-    public void onFullScreen(GeckoSession session, boolean aFullScreen) {
-        if (aFullScreen) {
+    public void onFullScreen(@NonNull GeckoSession session, boolean aFullScreen) {
+        mViewModel.setIsFullscreen(aFullScreen);
+    }
+
+    private Observer<ObservableBoolean> mIsFullscreenObserver = isFullScreen -> {
+        if (isFullScreen.get()) {
             if (!mAttachedWindow.isFullScreen()) {
                 enterFullScreenMode();
             }
@@ -899,21 +729,21 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             AtomicBoolean autoEnter = new AtomicBoolean(false);
             mAutoSelectedProjection = VideoProjectionMenuWidget.getAutomaticProjection(getSession().getCurrentUri(), autoEnter);
             if (mAutoSelectedProjection != VIDEO_PROJECTION_NONE && autoEnter.get()) {
-                mAutoEnteredVRVideo = true;
+                mViewModel.setAutoEnteredVRVideo(true);
                 postDelayed(() -> enterVRVideo(mAutoSelectedProjection), 300);
             } else {
-                mAutoEnteredVRVideo = false;
+                mViewModel.setAutoEnteredVRVideo(false);
                 if (mProjectionMenu != null) {
                     mProjectionMenu.setSelectedProjection(mAutoSelectedProjection);
                 }
             }
         } else {
-            if (mIsInVRVideo) {
+            if (mViewModel.getIsInVRVideo().getValue().get()) {
                 exitVRVideo();
             }
             exitFullScreenMode();
         }
-    }
+    };
 
     // WidgetManagerDelegate.UpdateListener
     @Override
@@ -943,8 +773,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void onCurrentSessionChange(GeckoSession aOldSession, GeckoSession aSession) {
-        handleSessionState();
-
         boolean isFullScreen = getSession().isInFullScreen();
         if (isFullScreen && !mAttachedWindow.isFullScreen()) {
             enterFullScreenMode();
@@ -975,8 +803,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             mAwesomeBar.setURLBarPopupDelegate(this);
         }
 
-        final String text = mURLBar.getText().trim();
-        final String originalText = mURLBar.getOriginalText().trim();
+        final String text = mBinding.navigationBarNavigation.urlBar.getText().trim();
+        final String originalText = mBinding.navigationBarNavigation.urlBar.getOriginalText().trim();
         if (originalText.length() <= 0) {
             mAwesomeBar.hide(UIWidget.KEEP_WIDGET);
             return;
@@ -986,12 +814,12 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mSuggestionsProvider.setFilterText(originalText);
         mSuggestionsProvider.getSuggestions()
                 .whenCompleteAsync((items, ex) -> {
-                    if (mURLBar.hasFocus()) {
+                    if (mBinding.navigationBarNavigation.urlBar.hasFocus()) {
                         mAwesomeBar.updateItems(items);
                         mAwesomeBar.setHighlightedText(originalText);
 
                         if (!mAwesomeBar.isVisible()) {
-                            mAwesomeBar.updatePlacement((int) WidgetPlacement.convertPixelsToDp(getContext(), mURLBar.getWidth()));
+                            mAwesomeBar.updatePlacement((int) WidgetPlacement.convertPixelsToDp(getContext(), mBinding.navigationBarNavigation.urlBar.getWidth()));
                             mAwesomeBar.show(CLEAR_FOCUS);
                         }
                     }
@@ -1031,15 +859,12 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void OnVoiceSearchResult(String transcription, float confidance) {
-        mURLBar.handleURLEdit(transcription);
+        mBinding.navigationBarNavigation.urlBar.handleURLEdit(transcription);
     }
 
     @Override
     public void onSharedPreferenceChanged(@NonNull SharedPreferences sharedPreferences, String key) {
-        if (key.equals(mAppContext.getString(R.string.settings_key_servo))) {
-            updateServoButton();
-
-        } else if (key.equals(mAppContext.getString(R.string.settings_key_user_agent_version))) {
+        if (key.equals(mAppContext.getString(R.string.settings_key_user_agent_version))) {
             if (mHamburgerMenu != null) {
                 mHamburgerMenu.setUAMode(SettingsStore.getInstance(getContext()).getUaMode());
             }
@@ -1049,7 +874,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     // WorldClickListener
     @Override
     public void onWorldClick() {
-        if (mIsInVRVideo && mMediaControlsWidget != null) {
+        if (mViewModel.getIsInVRVideo().getValue().get() && mMediaControlsWidget != null) {
             mMediaControlsWidget.setVisible(!mMediaControlsWidget.isVisible());
             if (mProjectionMenu.getSelectedProjection() != VideoProjectionMenuWidget.VIDEO_PROJECTION_3D_SIDE_BY_SIDE) {
                 if (mMediaControlsWidget.isVisible()) {
@@ -1072,51 +897,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     @Override
     public void OnItemClicked(SuggestionsWidget.SuggestionItem item) {
-        mURLBar.handleURLEdit(item.url);
-    }
-
-    // BookmarksViewListener
-
-    @Override
-    public void onBookmarksShown(WindowWidget aWindow) {
-        if (mAttachedWindow == aWindow) {
-            mURLBar.setURL("");
-            mURLBar.setHint(R.string.url_bookmarks_title);
-            mURLBar.setIsLibraryVisible(true);
-        }
-
-        hideNotifications();
-    }
-
-    @Override
-    public void onBookmarksHidden(WindowWidget aWindow) {
-        if (mAttachedWindow == aWindow) {
-            mURLBar.setIsLibraryVisible(false);
-            mURLBar.setURL(getSession().getCurrentUri());
-            mURLBar.setHint(R.string.search_placeholder);
-        }
-    }
-
-    // HistoryViewListener
-
-    @Override
-    public void onHistoryViewShown(WindowWidget aWindow) {
-        if (mAttachedWindow == aWindow) {
-            mURLBar.setURL("");
-            mURLBar.setHint(R.string.url_history_title);
-            mURLBar.setIsLibraryVisible(true);
-        }
-
-        hideNotifications();
-    }
-
-    @Override
-    public void onHistoryViewHidden(WindowWidget aWindow) {
-        if (mAttachedWindow == aWindow) {
-            mURLBar.setIsLibraryVisible(false);
-            mURLBar.setURL(getSession().getCurrentUri());
-            mURLBar.setHint(R.string.search_placeholder);
-        }
+        mBinding.navigationBarNavigation.urlBar.handleURLEdit(item.url);
     }
 
     // TrayListener
@@ -1129,7 +910,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         } else if (mAttachedWindow.isFullScreen()) {
             exitFullScreenMode();
 
-        } else if (mIsInVRVideo) {
+        } else if (mViewModel.getIsInVRVideo().getValue().get()) {
             exitVRVideo();
         }
     }
@@ -1147,7 +928,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         } else if (mAttachedWindow.isFullScreen()) {
             exitFullScreenMode();
 
-        } else if (mIsInVRVideo) {
+        } else if (mViewModel.getIsInVRVideo().getValue().get()) {
             exitVRVideo();
         }
     }
@@ -1231,12 +1012,12 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         @Override
         public void onPopUpAvailable() {
             showPopUpsBlockedNotification();
-            mURLBar.setIsPopUpAvailable(true);
+            mViewModel.setIsPopUpAvailable(true);
         }
 
         @Override
         public void onPopUpsCleared() {
-            mURLBar.setIsPopUpAvailable(false);
+            mViewModel.setIsPopUpAvailable(false);
             hidePopUpsBlockedNotification();
         }
     };
@@ -1247,7 +1028,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         final int currentCount = mBlockedCount;
         postDelayed(() -> {
             if (currentCount == mBlockedCount) {
-                showNotification(mURLBar.getPopUpButton(), R.string.popup_tooltip);
+                showNotification(mBinding.navigationBarNavigation.urlBar.getPopUpButton(), R.string.popup_tooltip);
             }
         }, POP_UP_NOTIFICATION_DELAY);
     }
@@ -1257,7 +1038,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         final int currentCount = mBlockedCount;
         post(() -> {
             if (currentCount == mBlockedCount) {
-                hideNotification(mURLBar.getPopUpButton());
+                hideNotification(mBinding.navigationBarNavigation.urlBar.getPopUpButton());
             }
         });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/RootWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/RootWidget.java
@@ -35,6 +35,11 @@ public class RootWidget extends UIWidget {
     }
 
     @Override
+    public void updateUI() {
+        // Nothing to do here
+    }
+
+    @Override
     public boolean onTouchEvent(MotionEvent event) {
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/RootWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/RootWidget.java
@@ -35,11 +35,6 @@ public class RootWidget extends UIWidget {
     }
 
     @Override
-    public void updateUI() {
-        // Nothing to do here
-    }
-
-    @Override
     public boolean onTouchEvent(MotionEvent event) {
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
@@ -3,6 +3,7 @@ package org.mozilla.vrbrowser.ui.widgets;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Typeface;
@@ -94,7 +95,6 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
         mHighlightedText = "";
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -107,6 +107,13 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
         mList.setOnItemClickListener(mClickListener);
         mList.setOnItemLongClickListener(mLongClickListener);
         mList.setOnScrollChangeListener((v, scrollX, scrollY, oldScrollX, oldScrollY) -> hideMenu());
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/SuggestionsWidget.java
@@ -67,11 +67,7 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
     }
 
     private void initialize(Context aContext) {
-        inflate(aContext, R.layout.list_popup_window, this);
-
-        mWidgetManager.addFocusChangeListener(this);
-
-        mList = findViewById(R.id.list);
+        updateUI();
 
         mScaleUpAnimation = AnimationUtils.loadAnimation(getContext(), R.anim.popup_scaleup);
         mScaleDownAnimation = AnimationUtils.loadAnimation(getContext(), R.anim.popup_scaledown);
@@ -92,12 +88,6 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
             }
         });
 
-        mAdapter = new SuggestionsAdapter(getContext(), R.layout.list_popup_window_item, new ArrayList<>());
-        mList.setAdapter(mAdapter);
-        mList.setOnItemClickListener(mClickListener);
-        mList.setOnItemLongClickListener(mLongClickListener);
-        mList.setOnScrollChangeListener((v, scrollX, scrollY, oldScrollX, oldScrollY) -> hideMenu());
-
         mAudio = AudioEngine.fromContext(aContext);
         mClipboard = (ClipboardManager) getContext().getSystemService(Context.CLIPBOARD_SERVICE);
 
@@ -105,9 +95,22 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
     }
 
     @Override
-    public void releaseWidget() {
-        mWidgetManager.removeFocusChangeListener(this);
+    public void updateUI() {
+        removeAllViews();
 
+        inflate(getContext(), R.layout.list_popup_window, this);
+
+        mList = findViewById(R.id.list);
+
+        mAdapter = new SuggestionsAdapter(getContext(), R.layout.list_popup_window_item, new ArrayList<>());
+        mList.setAdapter(mAdapter);
+        mList.setOnItemClickListener(mClickListener);
+        mList.setOnItemLongClickListener(mLongClickListener);
+        mList.setOnScrollChangeListener((v, scrollX, scrollY, oldScrollX, oldScrollY) -> hideMenu());
+    }
+
+    @Override
+    public void releaseWidget() {
         super.releaseWidget();
     }
 
@@ -128,12 +131,14 @@ public class SuggestionsWidget extends UIWidget implements WidgetManagerDelegate
     @Override
     public void show(@ShowFlags int aShowFlags) {
         super.show(aShowFlags);
+        mWidgetManager.addFocusChangeListener(this);
         mList.startAnimation(mScaleUpAnimation);
         mList.post(() -> mList.setSelectionAfterHeaderView());
     }
 
     @Override
     public void hide(@HideFlags int aHideFlags) {
+        mWidgetManager.removeFocusChangeListener(this);
         mList.startAnimation(mScaleDownAnimation);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -72,6 +72,13 @@ public class TabsWidget extends UIDialog {
     }
 
     private void initialize() {
+        updateUI();
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
         inflate(getContext(), R.layout.tabs, this);
 
         mTabsList = findViewById(R.id.tabsRecyclerView);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -75,7 +76,6 @@ public class TabsWidget extends UIDialog {
         updateUI();
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -142,6 +142,13 @@ public class TabsWidget extends UIDialog {
             mAdapter.notifyDataSetChanged();
             updateSelectionMode();
         });
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     public void attachToWindow(WindowWidget aWindow) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TitleBarWidget.java
@@ -6,26 +6,23 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
-import android.view.View;
-import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.StringRes;
 import androidx.databinding.DataBindingUtil;
+import androidx.databinding.ObservableBoolean;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
 
-import org.mozilla.geckoview.MediaElement;
 import org.mozilla.vrbrowser.R;
-import org.mozilla.vrbrowser.browser.Media;
+import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.databinding.TitleBarBinding;
+import org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URL;
-
-public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.UpdateListener {
+public class TitleBarWidget extends UIWidget {
 
     public interface Delegate {
         void onTitleClicked(@NonNull TitleBarWidget titleBar);
@@ -33,17 +30,11 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
         void onMediaPauseClicked(@NonNull TitleBarWidget titleBar);
     }
 
+    private WindowViewModel mViewModel;
     private TitleBarBinding mBinding;
     private WindowWidget mAttachedWindow;
-    private boolean mVisible = false;
-    private Media mMedia;
     private boolean mWidgetAdded = false;
     private Delegate mDelegate;
-    private String mUrl;
-    private boolean mInsecure;
-    private int mInsecureVisibility;
-    private boolean mPrivateMode;
-    private boolean mMediaAvailability;
 
     public TitleBarWidget(Context aContext) {
         super(aContext);
@@ -62,12 +53,9 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
 
     private void initialize(@NonNull Context aContext) {
         updateUI();
-
-        mWidgetManager.addUpdateListener(this);
     }
 
-    @Override
-    public void updateUI() {
+    private void updateUI() {
         removeAllViews();
 
         LayoutInflater inflater = LayoutInflater.from(getContext());
@@ -75,10 +63,15 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
         mBinding = DataBindingUtil.inflate(inflater, R.layout.title_bar, this, true);
         mBinding.setWidget(this);
         mBinding.setDelegate(mDelegate);
+        mBinding.setLifecycleOwner((VRBrowserActivity)getContext());
+        mBinding.setViewmodel(mViewModel);
+    }
 
-        mBinding.executePendingBindings();
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
 
-        updateState();
+        updateUI();
     }
 
     public void setDelegate(Delegate delegate) {
@@ -94,8 +87,6 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
     @Override
     public void releaseWidget() {
         detachFromWindow();
-
-        mWidgetManager.removeUpdateListener(this);
 
         mAttachedWindow = null;
         super.releaseWidget();
@@ -122,6 +113,11 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
     @Override
     public void detachFromWindow() {
         mAttachedWindow = null;
+
+        if (mViewModel != null) {
+            mViewModel.getIsTitleBarVisible().removeObserver(mIsVisibleObserver);
+            mViewModel = null;
+        }
     }
 
     @Override
@@ -134,135 +130,25 @@ public class TitleBarWidget extends UIWidget implements WidgetManagerDelegate.Up
         mWidgetPlacement.parentHandle = aWindow.getHandle();
         mAttachedWindow = aWindow;
 
-        setPrivateMode(aWindow.getSession().isPrivateMode());
+        // ModelView creation and observers setup
+        mViewModel = new ViewModelProvider(
+                (VRBrowserActivity)getContext(),
+                ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
+                .get(String.valueOf(mAttachedWindow.hashCode()), WindowViewModel.class);
+
+        mBinding.setViewmodel(mViewModel);
+
+        mViewModel.getIsTitleBarVisible().observe((VRBrowserActivity)getContext(), mIsVisibleObserver);
     }
 
-    @Override
-    public void setVisible(boolean aIsVisible) {
-        if (mVisible == aIsVisible || mWidgetManager == null) {
-            return;
-        }
-        mVisible = aIsVisible;
-        getPlacement().visible = aIsVisible;
+    Observer<ObservableBoolean> mIsVisibleObserver = isVisible -> {
+        mWidgetPlacement.visible = isVisible.get();
         if (!mWidgetAdded) {
-            mWidgetManager.addWidget(this);
+            mWidgetManager.addWidget(TitleBarWidget.this);
             mWidgetAdded = true;
         } else {
-            mWidgetManager.updateWidget(this);
-        }
-    }
-
-    public void setPrivateMode(boolean aPrivateMode) {
-        mPrivateMode = aPrivateMode;
-
-        mBinding.titleBar.setBackground(getContext().getDrawable(aPrivateMode ? R.drawable.title_bar_background_private : R.drawable.title_bar_background));
-        mBinding.mediaButton.setPrivateMode(aPrivateMode);
-    }
-
-    public void setURL(@StringRes int id) {
-        setURL(getResources().getString(id));
-    }
-
-    public void setURL(String urlString) {
-        if (urlString == null) {
-            return;
-        }
-
-        mUrl = urlString;
-
-        if (URLUtil.isValidUrl(urlString)) {
-            try {
-                URI uri = URI.create(urlString);
-                URL url = new URL(
-                        uri.getScheme() != null ? uri.getScheme() : "",
-                        uri.getAuthority() != null ? uri.getAuthority() : "",
-                        "");
-                mBinding.url.setText(url.toString());
-
-            } catch (MalformedURLException | IllegalArgumentException e) {
-                mBinding.url.setText("");
-            }
-
-        } else {
-            mBinding.url.setText(urlString);
-        }
-    }
-
-    public void setIsInsecure(boolean aIsInsecure) {
-        mInsecure = aIsInsecure;
-
-        if (mAttachedWindow != null && mAttachedWindow.getSession() != null &&
-                mAttachedWindow.getSession().getCurrentUri() != null &&
-                !(mAttachedWindow.getSession().getCurrentUri().startsWith("data") &&
-                mAttachedWindow.getSession().isPrivateMode())) {
-            mBinding.insecureIcon.setVisibility(aIsInsecure ? View.VISIBLE : View.GONE);
-        }
-    }
-
-    public void setInsecureVisibility(int visibility) {
-        mInsecureVisibility = visibility;
-        mBinding.insecureIcon.setVisibility(visibility);
-    }
-
-    public void mediaAvailabilityChanged(boolean available) {
-        mMediaAvailability = available;
-
-        if (mMedia != null) {
-            mMedia.removeMediaListener(mMediaDelegate);
-        }
-        if (available && mAttachedWindow != null && mAttachedWindow.getSession() != null) {
-            mMedia = mAttachedWindow.getSession().getFullScreenVideo();
-            if (mMedia != null) {
-                mMedia.addMediaListener(mMediaDelegate);
-                if (mMedia.isPlayed()) {
-                    mBinding.setIsMediaAvailable(true);
-                    mBinding.setIsMediaPlaying(true);
-                }
-            }
-        } else {
-            mMedia = null;
-            mBinding.setIsMediaAvailable(false);
-        }
-    }
-
-    public void updateMediaStatus() {
-        if (mMedia != null) {
-            mBinding.setIsMediaAvailable(mMedia.isPlayed());
-            mBinding.setIsMediaPlaying(mMedia.isPlaying());
-        }
-    }
-
-    private void updateState() {
-        setPrivateMode(mPrivateMode);
-        setIsInsecure(mInsecure);
-        setInsecureVisibility(mInsecureVisibility);
-        mediaAvailabilityChanged(mMediaAvailability);
-        updateMediaStatus();
-        setURL(mUrl);
-    }
-
-    MediaElement.Delegate mMediaDelegate = new MediaElement.Delegate() {
-        @Override
-        public void onPlaybackStateChange(@NonNull MediaElement mediaElement, int state) {
-            switch(state) {
-                case MediaElement.MEDIA_STATE_PLAY:
-                case MediaElement.MEDIA_STATE_PLAYING:
-                    mBinding.setIsMediaAvailable(true);
-                    mBinding.setIsMediaPlaying(true);
-                    break;
-                case MediaElement.MEDIA_STATE_PAUSE:
-                    mBinding.setIsMediaAvailable(true);
-                    mBinding.setIsMediaPlaying(false);
-            }
+            mWidgetManager.updateWidget(TitleBarWidget.this);
         }
     };
-
-    // WidgetManagerDelegate.UpdateListener
-    @Override
-    public void onWidgetUpdate(Widget aWidget) {
-        if (aWidget == mWidgetManager.getFocusedWindow()) {
-            mWidgetManager.updateWidget(this);
-        }
-    }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TooltipWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TooltipWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
@@ -46,7 +47,6 @@ public class TooltipWidget extends UIWidget {
         aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tooltip_z_distance);
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -54,6 +54,13 @@ public class TooltipWidget extends UIWidget {
 
         mLayout = findViewById(R.id.layout);
         mText = findViewById(R.id.tooltipText);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TooltipWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TooltipWidget.java
@@ -15,6 +15,7 @@ public class TooltipWidget extends UIWidget {
 
     protected TextView mText;
     protected ViewGroup mLayout;
+    protected int mLayoutRes;
 
     public TooltipWidget(@NonNull Context aContext, @NonNull  @LayoutRes int layoutRes) {
         super(aContext);
@@ -29,10 +30,8 @@ public class TooltipWidget extends UIWidget {
     }
 
     private void initialize(@NonNull @LayoutRes int layoutRes) {
-        inflate(getContext(), layoutRes, this);
-
-        mLayout = findViewById(R.id.layout);
-        mText = findViewById(R.id.tooltipText);
+        mLayoutRes = layoutRes;
+        updateUI();
     }
 
     @Override
@@ -45,6 +44,16 @@ public class TooltipWidget extends UIWidget {
         aPlacement.anchorX = 0.5f;
         aPlacement.anchorY = 0.5f;
         aPlacement.translationZ = WidgetPlacement.unitFromMeters(getContext(), R.dimen.tooltip_z_distance);
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        inflate(getContext(), mLayoutRes, this);
+
+        mLayout = findViewById(R.id.layout);
+        mText = findViewById(R.id.tooltipText);
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
@@ -29,6 +29,10 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
     private LinearLayout mMultiWindowControlsContainer;
     private boolean mVisible = false;
     private boolean mWidgetAdded = false;
+    private boolean mPrivateMode;
+    private boolean mClearMode;
+    private boolean mMoveLeftEnabled;
+    private boolean mMoveRightEnaabled;
 
     public TopBarWidget(Context aContext) {
         super(aContext);
@@ -52,7 +56,32 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
     }
 
     private void initialize(Context aContext) {
-        inflate(aContext, R.layout.top_bar, this);
+        updateUI();
+
+        mAudio = AudioEngine.fromContext(aContext);
+
+        mWidgetManager.addUpdateListener(this);
+    }
+
+    @Override
+    protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
+        Context context = getContext();
+        aPlacement.width = WidgetPlacement.dpDimension(context, R.dimen.top_bar_width);
+        aPlacement.height = WidgetPlacement.dpDimension(context, R.dimen.top_bar_height);
+        aPlacement.worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) * aPlacement.width/getWorldWidth();
+        aPlacement.translationY = WidgetPlacement.dpDimension(context, R.dimen.top_bar_window_margin);
+        aPlacement.anchorX = 0.5f;
+        aPlacement.anchorY = 0.0f;
+        aPlacement.parentAnchorX = 0.5f;
+        aPlacement.parentAnchorY = 1.0f;
+        aPlacement.opaque = false;
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        inflate(getContext(), R.layout.top_bar, this);
 
         mMultiWindowControlsContainer = findViewById(R.id.multiWindowControlsContainer);
 
@@ -100,23 +129,7 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
             }
         });
 
-        mAudio = AudioEngine.fromContext(aContext);
-
-        mWidgetManager.addUpdateListener(this);
-    }
-
-    @Override
-    protected void initializeWidgetPlacement(WidgetPlacement aPlacement) {
-        Context context = getContext();
-        aPlacement.width = WidgetPlacement.dpDimension(context, R.dimen.top_bar_width);
-        aPlacement.height = WidgetPlacement.dpDimension(context, R.dimen.top_bar_height);
-        aPlacement.worldWidth = WidgetPlacement.floatDimension(getContext(), R.dimen.window_world_width) * aPlacement.width/getWorldWidth();
-        aPlacement.translationY = WidgetPlacement.dpDimension(context, R.dimen.top_bar_window_margin);
-        aPlacement.anchorX = 0.5f;
-        aPlacement.anchorY = 0.0f;
-        aPlacement.parentAnchorX = 0.5f;
-        aPlacement.parentAnchorY = 1.0f;
-        aPlacement.opaque = false;
+        updateState();
     }
 
     @Override
@@ -148,6 +161,8 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
     }
 
     private void setPrivateMode(boolean aPrivateMode) {
+        mPrivateMode = aPrivateMode;
+
         mCloseButton.setPrivateMode(aPrivateMode);
         mMoveLeftButton.setPrivateMode(aPrivateMode);
         mMoveRightButton.setPrivateMode(aPrivateMode);
@@ -172,6 +187,8 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
     }
 
     public void setClearMode(boolean showClear) {
+        mClearMode = showClear;
+
         mMultiWindowControlsContainer.setVisibility(showClear ? GONE : VISIBLE);
         mClearButton.setVisibility(showClear ? VISIBLE : GONE);
     }
@@ -181,11 +198,21 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
     }
 
     public void setMoveLeftButtonEnabled(boolean aEnabled) {
+        mMoveLeftEnabled = aEnabled;
         mMoveLeftButton.setEnabled(aEnabled);
     }
 
     public void setMoveRightButtonEnabled(boolean aEnabled) {
+        mMoveRightEnaabled = aEnabled;
         mMoveRightButton.setEnabled(aEnabled);
+    }
+
+    private void updateState() {
+        setPrivateMode(mPrivateMode);
+        setClearMode(mClearMode);
+        setMoveLeftButtonEnabled(mMoveLeftEnabled);
+        setMoveRightButtonEnabled(mMoveRightEnaabled);
+        setVisible(mVisible);
     }
 
     // WidgetManagerDelegate.UpdateListener

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TopBarWidget.java
@@ -6,33 +6,31 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.util.AttributeSet;
-import android.widget.LinearLayout;
+import android.view.LayoutInflater;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+import androidx.databinding.ObservableBoolean;
+import androidx.lifecycle.Observer;
+import androidx.lifecycle.ViewModelProvider;
 
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.audio.AudioEngine;
-import org.mozilla.vrbrowser.ui.views.UIButton;
-import org.mozilla.vrbrowser.ui.views.UITextButton;
+import org.mozilla.vrbrowser.databinding.TopBarBinding;
+import org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel;
 
-public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.UpdateListener {
+public class TopBarWidget extends UIWidget {
 
-    private UIButton mCloseButton;
-    private UIButton mMoveLeftButton;
-    private UIButton mMoveRightButton;
-    private UITextButton mClearButton;
+    private WindowViewModel mViewModel;
+    private TopBarBinding mBinding;
     private AudioEngine mAudio;
     private WindowWidget mAttachedWindow;
     private TopBarWidget.Delegate mDelegate;
-    private LinearLayout mMultiWindowControlsContainer;
-    private boolean mVisible = false;
     private boolean mWidgetAdded = false;
-    private boolean mPrivateMode;
-    private boolean mClearMode;
-    private boolean mMoveLeftEnabled;
-    private boolean mMoveRightEnaabled;
 
     public TopBarWidget(Context aContext) {
         super(aContext);
@@ -56,11 +54,9 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
     }
 
     private void initialize(Context aContext) {
-        updateUI();
-
         mAudio = AudioEngine.fromContext(aContext);
 
-        mWidgetManager.addUpdateListener(this);
+        updateUI();
     }
 
     @Override
@@ -77,16 +73,17 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
         aPlacement.opaque = false;
     }
 
-    @Override
-    public void updateUI() {
+    private void updateUI() {
         removeAllViews();
 
-        inflate(getContext(), R.layout.top_bar, this);
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
-        mMultiWindowControlsContainer = findViewById(R.id.multiWindowControlsContainer);
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.top_bar, this, true);
+        mBinding.setLifecycleOwner((VRBrowserActivity)getContext());
+        mBinding.setViewmodel(mViewModel);
 
-        mCloseButton = findViewById(R.id.closeWindowButton);
-        mCloseButton.setOnClickListener(view -> {
+        mBinding.closeWindowButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -96,8 +93,7 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
             }
         });
 
-        mMoveLeftButton = findViewById(R.id.moveWindowLeftButton);
-        mMoveLeftButton.setOnClickListener(view -> {
+        mBinding.moveWindowLeftButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -107,8 +103,7 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
             }
         });
 
-        mMoveRightButton = findViewById(R.id.moveWindowRightButton);
-        mMoveRightButton.setOnClickListener(view -> {
+        mBinding.moveWindowRightButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -118,8 +113,7 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
             }
         });
 
-        mClearButton = findViewById(R.id.clearButton);
-        mClearButton.setOnClickListener(view -> {
+        mBinding.clearButton.setOnClickListener(view -> {
             view.requestFocusFromTouch();
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -128,20 +122,23 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
                 mDelegate.onCloseClicked(TopBarWidget.this);
             }
         });
-
-        updateState();
     }
 
     @Override
-    public void releaseWidget() {
-        mWidgetManager.removeUpdateListener(this);
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
 
-        super.releaseWidget();
+        updateUI();
     }
 
     @Override
     public void detachFromWindow() {
         mAttachedWindow = null;
+
+        if (mViewModel != null) {
+            mViewModel.getIsTopBarVisible().removeObserver(mIsVisible);
+            mViewModel = null;
+        }
     }
 
     @Override
@@ -149,79 +146,46 @@ public class TopBarWidget extends UIWidget implements WidgetManagerDelegate.Upda
         if (mAttachedWindow == aWindow) {
             return;
         }
+        detachFromWindow();
+
         mWidgetPlacement.parentHandle = aWindow.getHandle();
         mAttachedWindow = aWindow;
 
-        setPrivateMode(aWindow.getSession().isPrivateMode());
+        // ModelView creation and observers setup
+        mViewModel = new ViewModelProvider(
+                (VRBrowserActivity)getContext(),
+                ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
+                .get(String.valueOf(mAttachedWindow.hashCode()), WindowViewModel.class);
 
+        mBinding.setViewmodel(mViewModel);
+
+        mViewModel.getIsTopBarVisible().observe((VRBrowserActivity)getContext(), mIsVisible);
     }
 
     public @Nullable WindowWidget getAttachedWindow() {
         return mAttachedWindow;
     }
 
-    private void setPrivateMode(boolean aPrivateMode) {
-        mPrivateMode = aPrivateMode;
+    @Override
+    public void releaseWidget() {
+        detachFromWindow();
 
-        mCloseButton.setPrivateMode(aPrivateMode);
-        mMoveLeftButton.setPrivateMode(aPrivateMode);
-        mMoveRightButton.setPrivateMode(aPrivateMode);
-        mCloseButton.setBackground(getContext().getDrawable(aPrivateMode ? R.drawable.fullscreen_button_private : R.drawable.fullscreen_button));
-        mMoveLeftButton.setBackground(getContext().getDrawable(aPrivateMode ? R.drawable.fullscreen_button_private_first : R.drawable.fullscreen_button_first));
-        mMoveRightButton.setBackground(getContext().getDrawable(aPrivateMode ? R.drawable.fullscreen_button_private_last : R.drawable.fullscreen_button_last));
+        mAttachedWindow = null;
+        super.releaseWidget();
     }
 
-    @Override
-    public void setVisible(boolean aIsVisible) {
-        if (mVisible == aIsVisible ||  mWidgetManager == null) {
-            return;
-        }
-        mVisible = aIsVisible;
-        getPlacement().visible = aIsVisible;
+    Observer<ObservableBoolean> mIsVisible = isVisible -> {
+        mWidgetPlacement.visible = isVisible.get();
         if (!mWidgetAdded) {
-            mWidgetManager.addWidget(this);
+            mWidgetManager.addWidget(TopBarWidget.this);
             mWidgetAdded = true;
         } else {
-            mWidgetManager.updateWidget(this);
+            mWidgetManager.updateWidget(TopBarWidget.this);
         }
-    }
-
-    public void setClearMode(boolean showClear) {
-        mClearMode = showClear;
-
-        mMultiWindowControlsContainer.setVisibility(showClear ? GONE : VISIBLE);
-        mClearButton.setVisibility(showClear ? VISIBLE : GONE);
-    }
+    };
 
     public void setDelegate(TopBarWidget.Delegate aDelegate) {
         mDelegate = aDelegate;
-    }
-
-    public void setMoveLeftButtonEnabled(boolean aEnabled) {
-        mMoveLeftEnabled = aEnabled;
-        mMoveLeftButton.setEnabled(aEnabled);
-    }
-
-    public void setMoveRightButtonEnabled(boolean aEnabled) {
-        mMoveRightEnaabled = aEnabled;
-        mMoveRightButton.setEnabled(aEnabled);
-    }
-
-    private void updateState() {
-        setPrivateMode(mPrivateMode);
-        setClearMode(mClearMode);
-        setMoveLeftButtonEnabled(mMoveLeftEnabled);
-        setMoveRightButtonEnabled(mMoveRightEnaabled);
-        setVisible(mVisible);
-    }
-
-    // WidgetManagerDelegate.UpdateListener
-
-    @Override
-    public void onWidgetUpdate(Widget aWidget) {
-        if (aWidget != mAttachedWindow) {
-            return;
-        }
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
@@ -17,15 +17,15 @@ import android.view.View;
 import android.view.ViewParent;
 import android.widget.FrameLayout;
 
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.SettingsStore;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
-
-import androidx.annotation.IntDef;
-import androidx.annotation.NonNull;
 
 public abstract class UIWidget extends FrameLayout implements Widget {
 
@@ -429,4 +429,6 @@ public abstract class UIWidget extends FrameLayout implements Widget {
         return mWorldWidth;
     }
 
+    @Override
+    public abstract void updateUI();
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/UIWidget.java
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
@@ -57,6 +58,7 @@ public abstract class UIWidget extends FrameLayout implements Widget {
         initialize();
     }
 
+
     public UIWidget(Context aContext, AttributeSet aAttrs) {
         super(aContext, aAttrs);
         initialize();
@@ -92,6 +94,10 @@ public abstract class UIWidget extends FrameLayout implements Widget {
 
     @Override
     public void onResume() {
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
     }
 
     @Override
@@ -429,6 +435,4 @@ public abstract class UIWidget extends FrameLayout implements Widget {
         return mWorldWidth;
     }
 
-    @Override
-    public abstract void updateUI();
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Widget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Widget.java
@@ -36,4 +36,5 @@ public interface Widget {
     default void detachFromWindow() {}
     default void attachToWindow(@NonNull WindowWidget window) {}
     int getBorderWidth();
+    void updateUI();
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Widget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Widget.java
@@ -5,6 +5,7 @@
 
 package org.mozilla.vrbrowser.ui.widgets;
 
+import android.content.res.Configuration;
 import android.graphics.SurfaceTexture;
 import android.view.MotionEvent;
 import android.view.Surface;
@@ -17,6 +18,7 @@ public interface Widget {
 
     void onPause();
     void onResume();
+    void onConfigurationChanged(Configuration newConfig);
     void setSurfaceTexture(SurfaceTexture aTexture, final int aWidth, final int aHeight, Runnable aFirstDrawCallback);
     void setSurface(Surface aSurface, final int aWidth, final int aHeight, Runnable aFirstDrawCallback);
     void resizeSurface(final int aWidth, final int aHeight);
@@ -36,5 +38,4 @@ public interface Widget {
     default void detachFromWindow() {}
     default void attachToWindow(@NonNull WindowWidget window) {}
     int getBorderWidth();
-    void updateUI();
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
@@ -1,5 +1,6 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
+import android.content.Context;
 import android.view.View;
 
 import androidx.annotation.IntDef;
@@ -88,4 +89,5 @@ public interface WidgetManagerDelegate {
     void addConnectivityListener(ConnectivityReceiver.Delegate aListener);
     void removeConnectivityListener(ConnectivityReceiver.Delegate aListener);
     void saveState();
+    void updateLocale(@NonNull Context context);
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1219,6 +1219,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             if (callback != null) {
                 callback.onButtonClicked(index);
             }
+            mAlertDialog.releaseWidget();
+            mAlertDialog = null;
         });
         mAlertDialog.show(REQUEST_FOCUS);
     }
@@ -1226,7 +1228,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void showConfirmPrompt(String title, @NonNull String msg, @NonNull String[] btnMsg, @Nullable PromptDialogWidget.Delegate callback) {
         if (mConfirmDialog == null) {
             mConfirmDialog = new PromptDialogWidget(getContext());
-            mAlertDialog.setButtons(new int[] {
+            mConfirmDialog.setButtons(new int[] {
                     R.string.cancel_button,
                     R.string.ok_button
             });
@@ -1236,11 +1238,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mConfirmDialog.setTitle(title);
         mConfirmDialog.setBody(msg);
         mConfirmDialog.setButtons(btnMsg);
-        mAlertDialog.setButtonsDelegate(index -> {
-            mAlertDialog.hide(REMOVE_WIDGET);
+        mConfirmDialog.setButtonsDelegate(index -> {
+            mConfirmDialog.hide(REMOVE_WIDGET);
             if (callback != null) {
                 callback.onButtonClicked(index);
             }
+            mConfirmDialog.releaseWidget();
+            mConfirmDialog = null;
         });
         mConfirmDialog.show(REQUEST_FOCUS);
     }
@@ -1259,12 +1263,15 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             if (buttonsCallback != null) {
                 buttonsCallback.onButtonClicked(index);
             }
+            mAppDialog.releaseWidget();
         });
         mAppDialog.setLinkDelegate(() -> {
             mAppDialog.hide(REMOVE_WIDGET);
             if (linkCallback != null) {
                 linkCallback.run();
             }
+            mAppDialog.releaseWidget();
+            mAppDialog = null;
         });
         mAppDialog.show(REQUEST_FOCUS);
     }
@@ -1769,4 +1776,17 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         hideContextMenus();
     }
 
+    @Override
+    public void updateUI() {
+        mHistoryView.updateUI();
+        mBookmarksView.updateUI();
+
+        if (mView != null) {
+            View temp = mView;
+            unsetView(mView, false);
+            setView(temp, false);
+        }
+
+        updateTitleBar();
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.ui.widgets;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.PointF;
@@ -27,12 +28,17 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.UiThread;
+import androidx.lifecycle.ViewModelProvider;
 
+import org.mozilla.geckoview.AllowOrDeny;
 import org.mozilla.geckoview.GeckoResult;
 import org.mozilla.geckoview.GeckoSession;
+import org.mozilla.geckoview.MediaElement;
 import org.mozilla.geckoview.PanZoomController;
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.VRBrowserApplication;
+import org.mozilla.vrbrowser.browser.Media;
 import org.mozilla.vrbrowser.browser.PromptDelegate;
 import org.mozilla.vrbrowser.browser.SessionChangeListener;
 import org.mozilla.vrbrowser.browser.SettingsStore;
@@ -45,6 +51,7 @@ import org.mozilla.vrbrowser.ui.adapters.Bookmark;
 import org.mozilla.vrbrowser.ui.callbacks.BookmarksCallback;
 import org.mozilla.vrbrowser.ui.callbacks.HistoryCallback;
 import org.mozilla.vrbrowser.ui.callbacks.LibraryItemContextMenuClickCallback;
+import org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel;
 import org.mozilla.vrbrowser.ui.views.BookmarksView;
 import org.mozilla.vrbrowser.ui.views.HistoryView;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.ClearHistoryDialogWidget;
@@ -55,7 +62,6 @@ import org.mozilla.vrbrowser.ui.widgets.menus.LibraryMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -74,16 +80,6 @@ import static org.mozilla.vrbrowser.utils.ServoUtils.isInstanceOfServoSession;
 public class WindowWidget extends UIWidget implements SessionChangeListener,
         GeckoSession.ContentDelegate, GeckoSession.NavigationDelegate, VideoAvailabilityListener,
         GeckoSession.HistoryDelegate, GeckoSession.ProgressDelegate, GeckoSession.SelectionActionDelegate {
-
-    public interface HistoryViewDelegate {
-        default void onHistoryViewShown(WindowWidget aWindow) {}
-        default void onHistoryViewHidden(WindowWidget aWindow) {}
-    }
-
-    public interface BookmarksViewDelegate {
-        default void onBookmarksShown(WindowWidget aWindow) {}
-        default void onBookmarksHidden(WindowWidget aWindow) {}
-    }
 
     @IntDef(value = { SESSION_RELEASE_DISPLAY, SESSION_DO_NOT_RELEASE_DISPLAY})
     public @interface OldSessionDisplayAction {}
@@ -116,8 +112,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private int mWindowId;
     private BookmarksView mBookmarksView;
     private HistoryView mHistoryView;
-    private ArrayList<BookmarksViewDelegate> mBookmarksViewListeners;
-    private ArrayList<HistoryViewDelegate> mHistoryViewListeners;
     private Windows.WindowPlacement mWindowPlacement = Windows.WindowPlacement.FRONT;
     private Windows.WindowPlacement mWindowPlacementBeforeFullscreen = Windows.WindowPlacement.FRONT;
     private float mMaxWindowScale = 3;
@@ -136,6 +130,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private boolean mCaptureOnPageStop;
     private PromptDelegate mPromptDelegate;
     private Executor mUIThreadExecutor;
+    private WindowViewModel mViewModel;
 
     public interface WindowListener {
         default void onFocusRequest(@NonNull WindowWidget aWindow) {}
@@ -163,6 +158,13 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mWidgetManager = (WidgetManagerDelegate) aContext;
         mBorderWidth = SettingsStore.getInstance(aContext).getTransparentBorderWidth();
 
+        // ModelView creation and observers setup
+        mViewModel = new ViewModelProvider(
+                (VRBrowserActivity)getContext(),
+                ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
+                .get(String.valueOf(hashCode()), WindowViewModel.class);
+        mViewModel.setIsPrivateSession(mSession.isPrivateMode());
+
         mUIThreadExecutor = ((VRBrowserApplication)getContext().getApplicationContext()).getExecutors().mainThread();
 
         mListeners = new CopyOnWriteArrayList<>();
@@ -170,11 +172,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mBookmarksView = new BookmarksView(aContext);
         mBookmarksView.addBookmarksListener(mBookmarksListener);
-        mBookmarksViewListeners = new ArrayList<>();
 
         mHistoryView = new HistoryView(aContext);
         mHistoryView.addHistoryListener(mHistoryListener);
-        mHistoryViewListeners = new ArrayList<>();
 
         mHandle = ((WidgetManagerDelegate)aContext).newWidgetHandle();
         mWidgetPlacement = new WidgetPlacement(aContext);
@@ -308,6 +308,22 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
     }
 
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        mHistoryView.updateUI();
+        mBookmarksView.updateUI();
+
+        if (mView != null) {
+            View temp = mView;
+            unsetView(mView, false);
+            setView(temp, false);
+        }
+
+        mViewModel.refresh();
+    }
+
     public void close() {
         TelemetryWrapper.closeWindowEvent(mWindowId);
         GleanMetricsService.closeWindowEvent(mWindowId);
@@ -315,12 +331,16 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         releaseWidget();
         mBookmarksView.onDestroy();
         mHistoryView.onDestroy();
+        mViewModel.setIsTopBarVisible(false);
+        mViewModel.setIsTitleBarVisible(false);
         SessionStore.get().destroySession(mSession);
         if (mTopBar != null) {
             mWidgetManager.removeWidget(mTopBar);
+            mTopBar.setDelegate((TopBarWidget.Delegate) null);
         }
         if (mTitleBar != null) {
             mWidgetManager.removeWidget(mTitleBar);
+            mTitleBar.setDelegate((TitleBarWidget.Delegate) null);
         }
         mListeners.clear();
     }
@@ -411,22 +431,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         return mWidgetPlacement.height;
     }
 
-    public void addBookmarksViewListener(@NonNull BookmarksViewDelegate listener) {
-        mBookmarksViewListeners.add(listener);
-    }
-
-    public void removeBookmarksViewListener(@NonNull BookmarksViewDelegate listener) {
-        mBookmarksViewListeners.remove(listener);
-    }
-
-    public void addHistoryViewListener(@NonNull HistoryViewDelegate listener) {
-        mHistoryViewListeners.add(listener);
-    }
-
-    public void removeHistoryViewListener(@NonNull HistoryViewDelegate listener) {
-        mHistoryViewListeners.remove(listener);
-    }
-
     public void switchBookmarks() {
         if (isHistoryVisible()) {
             hideHistory(false);
@@ -448,13 +452,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (mView == null) {
             setView(mBookmarksView, switchSurface);
             mBookmarksView.onShow();
-            for (BookmarksViewDelegate listener : mBookmarksViewListeners) {
-                listener.onBookmarksShown(this);
-            }
+            mViewModel.setIsBookmarksVisible(true);
             mIsBookmarksVisible = true;
         }
-
-        updateTitleBar();
     }
 
     public void hideBookmarks() {
@@ -464,9 +464,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void hideBookmarks(boolean switchSurface) {
         if (mView != null) {
             unsetView(mBookmarksView, switchSurface);
-            for (BookmarksViewDelegate listener : mBookmarksViewListeners) {
-                listener.onBookmarksHidden(this);
-            }
+            mViewModel.setIsBookmarksVisible(false);
             mIsBookmarksVisible = false;
         }
     }
@@ -500,9 +498,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (mView == null) {
             setView(mHistoryView, switchSurface);
             mHistoryView.onShow();
-            for (HistoryViewDelegate listener : mHistoryViewListeners) {
-                listener.onHistoryViewShown(this);
-            }
+            mViewModel.setIsHistoryVisible(true);
             mIsHistoryVisible = true;
         }
     }
@@ -514,9 +510,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void hideHistory(boolean switchSurface) {
         if (mView != null) {
             unsetView(mHistoryView, switchSurface);
-            for (HistoryViewDelegate listener : mHistoryViewListeners) {
-                listener.onHistoryViewHidden(this);
-            }
+            mViewModel.setIsHistoryVisible(false);
             mIsHistoryVisible = false;
         }
     }
@@ -580,12 +574,18 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mWindowPlacement = aPlacement;
 
+        mViewModel.setPlacement(mWindowPlacement);
+
         if (mActive) {
             TelemetryWrapper.activePlacementEvent(mWindowPlacement.getValue(), true);
         }
     }
 
-    public @NonNull Windows.WindowPlacement getmWindowPlacementBeforeFullscreen() {
+    public void setIsOnlyWindow(boolean isOnlyWindow) {
+        mViewModel.setIsOnlyWindow(isOnlyWindow);
+    }
+
+    public @NonNull Windows.WindowPlacement getWindowPlacementBeforeFullscreen() {
         return mWindowPlacementBeforeFullscreen;
     }
 
@@ -626,59 +626,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 session.getTextInput().setView(this);
             }
             mSession.updateLastUse();
-        } else {
-            updateTitleBar();
         }
 
-        updateTitleBarMediaStatus();
         hideContextMenus();
 
         TelemetryWrapper.activePlacementEvent(mWindowPlacement.getValue(), mActive);
         updateBorder();
-    }
 
-    private void updateTitleBar() {
-        if (isBookmarksVisible()) {
-            updateTitleBarUrl(getResources().getString(R.string.url_bookmarks_title));
-
-        } else if (isHistoryVisible()) {
-                updateTitleBarUrl(getResources().getString(R.string.url_history_title));
-
-        } else {
-            updateTitleBarUrl(mSession.getCurrentUri());
-        }
-    }
-
-    private void updateTitleBarUrl(String url) {
-        if (mTitleBar != null && url != null) {
-            mTitleBar.setIsInsecure(!mSession.isSecure());
-            if (url.startsWith("data") && mSession.isPrivateMode()) {
-                mTitleBar.setInsecureVisibility(GONE);
-                mTitleBar.setURL(getResources().getString(R.string.private_browsing_title));
-
-            } else if (url.equals(mSession.getHomeUri())) {
-                mTitleBar.setInsecureVisibility(GONE);
-                mTitleBar.setURL(getResources().getString(R.string.url_home_title, getResources().getString(R.string.app_name)));
-
-            } else if (url.equals(getResources().getString(R.string.url_bookmarks_title)) ||
-                    url.equals(getResources().getString(R.string.url_history_title))) {
-                mTitleBar.setInsecureVisibility(GONE);
-                mTitleBar.setURL(url);
-
-            } else if (url.equals(getResources().getString(R.string.about_blank))) {
-                mTitleBar.setInsecureVisibility(GONE);
-                mTitleBar.setURL("");
-
-            } else {
-                mTitleBar.setURL(url);
-            }
-        }
-    }
-
-    public void updateTitleBarMediaStatus() {
-        if (mTitleBar != null) {
-            mTitleBar.updateMediaStatus();
-        }
+        mViewModel.setIsActiveWindow(active);
     }
 
     @Nullable
@@ -695,6 +650,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             mTopBar = aWidget;
             mTopBar.attachToWindow(this);
         }
+    }
+
+    public void setResizeMode(boolean resizing) {
+        mViewModel.setIsResizeMode(resizing);
     }
 
     public TitleBarWidget getTitleBar() {
@@ -894,6 +853,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void setIsFullScreen(boolean isFullScreen) {
         if (isFullScreen != mIsFullScreen) {
             mIsFullScreen = isFullScreen;
+            mViewModel.setIsFullscreen(isFullScreen);
             for (WindowListener listener: mListeners) {
                 listener.onFullScreen(this, isFullScreen);
             }
@@ -1021,6 +981,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (!aVisible) {
             clearFocus();
         }
+
+        mViewModel.setIsWindowVisible(aVisible);
     }
 
     @Override
@@ -1045,6 +1007,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             }
 
             mSession = aSession;
+            mViewModel.setIsPrivateSession(mSession.isPrivateMode());
+
             if (oldSession != null) {
                 onCurrentSessionChange(oldSession.getGeckoSession(), aSession.getGeckoSession());
             } else {
@@ -1084,12 +1048,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         callSurfaceChanged();
         aSession.getTextInput().setView(this);
 
-        boolean isPrivateMode  = aSession.getSettings().getUsePrivateMode();
-        if (isPrivateMode) {
-            setPrivateBrowsingEnabled(true);
-        } else {
-            setPrivateBrowsingEnabled(false);
-        }
+        mViewModel.setIsPrivateSession(aSession.getSettings().getUsePrivateMode());
+
         waitForFirstPaint();
     }
 
@@ -1198,9 +1158,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             GeckoSession session = mSession.getGeckoSession();
             return (session != null) && session.getPanZoomController().onMotionEvent(aEvent) == PanZoomController.INPUT_RESULT_HANDLED;
         }
-    }
-
-    private void setPrivateBrowsingEnabled(boolean isEnabled) {
     }
 
     public void showAlert(String title, @NonNull String msg, @Nullable PromptDialogWidget.Delegate callback) {
@@ -1539,22 +1496,68 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     // VideoAvailabilityListener
 
+    private Media mMedia;
+
     @Override
     public void onVideoAvailabilityChanged(boolean aVideosAvailable) {
-        if (mTitleBar != null) {
-            mTitleBar.mediaAvailabilityChanged(aVideosAvailable);
+        boolean mediaAvailable;
+        if (mSession != null) {
+            if (mMedia != null) {
+                mMedia.removeMediaListener(mMediaDelegate);
+            }
+
+            mMedia = mSession.getFullScreenVideo();
+            if (aVideosAvailable && mMedia != null) {
+                mMedia.addMediaListener(mMediaDelegate);
+                mediaAvailable = true;
+
+            } else {
+                mediaAvailable = false;
+            }
+
+        } else {
+            mediaAvailable = false;
         }
 
-        for (WindowListener listener: mListeners) {
-            listener.onVideoAvailabilityChanged(this);
+        if (mediaAvailable) {
+            if (mSession.getFullScreenVideo().isPlayed()) {
+                mViewModel.setIsMediaAvailable(true);
+                mViewModel.setIsMediaPlaying(true);
+            }
+
+        } else {
+            mMedia = null;
+            mViewModel.setIsMediaAvailable(false);
+            mViewModel.setIsMediaPlaying(false);
         }
     }
+
+    MediaElement.Delegate mMediaDelegate = new MediaElement.Delegate() {
+        @Override
+        public void onPlaybackStateChange(@NonNull MediaElement mediaElement, int state) {
+            switch(state) {
+                case MediaElement.MEDIA_STATE_PLAY:
+                case MediaElement.MEDIA_STATE_PLAYING:
+                    mViewModel.setIsMediaAvailable(true);
+                    mViewModel.setIsMediaPlaying(true);
+                    break;
+                case MediaElement.MEDIA_STATE_PAUSE:
+                    mViewModel.setIsMediaAvailable(true);
+                    mViewModel.setIsMediaPlaying(false);
+                    break;
+                case MediaElement.MEDIA_STATE_ABORT:
+                case MediaElement.MEDIA_STATE_EMPTIED:
+                    mViewModel.setIsMediaAvailable(false);
+                    mViewModel.setIsMediaPlaying(false);
+            }
+        }
+    };
 
     // GeckoSession.NavigationDelegate
 
 
     @Override
-    public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String s) {
+    public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String aUri) {
         mCaptureOnPageStop = true;
 
         if (isHistoryVisible()) {
@@ -1564,6 +1567,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         if (isBookmarksVisible()) {
             hideBookmarks();
         }
+
+        mViewModel.setUrl(aUri);
+        mViewModel.setIsLoading(true);
     }
 
     @Override
@@ -1572,6 +1578,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             mCaptureOnPageStop = false;
             captureImage();
         }
+
+        mViewModel.setIsLoading(false);
     }
 
     public void captureImage() {
@@ -1580,7 +1588,45 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public void onLocationChange(@NonNull GeckoSession session, @Nullable String url) {
-        updateTitleBarUrl(url);
+        mViewModel.setUrl(url);
+    }
+
+    @Override
+    public void onCanGoBack(@NonNull GeckoSession geckoSession, boolean canGoBack) {
+        mViewModel.setCanGoBack(canGoBack);
+    }
+
+    @Override
+    public void onCanGoForward(@NonNull GeckoSession geckoSession, boolean canGoForward) {
+        mViewModel.setCanGoForward(canGoForward);
+    }
+
+    @Override
+    public @Nullable GeckoResult<AllowOrDeny> onLoadRequest(GeckoSession aSession, @NonNull LoadRequest aRequest) {
+        final GeckoResult<AllowOrDeny> result = new GeckoResult<>();
+
+        Uri uri = Uri.parse(aRequest.uri);
+        if ("file".equalsIgnoreCase(uri.getScheme()) &&
+                !mWidgetManager.isPermissionGranted(android.Manifest.permission.READ_EXTERNAL_STORAGE)) {
+            mWidgetManager.requestPermission(
+                    aRequest.uri,
+                    android.Manifest.permission.READ_EXTERNAL_STORAGE,
+                    new GeckoSession.PermissionDelegate.Callback() {
+                        @Override
+                        public void grant() {
+                            result.complete(AllowOrDeny.ALLOW);
+                        }
+
+                        @Override
+                        public void reject() {
+                            result.complete(AllowOrDeny.DENY);
+                        }
+                    });
+            return result;
+        }
+
+        result.complete(AllowOrDeny.ALLOW);
+        return result;
     }
 
     // GeckoSession.HistoryDelegate
@@ -1713,9 +1759,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     @Override
     public void onSecurityChange(GeckoSession geckoSession, SecurityInformation securityInformation) {
-        if (mTitleBar != null) {
-            mTitleBar.setIsInsecure(!securityInformation.isSecure);
-        }
+        mViewModel.setIsInsecure(!securityInformation.isSecure);
     }
 
     // GeckoSession.SelectionActionDelegate
@@ -1776,17 +1820,4 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         hideContextMenus();
     }
 
-    @Override
-    public void updateUI() {
-        mHistoryView.updateUI();
-        mBookmarksView.updateUI();
-
-        if (mView != null) {
-            View temp = mView;
-            unsetView(mView, false);
-            setView(temp, false);
-        }
-
-        updateTitleBar();
-    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1309,6 +1309,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mNoInternetDialog.setBody(R.string.no_internet_message);
             mNoInternetDialog.setButtonsDelegate(index -> {
                 mNoInternetDialog.hide(UIWidget.REMOVE_WIDGET);
+                mNoInternetDialog.releaseWidget();
+                mNoInternetDialog = null;
             });
         }
 
@@ -1317,6 +1319,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         } else if (connected && mNoInternetDialog.isVisible()) {
             mNoInternetDialog.hide(UIWidget.REMOVE_WIDGET);
+            mNoInternetDialog.releaseWidget();
+            mNoInternetDialog = null;
         }
     };
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -65,7 +65,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             WidgetPlacement widgetPlacement;
             if (aWindow.isFullScreen()) {
                 widgetPlacement = aWindow.getBeforeFullscreenPlacement();
-                placement = aWindow.getmWindowPlacementBeforeFullscreen();
+                placement = aWindow.getWindowPlacementBeforeFullscreen();
             } else if (aWindow.isResizing()) {
                 widgetPlacement = aWindow.getBeforeResizePlacement();
                 placement = aWindow.getWindowPlacement();
@@ -156,7 +156,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         try (Writer writer = new FileWriter(file)) {
             WindowsState state = new WindowsState();
             state.privateMode = mPrivateMode;
-            state.focusedWindowPlacement = mFocusedWindow.isFullScreen() ?  mFocusedWindow.getmWindowPlacementBeforeFullscreen() : mFocusedWindow.getWindowPlacement();
+            state.focusedWindowPlacement = mFocusedWindow.isFullScreen() ?  mFocusedWindow.getWindowPlacementBeforeFullscreen() : mFocusedWindow.getWindowPlacement();
             ArrayList<Session> sessions = SessionStore.get().getSortedSessions(false);
             state.tabs = sessions.stream().map(Session::getSessionState).collect(Collectors.toCollection(ArrayList::new));
             for (WindowWidget window : mRegularWindows) {
@@ -207,7 +207,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         return mFocusedWindow;
     }
 
-    @NonNull
+    @Nullable
     public WindowWidget addWindow() {
         if (getCurrentWindows().size() >= MAX_WINDOWS) {
             return null;
@@ -389,11 +389,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mFocusedWindow = aWindow;
             if (prev != null && getCurrentWindows().contains(prev)) {
                 prev.setActiveWindow(false);
-                if (prev.isVisible()) {
-                    prev.getTitleBar().setVisible(true);
-                }
             }
-            mFocusedWindow.getTitleBar().setVisible(false);
             mFocusedWindow.setActiveWindow(true);
             if (mDelegate != null) {
                 mDelegate.onFocusedWindowChanged(mFocusedWindow, prev);
@@ -518,7 +514,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
 
         if (mPrivateWindows.size() == 0) {
             WindowWidget window = addWindow();
-            window.loadHome();
+            if (window != null) {
+                window.loadHome();
+            }
 
         } else {
             focusWindow(getWindowWithPlacement(mPrivateWindowPlacement));
@@ -662,11 +660,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         mWidgetManager.removeWidget(aWindow);
         mRegularWindows.remove(aWindow);
         mPrivateWindows.remove(aWindow);
-        aWindow.getTopBar().setVisible(false);
-        aWindow.getTopBar().setDelegate((TopBarWidget.Delegate) null);
         aWindow.removeWindowListener(this);
-        aWindow.getTitleBar().setVisible(false);
-        aWindow.getTitleBar().setDelegate((TitleBarWidget.Delegate) null);
         aWindow.close();
         updateMaxWindowScales();
         updateCurvedMode(true);
@@ -683,8 +677,6 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             setFirstPaint(aWindow, aWindow.getSession());
         }
         aWindow.setVisible(aVisible);
-        aWindow.getTopBar().setVisible(aVisible);
-        aWindow.getTitleBar().setVisible(aVisible);
     }
 
     private void placeWindow(@NonNull WindowWidget aWindow, WindowPlacement aPosition) {
@@ -804,54 +796,17 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             frontWindow.getPlacement().parentHandle = -1;
         }
 
-        updateTopBars();
-        updateTitleBars();
-
         ArrayList<WindowWidget> windows = getCurrentWindows();
+        for (WindowWidget window: windows) {
+            window.setIsOnlyWindow(windows.size() == 1);
+        }
+
         // Sort windows so frontWindow is the first one. Required for proper native matrix updates.
         windows.sort((o1, o2) -> o1 == frontWindow ? -1 : 0);
         for (WindowWidget window: getCurrentWindows()) {
             mWidgetManager.updateWidget(window);
             mWidgetManager.updateWidget(window.getTopBar());
             mWidgetManager.updateWidget(window.getTitleBar());
-        }
-    }
-
-    private void updateTopBars() {
-        ArrayList<WindowWidget> windows = getCurrentWindows();
-        WindowWidget leftWindow = getLeftWindow();
-        WindowWidget rightWindow = getRightWindow();
-        boolean visible = mFullscreenWindow == null && (windows.size() > 1 || isInPrivateMode());
-        for (WindowWidget window: windows) {
-            window.getTopBar().setVisible(visible);
-            window.getTopBar().setClearMode((windows.size() == 1 && isInPrivateMode()));
-            if (visible) {
-                window.getTopBar().setMoveLeftButtonEnabled(window != leftWindow);
-                window.getTopBar().setMoveRightButtonEnabled(window != rightWindow);
-            }
-        }
-        if (isInPrivateMode() && mPrivateWindows.size() == 1) {
-            if (mFocusedWindow != null) {
-                mFocusedWindow.getTopBar().setMoveLeftButtonEnabled(false);
-                mFocusedWindow.getTopBar().setMoveRightButtonEnabled(false);
-            }
-        }
-    }
-
-    private void updateTitleBars() {
-        ArrayList<WindowWidget> windows = getCurrentWindows();
-        for (WindowWidget window: windows) {
-            if (window == mFocusedWindow) {
-                window.getTitleBar().setVisible(false);
-
-            } else {
-                if (mFullscreenWindow != null) {
-                    window.getTitleBar().setVisible(false);
-
-                } else {
-                    window.getTitleBar().setVisible(true);
-                }
-            }
         }
     }
 
@@ -884,7 +839,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     public void enterResizeMode() {
         if (mFullscreenWindow == null) {
             for (WindowWidget window : getCurrentWindows()) {
-                window.getTopBar().setVisible(false);
+                window.setResizeMode(true);
             }
         }
     }
@@ -892,9 +847,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     public void exitResizeMode() {
         if (mFullscreenWindow == null) {
             for (WindowWidget window : getCurrentWindows()) {
-                if (getCurrentWindows().size() > 1 || isInPrivateMode()) {
-                    window.getTopBar().setVisible(true);
-                }
+                window.setResizeMode(false);
             }
         }
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/ClearHistoryDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/ClearHistoryDialogWidget.java
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.ui.widgets.dialogs;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.LayoutInflater;
 
 import androidx.databinding.DataBindingUtil;
@@ -44,6 +45,13 @@ public class ClearHistoryDialogWidget extends SettingDialogWidget {
         super.show(aShowFlags);
 
         mClearHistoryBinding.clearHistoryRadio.setChecked(0, false);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/ClearHistoryDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/ClearHistoryDialogWidget.java
@@ -36,7 +36,21 @@ public class ClearHistoryDialogWidget extends SettingDialogWidget {
     protected void initialize(Context aContext) {
         super.initialize(aContext);
 
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+
+    }
+
+    @Override
+    public void show(int aShowFlags) {
+        super.show(aShowFlags);
+
+        mClearHistoryBinding.clearHistoryRadio.setChecked(0, false);
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mClearHistoryBinding = DataBindingUtil.inflate(inflater, R.layout.clear_history_dialog, mBinding.content, true);
@@ -74,12 +88,5 @@ public class ClearHistoryDialogWidget extends SettingDialogWidget {
             SessionStore.get().purgeSessionHistory();
             onDismiss();
         }));
-    }
-
-    @Override
-    public void show(int aShowFlags) {
-        super.show(aShowFlags);
-
-        mClearHistoryBinding.clearHistoryRadio.setChecked(0, false);
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PromptDialogWidget.java
@@ -40,7 +40,14 @@ public class PromptDialogWidget extends UIDialog {
     }
 
     protected void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.prompt_dialog, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PromptDialogWidget.java
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.ui.widgets.dialogs;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -43,7 +44,6 @@ public class PromptDialogWidget extends UIDialog {
         updateUI();
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -62,6 +62,13 @@ public class PromptDialogWidget extends UIDialog {
                 mAppDialogDelegate.onButtonClicked(POSITIVE);
             }
         });
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets.dialogs;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.graphics.RectF;
 import android.view.View;
@@ -49,12 +50,18 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
         mBackHandler = this::onDismiss;
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
         inflate(getContext(), R.layout.selection_action_menu, this);
         mContainer = findViewById(R.id.selectionMenuContainer);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SelectionActionWidget.java
@@ -42,13 +42,19 @@ public class SelectionActionWidget extends UIWidget implements WidgetManagerDele
     }
 
     private void initialize() {
-        inflate(getContext(), R.layout.selection_action_menu, this);
-        mContainer = findViewById(R.id.selectionMenuContainer);
+        updateUI();
+
         mMinButtonWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.selection_action_item_min_width);
         mMaxButtonWidth = WidgetPlacement.pixelDimension(getContext(), R.dimen.selection_action_item_max_width);
-        mBackHandler = () -> {
-            onDismiss();
-        };
+        mBackHandler = this::onDismiss;
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        inflate(getContext(), R.layout.selection_action_menu, this);
+        mContainer = findViewById(R.id.selectionMenuContainer);
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.ui.widgets.dialogs;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.LayoutInflater;
 import android.view.View;
 
@@ -73,6 +74,13 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
         mBinding.headerLayout.setDescription(R.string.send_tab_dialog_description);
         mBinding.footerLayout.setFooterButtonText(R.string.send_tab_dialog_button);
         mBinding.footerLayout.setFooterButtonClickListener(this::sendTabButtonClick);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SendTabDialogWidget.java
@@ -53,15 +53,22 @@ public class SendTabDialogWidget extends SettingDialogWidget implements
     protected void initialize(@NonNull Context aContext) {
         super.initialize(aContext);
 
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+
+        mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mSendTabsDialogBinding = DataBindingUtil.inflate(inflater, R.layout.send_tabs_display, mBinding.content, true);
         mSendTabsDialogBinding.setIsSyncing(false);
         mSendTabsDialogBinding.setIsEmpty(false);
-
-        mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
-
+        
         mBinding.headerLayout.setTitle(getResources().getString(R.string.send_tab_dialog_title));
         mBinding.headerLayout.setDescription(R.string.send_tab_dialog_description);
         mBinding.footerLayout.setFooterButtonText(R.string.send_tab_dialog_button);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SettingDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SettingDialogWidget.java
@@ -19,16 +19,7 @@ public abstract class SettingDialogWidget extends UIDialog {
     }
 
     protected void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
-
-        // Inflate this data binding layout
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.setting_dialog, this, true);
-
-        // Header
-        mBinding.headerLayout.setBackClickListener(view -> onDismiss());
-
-        // Footer
-        mBinding.footerLayout.setFooterButtonClickListener(v -> onFooterButton());
+        updateUI();
     }
 
     @Override
@@ -57,4 +48,19 @@ public abstract class SettingDialogWidget extends UIDialog {
 
     }
 
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.setting_dialog, this, true);
+
+        // Header
+        mBinding.headerLayout.setBackClickListener(view -> onDismiss());
+
+        // Footer
+        mBinding.footerLayout.setFooterButtonClickListener(v -> onFooterButton());
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SettingDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SettingDialogWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets.dialogs;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.LayoutInflater;
 
 import androidx.databinding.DataBindingUtil;
@@ -48,7 +49,6 @@ public abstract class SettingDialogWidget extends UIDialog {
 
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -62,5 +62,12 @@ public abstract class SettingDialogWidget extends UIDialog {
 
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(v -> onFooterButton());
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.graphics.drawable.ClipDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
@@ -99,7 +100,6 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
         ((Application)aContext.getApplicationContext()).registerActivityLifecycleCallbacks(this);
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -115,6 +115,13 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
         mVoiceInputClipDrawable.setLevel(0);
 
         mBinding.closeButton.setOnClickListener(view -> hide(KEEP_WIDGET));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     public void setDelegate(VoiceSearchDelegate delegate) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -80,21 +80,12 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
-
-        // Inflate this data binding layout
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.voice_search_dialog, this, true);
+        updateUI();
 
         mWidgetManager.addPermissionListener(this);
 
         mMozillaSpeechService = MozillaSpeechService.getInstance();
         mMozillaSpeechService.setProductTag(getContext().getString(R.string.voice_app_id));
-
-        Drawable mVoiceInputBackgroundDrawable = getResources().getDrawable(R.drawable.ic_voice_search_volume_input_black, getContext().getTheme());
-        mVoiceInputClipDrawable = new ClipDrawable(getContext().getDrawable(R.drawable.ic_voice_search_volume_input_clip), Gravity.START, ClipDrawable.HORIZONTAL);
-        Drawable[] layers = new Drawable[] {mVoiceInputBackgroundDrawable, mVoiceInputClipDrawable };
-        mBinding.voiceSearchAnimationListening.setImageDrawable(new LayerDrawable(layers));
-        mVoiceInputClipDrawable.setLevel(0);
 
         mSearchingAnimation = new RotateAnimation(0, 360f,
                 Animation.RELATIVE_TO_SELF, 0.5f,
@@ -104,10 +95,26 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
         mSearchingAnimation.setDuration(ANIMATION_DURATION);
         mSearchingAnimation.setRepeatCount(Animation.INFINITE);
 
-        mBinding.closeButton.setOnClickListener(view -> onDismiss());
-
         mMozillaSpeechService.addListener(mVoiceSearchListener);
         ((Application)aContext.getApplicationContext()).registerActivityLifecycleCallbacks(this);
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.voice_search_dialog, this, true);
+
+        Drawable mVoiceInputBackgroundDrawable = getResources().getDrawable(R.drawable.ic_voice_search_volume_input_black, getContext().getTheme());
+        mVoiceInputClipDrawable = new ClipDrawable(getContext().getDrawable(R.drawable.ic_voice_search_volume_input_clip), Gravity.START, ClipDrawable.HORIZONTAL);
+        Drawable[] layers = new Drawable[] {mVoiceInputBackgroundDrawable, mVoiceInputClipDrawable };
+        mBinding.voiceSearchAnimationListening.setImageDrawable(new LayerDrawable(layers));
+        mVoiceInputClipDrawable.setLevel(0);
+
+        mBinding.closeButton.setOnClickListener(view -> hide(KEEP_WIDGET));
     }
 
     public void setDelegate(VoiceSearchDelegate delegate) {
@@ -175,7 +182,7 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
                         if (mDelegate != null) {
                             mDelegate.OnVoiceSearchResult(transcription, confidence);
                         }
-                        hide(REMOVE_WIDGET);
+                        hide(KEEP_WIDGET);
                         break;
                     case START_LISTEN:
                         // Handle when the api successfully opened the microphone and started listening

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/BrightnessMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/BrightnessMenuWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.view.View;
 
 import org.mozilla.vrbrowser.R;
@@ -36,6 +37,13 @@ public class BrightnessMenuWidget extends MenuWidget {
         super.updateUI();
 
         createMenuItems();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     public void setParentWidget(UIWidget aParent) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/BrightnessMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/BrightnessMenuWidget.java
@@ -1,10 +1,12 @@
 package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.content.Context;
+import android.view.View;
 
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
+import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 
@@ -13,7 +15,8 @@ public class BrightnessMenuWidget extends MenuWidget {
     ArrayList<MenuItem> mItems;
     public BrightnessMenuWidget(Context aContext) {
         super(aContext, R.layout.menu);
-        createMenuItems();
+
+        updateUI();
     }
 
     @Override
@@ -26,6 +29,13 @@ public class BrightnessMenuWidget extends MenuWidget {
         aPlacement.anchorY = 0.0f;
         aPlacement.translationY = WidgetPlacement.dpDimension(getContext(), R.dimen.video_projection_menu_translation_y);
         aPlacement.translationZ = 2.0f;
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+
+        createMenuItems();
     }
 
     public void setParentWidget(UIWidget aParent) {
@@ -62,5 +72,12 @@ public class BrightnessMenuWidget extends MenuWidget {
         mWidgetManager.setWorldBrightness(this, getSelectedBrightness());
         mWidgetPlacement.visible = false;
         mWidgetManager.updateWidget(this);
+    }
+
+    @Override
+    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
+            hide(KEEP_WIDGET);
+        }
     }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/ContextMenuWidget.java
@@ -9,19 +9,16 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.net.Uri;
-import android.view.View;
 
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.utils.StringUtils;
-import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 
-public class ContextMenuWidget extends MenuWidget implements WidgetManagerDelegate.FocusChangeListener {
+public class ContextMenuWidget extends MenuWidget {
     ArrayList<MenuItem> mItems;
     private Runnable mDismissCallback;
 
@@ -31,12 +28,7 @@ public class ContextMenuWidget extends MenuWidget implements WidgetManagerDelega
     }
 
     private void initialize() {
-        mAdapter.updateBackgrounds(R.drawable.context_menu_item_background_first,
-                R.drawable.context_menu_item_background_last,
-                R.drawable.context_menu_item_background,
-                R.drawable.context_menu_item_background_single);
-        mAdapter.updateLayoutId(R.layout.context_menu_item);
-        menuContainer.setBackground(getContext().getDrawable(R.drawable.context_menu_background));
+        updateUI();
     }
 
     @Override
@@ -51,16 +43,15 @@ public class ContextMenuWidget extends MenuWidget implements WidgetManagerDelega
     }
 
     @Override
-    public void show(@ShowFlags int aShowFlags) {
-        mWidgetManager.addFocusChangeListener(ContextMenuWidget.this);
-        super.show(aShowFlags);
-    }
+    public void updateUI() {
+        super.updateUI();
 
-    @Override
-    public void hide(@HideFlags int aHideFlags) {
-        super.hide(aHideFlags);
-
-        mWidgetManager.removeFocusChangeListener(this);
+        mAdapter.updateBackgrounds(R.drawable.context_menu_item_background_first,
+                R.drawable.context_menu_item_background_last,
+                R.drawable.context_menu_item_background,
+                R.drawable.context_menu_item_background_single);
+        mAdapter.updateLayoutId(R.layout.context_menu_item);
+        menuContainer.setBackground(getContext().getDrawable(R.drawable.context_menu_background));
     }
 
     @Override
@@ -119,15 +110,6 @@ public class ContextMenuWidget extends MenuWidget implements WidgetManagerDelega
         mWidgetPlacement.height = mItems.size() * WidgetPlacement.dpDimension(getContext(), R.dimen.context_menu_row_height);
         mWidgetPlacement.height += mBorderWidth * 2;
         mWidgetPlacement.height += 10.0f; // Link separator
-    }
-
-    // WidgetManagerDelegate.FocusChangeListener
-
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
-            onDismiss();
-        }
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/ContextMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/ContextMenuWidget.java
@@ -8,11 +8,13 @@ package org.mozilla.vrbrowser.ui.widgets.menus;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.net.Uri;
 
 import org.mozilla.geckoview.GeckoSession;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService;
+import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.utils.StringUtils;
 
@@ -52,6 +54,13 @@ public class ContextMenuWidget extends MenuWidget {
                 R.drawable.context_menu_item_background_single);
         mAdapter.updateLayoutId(R.layout.context_menu_item);
         menuContainer.setBackground(getContext().getDrawable(R.drawable.context_menu_background));
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/HamburgerMenuWidget.java
@@ -2,22 +2,19 @@ package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.view.View;
 
 import androidx.annotation.IntDef;
 
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.vrbrowser.R;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.utils.AnimationHelper;
-import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Optional;
 
-public class HamburgerMenuWidget extends MenuWidget implements WidgetManagerDelegate.FocusChangeListener {
+public class HamburgerMenuWidget extends MenuWidget {
 
     public interface MenuDelegate {
         void onSendTab();
@@ -42,6 +39,13 @@ public class HamburgerMenuWidget extends MenuWidget implements WidgetManagerDele
     }
 
     private void initialize() {
+        updateUI();
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+
         mAdapter.updateBackgrounds(R.drawable.context_menu_item_background_first,
                 R.drawable.context_menu_item_background_last,
                 R.drawable.context_menu_item_background,
@@ -56,13 +60,11 @@ public class HamburgerMenuWidget extends MenuWidget implements WidgetManagerDele
         super.show(aShowFlags);
 
         AnimationHelper.scaleIn(findViewById(R.id.menuContainer), 100, 0, null);
-        mWidgetManager.addFocusChangeListener(this);
     }
 
     @Override
     public void hide(int aHideFlags) {
         AnimationHelper.scaleOut(findViewById(R.id.menuContainer), 100, 0, () -> HamburgerMenuWidget.super.hide(aHideFlags));
-        mWidgetManager.removeFocusChangeListener(this);
     }
 
     @Override
@@ -131,12 +133,4 @@ public class HamburgerMenuWidget extends MenuWidget implements WidgetManagerDele
         updateMenuItems();
     }
 
-    // FocusChangeListener
-
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
-            onDismiss();
-        }
-    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/HamburgerMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/HamburgerMenuWidget.java
@@ -2,6 +2,7 @@ package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.Configuration;
 
 import androidx.annotation.IntDef;
 
@@ -53,6 +54,13 @@ public class HamburgerMenuWidget extends MenuWidget {
         mAdapter.updateLayoutId(R.layout.hamburger_menu_item);
 
         updateMenuItems();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/LibraryMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/LibraryMenuWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.content.Context;
+import android.content.res.Configuration;
 
 import androidx.annotation.NonNull;
 
@@ -72,6 +73,13 @@ public class LibraryMenuWidget extends MenuWidget {
                 R.drawable.library_context_menu_item_background_middle,
                 R.drawable.library_context_menu_item_background_single);
         mAdapter.updateLayoutId(R.layout.library_menu_item);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/LibraryMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/LibraryMenuWidget.java
@@ -1,21 +1,18 @@
 package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.content.Context;
-import android.view.View;
 
 import androidx.annotation.NonNull;
 
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.callbacks.LibraryItemContextMenuClickCallback;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.utils.AnimationHelper;
-import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.Optional;
 
-public class LibraryMenuWidget extends MenuWidget implements WidgetManagerDelegate.FocusChangeListener {
+public class LibraryMenuWidget extends MenuWidget {
 
     public enum LibraryItemType {
         BOOKMARKS,
@@ -62,6 +59,13 @@ public class LibraryMenuWidget extends MenuWidget implements WidgetManagerDelega
     }
 
     private void initialize() {
+        updateUI();
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+
         mAdapter.updateBackgrounds(
                 R.drawable.library_context_menu_item_background_top,
                 R.drawable.library_context_menu_item_background_bottom,
@@ -75,13 +79,11 @@ public class LibraryMenuWidget extends MenuWidget implements WidgetManagerDelega
         super.show(aShowFlags);
 
         AnimationHelper.scaleIn(findViewById(R.id.menuContainer), 100, 0, null);
-        mWidgetManager.addFocusChangeListener(this);
     }
 
     @Override
     public void hide(int aHideFlags) {
         AnimationHelper.scaleOut(findViewById(R.id.menuContainer), 100, 0, () -> LibraryMenuWidget.super.hide(aHideFlags));
-        mWidgetManager.removeFocusChangeListener(this);
     }
 
     @Override
@@ -136,12 +138,4 @@ public class LibraryMenuWidget extends MenuWidget implements WidgetManagerDelega
         mWidgetPlacement.height += mBorderWidth * 2;
     }
 
-    // FocusChangeListener
-
-    @Override
-    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus)) {
-            onDismiss();
-        }
-    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/MenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/MenuWidget.java
@@ -20,14 +20,16 @@ import androidx.annotation.LayoutRes;
 
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
+import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 
-public abstract class MenuWidget extends UIWidget {
+public abstract class MenuWidget extends UIWidget implements WidgetManagerDelegate.FocusChangeListener {
     protected MenuAdapter mAdapter;
     protected ListView mListView;
     protected View menuContainer;
+    protected int mLayoutRes;
 
     public MenuWidget(Context aContext, @LayoutRes int layout) {
         super(aContext);
@@ -40,15 +42,38 @@ public abstract class MenuWidget extends UIWidget {
     }
 
     private void initialize(Context aContext, @LayoutRes int layout, ArrayList<MenuItem> aItems) {
-        inflate(aContext, layout, this);
+        mLayoutRes = layout;
+        updateUI();
+    }
+
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        inflate(getContext(), mLayoutRes, this);
         mListView = findViewById(R.id.menuListView);
         menuContainer = findViewById(R.id.menuContainer);
 
 
-        mAdapter = new MenuAdapter(aContext, aItems);
+        mAdapter = new MenuAdapter(getContext(), null);
         mListView.setAdapter(mAdapter);
         mListView.setVerticalScrollBarEnabled(false);
         mListView.setFastScrollAlwaysVisible(false);
+    }
+
+
+    @Override
+    public void show(@ShowFlags int aShowFlags) {
+        super.show(aShowFlags);
+
+        mWidgetManager.addFocusChangeListener(this);
+    }
+
+    @Override
+    public void hide(@HideFlags int aHideFlags) {
+        super.hide(aHideFlags);
+
+        mWidgetManager.removeFocusChangeListener(this);
     }
 
     public void updateMenuItems(ArrayList<MenuItem> aItems) {
@@ -204,6 +229,13 @@ public abstract class MenuWidget extends UIWidget {
             }
 
             return false;
+        }
+    }
+
+    @Override
+    public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+        if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
+            onDismiss();
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/MenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/MenuWidget.java
@@ -46,7 +46,6 @@ public abstract class MenuWidget extends UIWidget implements WidgetManagerDelega
         updateUI();
     }
 
-    @Override
     public void updateUI() {
         removeAllViews();
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/VideoProjectionMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/VideoProjectionMenuWidget.java
@@ -1,6 +1,7 @@
 package org.mozilla.vrbrowser.ui.widgets.menus;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.view.View;
 
@@ -70,6 +71,13 @@ public class VideoProjectionMenuWidget extends MenuWidget {
         super.updateUI();
 
         createMenuItems();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     public void setParentWidget(UIWidget aParent) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/VideoProjectionMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/VideoProjectionMenuWidget.java
@@ -9,7 +9,6 @@ import androidx.annotation.Nullable;
 
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
-import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
@@ -17,7 +16,7 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 
-public class VideoProjectionMenuWidget extends MenuWidget implements WidgetManagerDelegate.FocusChangeListener {
+public class VideoProjectionMenuWidget extends MenuWidget {
 
     @IntDef(value = { VIDEO_PROJECTION_NONE, VIDEO_PROJECTION_3D_SIDE_BY_SIDE, VIDEO_PROJECTION_360,
                       VIDEO_PROJECTION_360_STEREO, VIDEO_PROJECTION_180,
@@ -50,7 +49,8 @@ public class VideoProjectionMenuWidget extends MenuWidget implements WidgetManag
 
     public VideoProjectionMenuWidget(Context aContext) {
         super(aContext, R.layout.menu);
-        createMenuItems();
+
+        updateUI();
     }
 
     @Override
@@ -66,17 +66,10 @@ public class VideoProjectionMenuWidget extends MenuWidget implements WidgetManag
     }
 
     @Override
-    public void show(@ShowFlags int aShowFlags) {
-        super.show(aShowFlags);
+    public void updateUI() {
+        super.updateUI();
 
-        mWidgetManager.addFocusChangeListener(VideoProjectionMenuWidget.this);
-    }
-
-    @Override
-    public void hide(@HideFlags int aHideFlags) {
-        super.hide(aHideFlags);
-
-        mWidgetManager.removeFocusChangeListener(this);
+        createMenuItems();
     }
 
     public void setParentWidget(UIWidget aParent) {
@@ -176,7 +169,7 @@ public class VideoProjectionMenuWidget extends MenuWidget implements WidgetManag
     @Override
     public void onGlobalFocusChanged(View oldFocus, View newFocus) {
         if (!ViewUtils.isEqualOrChildrenOf(this, newFocus) && isVisible()) {
-            onDismiss();
+            hide(KEEP_WIDGET);
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
@@ -76,11 +76,6 @@ public class PromptWidget extends UIDialog {
     }
 
     @Override
-    public void updateUI() {
-        // Nothing to do here
-    }
-
-    @Override
     public void show(@ShowFlags int aShowFlags) {
         mLayout.measure(View.MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED),
                         View.MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/prompts/PromptWidget.java
@@ -76,6 +76,11 @@ public class PromptWidget extends UIDialog {
     }
 
     @Override
+    public void updateUI() {
+        // Nothing to do here
+    }
+
+    @Override
     public void show(@ShowFlags int aShowFlags) {
         mLayout.measure(View.MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED),
                         View.MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED));

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ContentLanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ContentLanguageOptionsView.java
@@ -39,8 +39,6 @@ public class ContentLanguageOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
-
         // Preferred languages adapter
         mPreferredAdapter = new LanguagesAdapter(getContext(), mLanguageItemCallback, true);
         mPreferredAdapter.setLanguageList(LocaleUtils.getPreferredLanguages(getContext()));
@@ -48,6 +46,17 @@ public class ContentLanguageOptionsView extends SettingsView {
         // Available languages adapter
         mAvailableAdapter = new LanguagesAdapter(getContext(), mLanguageItemCallback, false);
         mAvailableAdapter.setLanguageList(LocaleUtils.getAvailableLanguages());
+
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_language_content, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ControllerOptionsView.java
@@ -26,7 +26,14 @@ class ControllerOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_controller, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DeveloperOptionsView.java
@@ -31,7 +31,14 @@ class DeveloperOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_developer, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayLanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayLanguageOptionsView.java
@@ -30,7 +30,14 @@ class DisplayLanguageOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_language_display, this, true);
@@ -94,9 +101,7 @@ class DisplayLanguageOptionsView extends SettingsView {
             String locale = LocaleUtils.getSupportedLocaleForIndex(checkedId);
             LocaleUtils.setDisplayLocale(getContext(), locale);
 
-            if (mDelegate != null) {
-                mDelegate.showRestartDialog();
-            }
+            mWidgetManager.updateLocale(LocaleUtils.setLocale(getContext()));
         }
     }
 
@@ -105,4 +110,5 @@ class DisplayLanguageOptionsView extends SettingsView {
         return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
                 WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
     }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
@@ -32,7 +32,14 @@ class DisplayOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_display, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/EnvironmentOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/EnvironmentOptionsView.java
@@ -29,7 +29,14 @@ class EnvironmentOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_environment, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -53,7 +53,14 @@ class FxAAccountOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_fxa_account, this, true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
@@ -42,7 +42,20 @@ class LanguageOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+
+        mContentLanguage = new ContentLanguageOptionsView(getContext(), mWidgetManager);
+        mVoiceLanguage = new VoiceSearchLanguageOptionsView(getContext(), mWidgetManager);
+        mDisplayLanguage = new DisplayLanguageOptionsView(getContext(), mWidgetManager);
+
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(aContext);
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_language, this, true);
@@ -62,12 +75,6 @@ class LanguageOptionsView extends SettingsView {
         setVoiceLanguage();
         setContentLanguage();
         setDisplayLanguage();
-
-        mContentLanguage = new ContentLanguageOptionsView(getContext(), mWidgetManager);
-        mVoiceLanguage = new VoiceSearchLanguageOptionsView(getContext(), mWidgetManager);
-        mDisplayLanguage = new DisplayLanguageOptionsView(getContext(), mWidgetManager);
-
-        mPrefs = PreferenceManager.getDefaultSharedPreferences(aContext);
     }
 
     @Override
@@ -85,10 +92,9 @@ class LanguageOptionsView extends SettingsView {
     }
 
     private OnClickListener mResetListener = (view) -> {
-        if (mContentLanguage.reset() |
-            mDisplayLanguage.reset() |
-            mVoiceLanguage.reset())
-            showRestartDialog();
+        mContentLanguage.reset();
+        mDisplayLanguage.reset();
+        mVoiceLanguage.reset();
     };
 
     private void setVoiceLanguage() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PopUpExceptionsOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PopUpExceptionsOptionsView.java
@@ -37,13 +37,20 @@ class PopUpExceptionsOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
 
         // Preferred languages adapter
         mAdapter = new PopUpAdapter(getContext(), mCallback);
 
         // View Model
         mViewModel = new PopUpsViewModel(((Application)getContext().getApplicationContext()));
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_privacy_popups, this, true);
@@ -114,4 +121,5 @@ class PopUpExceptionsOptionsView extends SettingsView {
         }
 
     };
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
@@ -43,7 +43,16 @@ class PrivacyOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+
+        ((Application)aContext.getApplicationContext()).registerActivityLifecycleCallbacks(mLifeCycleListener);
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_privacy, this, true);
@@ -55,8 +64,6 @@ class PrivacyOptionsView extends SettingsView {
 
         // Footer
         mBinding.footerLayout.setFooterButtonClickListener(v -> resetOptions());
-
-        ((Application)aContext.getApplicationContext()).registerActivityLifecycleCallbacks(mLifeCycleListener);
 
         // Options
         mBinding.showPrivacyButton.setOnClickListener(v -> {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsView.java
@@ -91,4 +91,9 @@ abstract class SettingsView extends FrameLayout {
     protected boolean reset() {
         return false;
     }
+
+    protected void updateUI() {
+        removeAllViews();
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.text.Html;
@@ -114,7 +115,6 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    @Override
     public void updateUI() {
         removeAllViews();
 
@@ -225,6 +225,13 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
         });
 
         mCurrentView = null;
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        updateUI();
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -98,15 +98,30 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
 
     @SuppressLint("ClickableViewAccessibility")
     private void initialize() {
-        LayoutInflater inflater = LayoutInflater.from(getContext());
-
-        // Inflate this data binding layout
-        mBinding = DataBindingUtil.inflate(inflater, R.layout.settings, this, true);
+        updateUI();
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
         mAccounts.addAccountListener(mAccountObserver);
 
         mUIThreadExecutor = ((VRBrowserApplication)getContext().getApplicationContext()).getExecutors().mainThread();
+
+        mAudio = AudioEngine.fromContext(getContext());
+
+        mViewMarginH = mWidgetPlacement.width - WidgetPlacement.dpDimension(getContext(), R.dimen.options_width);
+        mViewMarginH = WidgetPlacement.convertDpToPixel(getContext(), mViewMarginH);
+        mViewMarginV = mWidgetPlacement.height - WidgetPlacement.dpDimension(getContext(), R.dimen.options_height);
+        mViewMarginV = WidgetPlacement.convertDpToPixel(getContext(), mViewMarginV);
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public void updateUI() {
+        removeAllViews();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+
+        // Inflate this data binding layout
+        mBinding = DataBindingUtil.inflate(inflater, R.layout.settings, this, true);
 
         mBinding.backButton.setOnClickListener(v -> {
             if (mAudio != null) {
@@ -158,8 +173,8 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             String app_name = getResources().getString(R.string.app_name);
             String[] app_name_parts = app_name.split(" ");
             mBinding.versionText.setText(Html.fromHtml("<b>" + app_name_parts[0] + "</b>" +
-                    " " + app_name_parts[1] + " " +
-                    " <b>" + pInfo.versionName + "</b>",
+                            " " + app_name_parts[1] + " " +
+                            " <b>" + pInfo.versionName + "</b>",
                     Html.FROM_HTML_MODE_LEGACY));
 
         } catch (PackageManager.NameNotFoundException e) {
@@ -209,12 +224,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             showControllerOptionsDialog();
         });
 
-        mAudio = AudioEngine.fromContext(getContext());
-
-        mViewMarginH = mWidgetPlacement.width - WidgetPlacement.dpDimension(getContext(), R.dimen.options_width);
-        mViewMarginH = WidgetPlacement.convertDpToPixel(getContext(), mViewMarginH);
-        mViewMarginV = mWidgetPlacement.height - WidgetPlacement.dpDimension(getContext(), R.dimen.options_height);
-        mViewMarginV = WidgetPlacement.convertDpToPixel(getContext(), mViewMarginV);
+        mCurrentView = null;
     }
 
     @Override
@@ -277,7 +287,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
                     mAccounts.logoutAsync();
 
                 } else {
-                    hide(REMOVE_WIDGET);
+                    hide(KEEP_WIDGET);
 
                     CompletableFuture<String> result = mAccounts.authUrlAsync();
                     if (result != null) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/VoiceSearchLanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/VoiceSearchLanguageOptionsView.java
@@ -30,7 +30,14 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
     }
 
     private void initialize(Context aContext) {
-        LayoutInflater inflater = LayoutInflater.from(aContext);
+        updateUI();
+    }
+
+    @Override
+    protected void updateUI() {
+        super.updateUI();
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.options_language_voice, this, true);
@@ -100,4 +107,5 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
         return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
                 WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
     }
+    
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/LocaleUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/LocaleUtils.java
@@ -32,6 +32,10 @@ public class LocaleUtils {
         getAllLanguages();
     }
 
+    public static void refresh() {
+        getAllLanguages(true);
+    }
+
     public static void saveSystemLocale() {
         mSystemLocale = Locale.getDefault();
     }
@@ -47,7 +51,11 @@ public class LocaleUtils {
     }
 
     private static HashMap<String, Language> getAllLanguages() {
-        if (mLanguagesCache != null) {
+        return getAllLanguages(false);
+    }
+
+    private static HashMap<String, Language> getAllLanguages(boolean refresh) {
+        if (mLanguagesCache != null && !refresh) {
             return mLanguagesCache;
         }
 
@@ -198,7 +206,7 @@ public class LocaleUtils {
     }
 
     public static void setDisplayLocale(@NonNull Context context, @NonNull String locale) {
-        SettingsStore.getInstance(context).setDisplayLocale(locale);
+        SettingsStore.getInstance(context).setDisplayLocale(getClosestAvailableLocale(locale));
     }
 
     @NonNull

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/StringUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/StringUtils.java
@@ -3,6 +3,7 @@ package org.mozilla.vrbrowser.utils;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
 
 import androidx.annotation.NonNull;
@@ -19,7 +20,14 @@ public class StringUtils {
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     public static String getStringByLocale(Context context, int id, Locale locale) {
         Configuration configuration = new Configuration(context.getResources().getConfiguration());
-        configuration.setLocale(locale);
+        // This looks like an Android bug, when trying to get the localized string for the system locale
+        // it returns the locale for the current context one.
+        Locale deviceLocale = Resources.getSystem().getConfiguration().getLocales().get(0);
+        if (deviceLocale.equals(locale)) {
+            configuration.setLocale(deviceLocale);
+        } else {
+            configuration.setLocale(locale);
+        }
         return context.createConfigurationContext(configuration).getResources().getString(id);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
@@ -7,12 +7,17 @@ package org.mozilla.vrbrowser.utils;
 
 import android.content.Context;
 import android.util.Base64;
+import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.browser.SettingsStore;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 import java.util.regex.Pattern;
 
 
@@ -72,5 +77,42 @@ public class UrlUtils {
         InternalPages.PageResources pageResources = InternalPages.PageResources.create(R.raw.private_mode, R.raw.private_style);
         byte[] privatePageBytes = InternalPages.createAboutPage(context, pageResources);
         return uri.equals("data:text/html;base64," + Base64.encodeToString(privatePageBytes, Base64.NO_WRAP));
+    }
+
+    public static Boolean isHomeUri(@NonNull Context context, @Nullable String aUri) {
+        return aUri != null && aUri.toLowerCase().startsWith(
+                SettingsStore.getInstance(context).getHomepage()
+        );
+    }
+
+    public static Boolean isDataUri(@NonNull String aUri) {
+        return aUri.startsWith("data");
+    }
+
+    public static Boolean isBlankUri(@NonNull Context context, @NonNull String aUri) {
+        return aUri.equals(context.getString(R.string.about_blank));
+    }
+
+    public static String titleBarUrl(@Nullable String aUri) {
+        if (aUri == null) {
+            return "";
+        }
+
+        if (URLUtil.isValidUrl(aUri)) {
+            try {
+                URI uri = URI.create(aUri);
+                URL url = new URL(
+                        uri.getScheme() != null ? uri.getScheme() : "",
+                        uri.getAuthority() != null ? uri.getAuthority() : "",
+                        "");
+                return url.toString();
+
+            } catch (MalformedURLException | IllegalArgumentException e) {
+                return "";
+            }
+
+        } else {
+            return aUri;
+        }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <activity
             android:name=".VRBrowserActivity"
             android:launchMode="singleInstance"
-            android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode|locale"
+            android:configChanges="density|keyboardHidden|navigation|orientation|screenSize|uiMode|locale|layoutDirection"
             android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/res/layout/navigation_bar.xml
+++ b/app/src/main/res/layout/navigation_bar.xml
@@ -1,9 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
+    </data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <include
+            android:id="@+id/navigation_bar_navigation"
+            layout="@layout/navigation_bar_navigation"
+            app:viewmodel="@{viewmodel}"/>
 
-    <include layout="@layout/navigation_bar_navigation" />
+        <include
+            android:id="@+id/navigation_bar_fullscreen"
+            layout="@layout/navigation_bar_fullscreen"
+            app:viewmodel="@{viewmodel}"/>
 
-    <include layout="@layout/navigation_bar_fullscreen" />
-
-    <include layout="@layout/navigation_bar_menu" />
-</merge>
+        <include
+            android:id="@+id/navigation_bar_menu"
+            layout="@layout/navigation_bar_menu"
+            app:viewmodel="@{viewmodel}"/>
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/navigation_bar_fullscreen.xml
+++ b/app/src/main/res/layout/navigation_bar_fullscreen.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
-
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
+        <variable
+            name="ab"
+            type="boolean" />
+    </data>
     <FrameLayout
         android:id="@+id/fullScreenModeContainer"
         android:layout_width="wrap_content"
@@ -26,26 +34,30 @@
                 style="?attr/fullScreenButtonStyle"
                 android:background="@drawable/fullscreen_button_first"
                 android:src="@drawable/ic_icon_back"
-                android:tooltipText="@string/back_tooltip" />
+                android:tooltipText="@string/back_tooltip"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <org.mozilla.vrbrowser.ui.views.UIButton
                 android:id="@+id/fullScreenResizeEnterButton"
                 style="?attr/fullScreenButtonStyle"
                 android:src="@drawable/ic_icon_resize"
-                android:tooltipText="@string/resize_tooltip" />
+                android:tooltipText="@string/resize_tooltip"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <org.mozilla.vrbrowser.ui.views.UIButton
                 android:id="@+id/projectionButton"
                 style="?attr/fullScreenButtonStyle"
                 android:src="@drawable/ic_icon_vr_projection"
-                android:tooltipText="@string/video_mode_tooltip" />
+                android:tooltipText="@string/video_mode_tooltip"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <org.mozilla.vrbrowser.ui.views.UIButton
                 android:id="@+id/brightnessButton"
                 style="?attr/fullScreenButtonStyle"
                 android:background="@drawable/fullscreen_button_last"
                 android:src="@drawable/ic_icon_brightness"
-                android:tooltipText="@string/brightness_mode_tooltip" />
+                android:tooltipText="@string/brightness_mode_tooltip"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
         </LinearLayout>
     </FrameLayout>
-</merge>
+</layout>

--- a/app/src/main/res/layout/navigation_bar_menu.xml
+++ b/app/src/main/res/layout/navigation_bar_menu.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
-
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
+    </data>
     <LinearLayout
         android:id="@+id/resizeModeContainer"
         android:layout_width="wrap_content"
@@ -14,39 +19,45 @@
             android:id="@+id/resizePreset3"
             style="@style/navigationBarTextButtonStartTheme"
             android:text="3x"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UITextButton
             android:id="@+id/resizePreset2"
             style="@style/navigationBarTextButtonMiddleTheme"
             android:padding="5dp"
             android:text="2x"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UITextButton
             android:id="@+id/resizePreset15"
             style="@style/navigationBarTextButtonMiddleTheme"
             android:padding="5dp"
             android:text="1.5x"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UITextButton
             android:id="@+id/resizePreset1"
             style="@style/navigationBarTextButtonMiddleTheme"
             android:padding="5dp"
             android:text="1x"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UITextButton
             android:id="@+id/resizePreset0"
             style="@style/navigationBarTextButtonMiddleTheme"
             android:padding="5dp"
             android:text="0.5x"
-            android:textSize="14sp" />
+            android:textSize="14sp"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/resizeExitButton"
             style="@style/navigationBarTextButtonEndTheme"
-            android:src="@drawable/ic_icon_resize_done" />
+            android:src="@drawable/ic_icon_resize_done"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
     </LinearLayout>
-</merge>
+</layout>

--- a/app/src/main/res/layout/navigation_bar_navigation.xml
+++ b/app/src/main/res/layout/navigation_bar_navigation.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
-
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
+    </data>
     <LinearLayout
         android:id="@+id/navigationBarContainer"
         style="?attr/navigationBarStyle"
@@ -15,7 +20,9 @@
             android:layout_weight="1"
             android:src="@drawable/ic_icon_back"
             android:tint="@color/midnight"
-            android:tooltipText="@string/back_tooltip" />
+            android:tooltipText="@string/back_tooltip"
+            android:enabled="@{viewmodel.canGoBack}"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/forwardButton"
@@ -23,15 +30,18 @@
             android:layout_marginStart="10dp"
             android:layout_weight="1"
             android:src="@drawable/ic_icon_forward"
-            android:tooltipText="@string/forward_tooltip" />
+            android:tooltipText="@string/forward_tooltip"
+            android:enabled="@{viewmodel.canGoForward}"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/reloadButton"
             style="?attr/navigationBarButtonStyle"
             android:layout_marginStart="10dp"
             android:layout_weight="1"
-            android:src="@drawable/ic_icon_reload"
-            android:tooltipText="@string/refresh_tooltip" />
+            android:src="@{viewmodel.isLoading ? @drawable/ic_icon_exit : @drawable/ic_icon_reload}"
+            android:tooltipText="@{viewmodel.isLoading ? @string/stop_tooltip : @string/refresh_tooltip}"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/homeButton"
@@ -39,7 +49,8 @@
             android:layout_marginStart="10dp"
             android:layout_weight="1"
             android:src="@drawable/ic_icon_home"
-            android:tooltipText="@string/home_tooltip" />
+            android:tooltipText="@string/home_tooltip"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.NavigationURLBar
             android:id="@+id/urlBar"
@@ -48,7 +59,7 @@
             android:layout_gravity="center_vertical"
             android:layout_marginStart="10dp"
             android:layout_weight="100"
-            android:orientation="horizontal" />
+            android:orientation="horizontal"/>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/servoButton"
@@ -56,7 +67,9 @@
             android:layout_marginStart="10dp"
             android:layout_weight="1"
             android:src="@drawable/ic_icon_servo"
-            android:tooltipText="@string/servo_tooltip" />
+            android:tooltipText="@string/servo_tooltip"
+            visibleGone="@{viewmodel.isServoAvailable}"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/menuButton"
@@ -64,6 +77,7 @@
             android:layout_marginStart="10dp"
             android:layout_weight="1"
             android:src="@drawable/ic_icon_hamburger_menu"
-            android:tooltipText="@string/hamburger_menu_tooltip" />
+            android:tooltipText="@string/hamburger_menu_tooltip"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
     </LinearLayout>
-</merge>
+</layout>

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -4,53 +4,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
-        <import type="org.mozilla.geckoview.GeckoSessionSettings" />
         <import type="org.mozilla.vrbrowser.ui.views.CustomInlineAutocompleteEditText" />
-
         <variable
-            name="isLibraryVisible"
-            type="boolean" />
-
-        <variable
-            name="isInsecure"
-            type="boolean" />
-
-        <variable
-            name="isLoading"
-            type="boolean" />
-
-        <variable
-            name="uaMode"
-            type="int" />
-
-        <variable
-            name="isMicrophoneEnabled"
-            type="boolean" />
-
-        <variable
-            name="isBookmarked"
-            type="boolean" />
-
-        <variable
-            name="isFocused"
-            type="boolean" />
-
-        <variable
-            name="isSpecialUrl"
-            type="boolean" />
-
-        <variable
-            name="isPrivateMode"
-            type="boolean" />
-
-        <variable
-            name="isUrlEmpty"
-            type="boolean" />
-
-        <variable
-            name="isPopUpAvailable"
-            type="boolean" />
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
     </data>
 
     <FrameLayout
@@ -65,8 +22,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:addStatesFromChildren="true"
-            android:background="@{isPrivateMode ? @drawable/url_background_private : @drawable/url_background}"
-            android:foreground="@{isPrivateMode ? @drawable/url_background_private_outline : @drawable/url_background_outline}">
+            android:background="@{viewmodel.isPrivateSession ? @drawable/url_background_private : @drawable/url_background}"
+            android:foreground="@{viewmodel.isPrivateSession ? @drawable/url_background_private_outline : @drawable/url_background_outline}">
 
             <LinearLayout
                 android:id="@+id/endButtonsLayout"
@@ -83,20 +40,20 @@
                 <org.mozilla.vrbrowser.ui.views.UIButton
                     android:id="@+id/microphoneButton"
                     style="@style/urlBarIconTheme"
-                    android:layout_width="@{(isLibraryVisible || isSpecialUrl) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
-                    android:background="@{(isLibraryVisible || isSpecialUrl) ? (isPrivateMode ? @drawable/url_button_end_private : @drawable/url_button_end) : (isPrivateMode ? @drawable/url_button_private : @drawable/url_button)}"
+                    android:layout_width="@{(viewmodel.isLibraryVisible || viewmodel.isSpecialUrl) ? @dimen/url_bar_last_item_width : @dimen/url_bar_item_width}"
+                    android:background="@{(viewmodel.isLibraryVisible || viewmodel.isSpecialUrl) ? (viewmodel.isPrivateSession ? @drawable/url_button_end_private : @drawable/url_button_end) : (viewmodel.isPrivateSession ? @drawable/url_button_private : @drawable/url_button)}"
                     android:src="@drawable/ic_icon_microphone"
                     android:tint="@color/fog"
                     android:tooltipText="@string/voice_search_tooltip"
-                    app:visibleGone="@{isMicrophoneEnabled &amp;&amp; !isFocused}" />
+                    app:visibleGone="@{viewmodel.isMicrophoneEnabled &amp;&amp; !viewmodel.isFocused}"/>
 
                 <org.mozilla.vrbrowser.ui.views.UIButton
                     android:id="@+id/bookmarkButton"
                     style="@style/urlBarIconThemeEnd"
-                    android:src="@{isBookmarked ? @drawable/ic_icon_bookmarked_active : @drawable/ic_icon_bookmarked}"
+                    android:src="@{viewmodel.isBookmarked ? @drawable/ic_icon_bookmarked_active : @drawable/ic_icon_bookmarked}"
                     android:tint="@color/fog"
                     android:tooltipText="@string/bookmark_tooltip"
-                    app:visibleGone="@{!(isLibraryVisible || isSpecialUrl) &amp;&amp; !isFocused}"
+                    app:visibleGone="@{!(viewmodel.isLibraryVisible || viewmodel.isSpecialUrl) &amp;&amp; !viewmodel.isFocused}"
                     tools:src="@drawable/ic_icon_bookmarked" />
 
                 <org.mozilla.vrbrowser.ui.views.UIButton
@@ -105,7 +62,7 @@
                     android:src="@drawable/ic_icon_clear"
                     android:tint="@color/fog"
                     android:tooltipText="@string/clear_tooltip"
-                    app:visibleGone="@{!isMicrophoneEnabled &amp;&amp; isFocused &amp;&amp; (urlEditText.text.length > 0)}" />
+                    app:visibleGone="@{!viewmodel.isMicrophoneEnabled &amp;&amp; viewmodel.isFocused &amp;&amp; (urlEditText.text.length > 0)}" />
             </LinearLayout>
 
             <RelativeLayout
@@ -115,7 +72,7 @@
                 android:layout_alignParentStart="true"
                 android:addStatesFromChildren="true"
                 android:background="@null"
-                app:visibleGone="@{!isLibraryVisible}">
+                app:visibleGone="@{!viewmodel.isLibraryVisible}">
 
                 <LinearLayout
                     android:id="@+id/startButtonsLayout"
@@ -136,12 +93,12 @@
                         android:src="@drawable/ic_icon_popup_awesomebar"
                         android:tint="@color/fog"
                         android:tooltipText="@string/popup_tooltip"
-                        app:visibleGone="@{isPopUpAvailable}" />
+                        app:visibleGone="@{viewmodel.isPopUpAvailable}" />
 
                     <View
                         android:layout_width="15dp"
                         android:layout_height="match_parent"
-                        app:visibleGone="@{!isPopUpAvailable}"/>
+                        app:visibleGone="@{!viewmodel.isPopUpAvailable}"/>
                 </LinearLayout>
 
                 <LinearLayout
@@ -157,14 +114,14 @@
                         android:paddingEnd="5dp"
                         android:contentDescription="Loading animation"
                         android:src="@drawable/loading_shape"
-                        app:visibleGone="@{isLoading}" />
+                        app:visibleGone="@{viewmodel.isLoading}" />
                     <ImageView
                         android:id="@+id/insecureIcon"
                         android:layout_width="24dp"
                         android:layout_height="24dp"
                         android:contentDescription="SSL icon"
                         android:src="@drawable/ic_icon_security_state_insecure"
-                        app:visibleGone="@{isInsecure &amp;&amp; (urlEditText.length() != 0)}" />
+                        app:visibleGone="@{viewmodel.isInsecureVisible &amp;&amp; (urlEditText.length() != 0)}" />
                 </LinearLayout>
 
             </RelativeLayout>
@@ -174,7 +131,7 @@
                 android:layout_width="15dp"
                 android:layout_height="match_parent"
                 android:layout_toEndOf="@id/iconsLayout"
-                app:visibleGone="@{isLibraryVisible}"/>
+                app:visibleGone="@{viewmodel.isLibraryVisible}"/>
 
             <org.mozilla.vrbrowser.ui.views.CustomInlineAutocompleteEditText
                 android:id="@+id/urlEditText"
@@ -183,7 +140,7 @@
                 android:paddingEnd="10dp"
                 android:layout_toStartOf="@id/endButtonsLayout"
                 android:layout_toEndOf="@id/padding"
-                android:foreground="@{isUrlEmpty ? (isPrivateMode ? @drawable/url_bar_hint_fading_edge_private : @drawable/url_bar_hint_fading_edge) : null}"
+                android:foreground="@{viewmodel.isUrlEmpty ? (viewmodel.isPrivateSession ? @drawable/url_bar_hint_fading_edge_private : @drawable/url_bar_hint_fading_edge) : null}"
                 android:foregroundGravity="fill_vertical|right"
                 android:ems="10"
                 android:fadingEdgeLength="40dp"
@@ -199,6 +156,7 @@
                 android:textColorHighlight="@color/azure"
                 android:textIsSelectable="true"
                 android:textSize="16sp"
+                android:text="@{viewmodel.navigationBarUrl}"
                 app:autocompleteBackgroundColor="@color/azure" />
         </RelativeLayout>
     </FrameLayout>

--- a/app/src/main/res/layout/title_bar.xml
+++ b/app/src/main/res/layout/title_bar.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
-
         <import type="android.view.View" />
+        <import type="org.mozilla.vrbrowser.utils.UrlUtils" />
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
 
         <variable
             name="widget"
@@ -32,11 +36,10 @@
 
         <LinearLayout
             android:id="@+id/title_bar"
-            style="?attr/navigationBarStyle"
             android:layout_width="260dp"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:background="@drawable/title_bar_background"
+            android:background="@{(viewmodel.isPrivateSession ? @drawable/title_bar_background_private : @drawable/title_bar_background)}"
             android:clickable="true"
             android:focusable="true"
             android:gravity="center_horizontal"
@@ -54,7 +57,7 @@
                 android:padding="5dp"
                 android:src="@drawable/ic_icon_security_state_insecure"
                 android:tint="@color/rhino"
-                android:visibility="gone" />
+                app:visibleGone="@{viewmodel.isInsecureVisible}" />
 
             <TextView
                 android:id="@+id/url"
@@ -69,15 +72,16 @@
                 android:paddingEnd="5dp"
                 android:requiresFadingEdge="horizontal"
                 android:singleLine="true"
-                tools:text="http://mozilla.org" />
+                tools:text="@{viewmodel.titleBarUrl}" />
         </LinearLayout>
 
         <org.mozilla.vrbrowser.ui.views.UIButton
             android:id="@+id/mediaButton"
             style="?attr/navigationBarButtonStyle"
-            android:src="@{isMediaPlaying ? @drawable/ic_icon_media_pause : @drawable/ic_icon_media_play}"
-            android:onClick="@{(view) -> isMediaPlaying ? delegate.onMediaPauseClicked(widget) : delegate.onMediaPlayClicked(widget)}"
-            android:tooltipText="@{isMediaPlaying ? @string/media_pause_tooltip : @string/media_resume_tooltip}"
-            android:visibility="@{isMediaAvailable ? View.VISIBLE : View.GONE}" />
+            android:src="@{viewmodel.isMediaPlaying ? @drawable/ic_icon_media_pause : @drawable/ic_icon_media_play}"
+            android:onClick="@{(view) -> viewmodel.isMediaPlaying ? delegate.onMediaPauseClicked(widget) : delegate.onMediaPlayClicked(widget)}"
+            android:tooltipText="@{viewmodel.isMediaPlaying ? @string/media_pause_tooltip : @string/media_resume_tooltip}"
+            android:visibility="@{viewmodel.isMediaAvailable ? View.VISIBLE : View.GONE}"
+            app:privateMode="@{viewmodel.isPrivateSession}"/>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/top_bar.xml
+++ b/app/src/main/res/layout/top_bar.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="org.mozilla.vrbrowser.ui.widgets.Windows.WindowPlacement"/>
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
+    </data>
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -15,29 +23,34 @@
 
         <LinearLayout
             android:id="@+id/multiWindowControlsContainer"
-            style="?attr/navigationBarStyle"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center_horizontal"
             android:orientation="horizontal"
-            android:padding="0dp">
+            app:visibleGone="@{!viewmodel.showClearButton}">
 
             <org.mozilla.vrbrowser.ui.views.UIButton
                 android:id="@+id/moveWindowLeftButton"
-                style="?attr/fullScreenButtonStyle"
-                android:background="@drawable/fullscreen_button_first"
-                android:src="@drawable/ic_icon_window_left" />
+                style="@style/uiButtonTheme"
+                android:background="@{viewmodel.isPrivateSession ? @drawable/fullscreen_button_private_first : @drawable/fullscreen_button_first}"
+                android:src="@drawable/ic_icon_window_left"
+                android:enabled="@{viewmodel.placement != WindowPlacement.LEFT}"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <org.mozilla.vrbrowser.ui.views.UIButton
                 android:id="@+id/closeWindowButton"
-                style="?attr/fullScreenButtonStyle"
-                android:src="@drawable/ic_icon_window_exit" />
+                style="@style/uiButtonTheme"
+                android:background="@{viewmodel.isPrivateSession ? @drawable/fullscreen_button_private : @drawable/fullscreen_button}"
+                android:src="@drawable/ic_icon_window_exit"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
 
             <org.mozilla.vrbrowser.ui.views.UIButton
                 android:id="@+id/moveWindowRightButton"
-                style="?attr/fullScreenButtonStyle"
-                android:background="@drawable/fullscreen_button_last"
-                android:src="@drawable/ic_icon_window_right" />
+                style="@style/uiButtonTheme"
+                android:background="@{viewmodel.isPrivateSession ? @drawable/fullscreen_button_private_last : @drawable/fullscreen_button_last}"
+                android:src="@drawable/ic_icon_window_right"
+                android:enabled="@{viewmodel.placement != WindowPlacement.RIGHT}"
+                app:privateMode="@{viewmodel.isPrivateSession}"/>
         </LinearLayout>
 
         <org.mozilla.vrbrowser.ui.views.UITextButton
@@ -47,7 +60,7 @@
             android:text="@string/private_clear_button"
             android:textAllCaps="true"
             android:textSize="@dimen/text_medium_big_size"
-            android:visibility="gone" />
+            app:visibleGone="@{viewmodel.showClearButton}" />
 
     </FrameLayout>
-</merge>
+</layout>

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+    <data>
+        <variable
+            name="viewmodel"
+            type="org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel" />
+    </data>
+
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -71,4 +77,4 @@
         </LinearLayout>
 
     </RelativeLayout>
-</merge>
+</layout>

--- a/app/src/noapi/java/org/mozilla/vrbrowser/PlatformActivity.java
+++ b/app/src/noapi/java/org/mozilla/vrbrowser/PlatformActivity.java
@@ -8,12 +8,12 @@ package org.mozilla.vrbrowser;
 import android.app.Activity;
 import android.opengl.GLSurfaceView;
 import android.os.Bundle;
-import android.provider.ContactsContract;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
-import android.widget.ImageButton;
 import android.widget.TextView;
+
+import androidx.annotation.Keep;
 
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
-
-import androidx.annotation.Keep;
 
 public class PlatformActivity extends Activity {
     static String LOGTAG = SystemUtils.createLogtag(PlatformActivity.class);


### PR DESCRIPTION
Fixes #2693 Support for config changes and language hot reload.

This fixes the related crash when changing the system language and also adds support for language hot reloading Fennec/Fenix style so no more restarts are required after changing languages.

There are a couple of things that I didn't add to this PR as it was getting too big already:
- [ ]  Refactor UI code to ViewModels to separate model/view which is very coupled right now. I started that for the PopUps view but there are still a lot of widgets to migrate. That would give us a better/easier way of saving/restoring UI states.
- [ ]  Add support for a default "Follow system language" as Fenix does so it's clearer for the user which language is being used.

Things to consider while testing:
- All widgets states restoration after a language change
- All widgets are correctly translated after a language change
- Languages changes both at a system and app levels