### PR TITLE
Fixes #2706 Remove dialog from stack when released

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/UIDialog.java
@@ -34,6 +34,7 @@ public abstract class UIDialog extends UIWidget implements WidgetManagerDelegate
     @Override
     public void releaseWidget() {
         mWidgetManager.removeWorldClickListener(this);
+        mDialogs.remove(this);
         super.releaseWidget();
     }
 


### PR DESCRIPTION
Fixes #2706 When quitting the app the process is not cleaned in Quest and the static memory is still alive when restarting. This forces that the Dialog is removed from the stack when the app is destroyed.