### PR TITLE
Keep currently open dialogs after a config change

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -136,8 +136,6 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
 
         updateBookmarks();
 
-        setVisibility(GONE);
-
         setOnTouchListener((v, event) -> {
             v.requestFocusFromTouch();
             return false;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -138,8 +138,6 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
 
         updateHistory();
 
-        setVisibility(GONE);
-
         setOnTouchListener((v, event) -> {
             v.requestFocusFromTouch();
             return false;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -35,6 +35,7 @@ import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.databinding.TrayBinding;
 import org.mozilla.vrbrowser.ui.viewmodel.WindowViewModel;
 import org.mozilla.vrbrowser.ui.views.UIButton;
+import org.mozilla.vrbrowser.ui.widgets.settings.SettingsView;
 import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 
 import java.util.ArrayList;
@@ -431,10 +432,10 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Widge
     }
 
     public void toggleSettingsDialog() {
-        toggleSettingsDialog(SettingsWidget.SettingDialog.MAIN);
+        toggleSettingsDialog(SettingsView.SettingViewType.MAIN);
     }
 
-    public void toggleSettingsDialog(@NonNull SettingsWidget.SettingDialog settingDialog) {
+    public void toggleSettingsDialog(@NonNull SettingsView.SettingViewType settingDialog) {
         UIWidget widget = getChild(mSettingsDialogHandle);
         if (widget == null) {
             widget = createChild(SettingsWidget.class, false);
@@ -451,7 +452,7 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Widge
         }
     }
 
-    public void showSettingsDialog(@NonNull SettingsWidget.SettingDialog settingDialog) {
+    public void showSettingsDialog(@NonNull SettingsView.SettingViewType settingDialog) {
         UIWidget widget = getChild(mSettingsDialogHandle);
         if (widget == null) {
             widget = createChild(SettingsWidget.class, false);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -75,6 +75,7 @@ import mozilla.components.concept.storage.RedirectSource;
 import mozilla.components.concept.storage.VisitInfo;
 import mozilla.components.concept.storage.VisitType;
 
+import static org.mozilla.vrbrowser.ui.widgets.settings.SettingsView.SettingViewType.FXA;
 import static org.mozilla.vrbrowser.utils.ServoUtils.isInstanceOfServoSession;
 
 public class WindowWidget extends UIWidget implements SessionChangeListener,
@@ -1361,7 +1362,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onFxASynSettings(@NonNull View view) {
-            mWidgetManager.getTray().showSettingsDialog(SettingsWidget.SettingDialog.FXA);
+            mWidgetManager.getTray().showSettingsDialog(FXA);
         }
 
         @Override
@@ -1400,7 +1401,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         @Override
         public void onFxASynSettings(@NonNull View view) {
-            mWidgetManager.getTray().showSettingsDialog(SettingsWidget.SettingDialog.FXA);
+            mWidgetManager.getTray().showSettingsDialog(FXA);
         }
 
         @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -59,7 +59,6 @@ import org.mozilla.vrbrowser.ui.widgets.dialogs.PromptDialogWidget;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.SelectionActionWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.ContextMenuWidget;
 import org.mozilla.vrbrowser.ui.widgets.menus.LibraryMenuWidget;
-import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.Arrays;
@@ -315,12 +314,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
         mHistoryView.updateUI();
         mBookmarksView.updateUI();
-
-        if (mView != null) {
-            View temp = mView;
-            unsetView(mView, false);
-            setView(temp, false);
-        }
 
         mViewModel.refresh();
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -24,7 +24,6 @@ import org.mozilla.vrbrowser.telemetry.GleanMetricsService;
 import org.mozilla.vrbrowser.telemetry.TelemetryWrapper;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.PromptDialogWidget;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.UIDialog;
-import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 import org.mozilla.vrbrowser.utils.BitmapCache;
 import org.mozilla.vrbrowser.utils.ConnectivityReceiver;
 import org.mozilla.vrbrowser.utils.SystemUtils;
@@ -46,6 +45,8 @@ import mozilla.components.concept.sync.AuthType;
 import mozilla.components.concept.sync.OAuthAccount;
 import mozilla.components.concept.sync.Profile;
 import mozilla.components.concept.sync.TabData;
+
+import static org.mozilla.vrbrowser.ui.widgets.settings.SettingsView.SettingViewType.FXA;
 
 public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWidget.Delegate,
         WindowWidget.WindowListener, TabsWidget.TabDelegate, Services.TabReceivedDelegate {
@@ -876,7 +877,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                         break;
 
                     case SETTINGS:
-                        mWidgetManager.getTray().showSettingsDialog(SettingsWidget.SettingDialog.FXA);
+                        mWidgetManager.getTray().showSettingsDialog(FXA);
                         break;
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SignOutDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SignOutDialogWidget.java
@@ -13,10 +13,11 @@ import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.Accounts;
 import org.mozilla.vrbrowser.browser.Places;
 import org.mozilla.vrbrowser.ui.widgets.UIWidget;
-import org.mozilla.vrbrowser.ui.widgets.settings.SettingsWidget;
 
 import java.util.Objects;
 import java.util.concurrent.Executor;
+
+import static org.mozilla.vrbrowser.ui.widgets.settings.SettingsView.SettingViewType.FXA;
 
 public class SignOutDialogWidget extends PromptDialogWidget {
 
@@ -60,10 +61,10 @@ public class SignOutDialogWidget extends PromptDialogWidget {
 
             } else if (index == PromptDialogWidget.POSITIVE) {
                 hide(UIWidget.REMOVE_WIDGET);
-                mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA);
+                mWidgetManager.getTray().toggleSettingsDialog(FXA);
             }
         });
-        setDelegate(() -> mWidgetManager.getTray().toggleSettingsDialog(SettingsWidget.SettingDialog.FXA));
+        setDelegate(() -> mWidgetManager.getTray().toggleSettingsDialog(FXA));
 
         setDescriptionVisible(false);
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ContentLanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ContentLanguageOptionsView.java
@@ -63,7 +63,7 @@ public class ContentLanguageOptionsView extends SettingsView {
 
         // Header
         mBinding.headerLayout.setBackClickListener(view -> {
-            mDelegate.showView(new LanguageOptionsView(getContext(), mWidgetManager));
+            mDelegate.showView(SettingViewType.LANGUAGE);
         });
         mBinding.headerLayout.setHelpClickListener(view -> {
             SessionStore.get().getActiveSession().loadUri(getResources().getString(R.string.sumo_language_content_url));
@@ -158,4 +158,8 @@ public class ContentLanguageOptionsView extends SettingsView {
         refreshLanguages();
     }
 
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.LANGUAGE_CONTENT;
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ControllerOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/ControllerOptionsView.java
@@ -93,4 +93,9 @@ class ControllerOptionsView extends SettingsView {
         setScrollDirection(checkedId, doApply);
     };
 
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.CONTROLLER;
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DeveloperOptionsView.java
@@ -227,4 +227,9 @@ class DeveloperOptionsView extends SettingsView {
         }
     }
 
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.LANGUAGE_VOICE;
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayLanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayLanguageOptionsView.java
@@ -46,7 +46,7 @@ class DisplayLanguageOptionsView extends SettingsView {
 
         // Header
         mBinding.headerLayout.setBackClickListener(view -> {
-            mDelegate.showView(new LanguageOptionsView(getContext(), mWidgetManager));
+            mDelegate.showView(SettingViewType.LANGUAGE);
         });
         mBinding.headerLayout.setHelpClickListener(view -> {
             SessionStore.get().getActiveSession().loadUri(getResources().getString(R.string.sumo_language_display_url));
@@ -109,6 +109,11 @@ class DisplayLanguageOptionsView extends SettingsView {
     public Point getDimensions() {
         return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
                 WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+    }
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.LANGUAGE_DISPLAY;
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
@@ -346,4 +346,9 @@ class DisplayOptionsView extends SettingsView {
                 WidgetPlacement.dpDimension(getContext(), R.dimen.display_options_height));
     }
 
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.DISPLAY;
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/EnvironmentOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/EnvironmentOptionsView.java
@@ -121,4 +121,9 @@ class EnvironmentOptionsView extends SettingsView {
         }
     }
 
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.ENVIRONMENT;
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/FxAAccountOptionsView.java
@@ -239,4 +239,9 @@ class FxAAccountOptionsView extends SettingsView {
         }
     };
 
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.FXA;
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
@@ -135,11 +135,11 @@ class LanguageOptionsView extends SettingsView {
         return spanned;
     }
 
-    private OnClickListener mContentListener = v -> mDelegate.showView(mContentLanguage);
+    private OnClickListener mContentListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_CONTENT);
 
-    private OnClickListener mVoiceSearchListener = v -> mDelegate.showView(mVoiceLanguage);
+    private OnClickListener mVoiceSearchListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_VOICE);
 
-    private OnClickListener mDisplayListener = v -> mDelegate.showView(mDisplayLanguage);
+    private OnClickListener mDisplayListener = v -> mDelegate.showView(SettingViewType.LANGUAGE_DISPLAY);
 
     private SharedPreferences.OnSharedPreferenceChangeListener mPreferencesListener = (sharedPreferences, key) -> {
         if (key.equals(getContext().getString(R.string.settings_key_content_languages))) {
@@ -157,6 +157,11 @@ class LanguageOptionsView extends SettingsView {
     public Point getDimensions() {
         return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
                 WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+    }
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.LANGUAGE;
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PopUpExceptionsOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PopUpExceptionsOptionsView.java
@@ -57,7 +57,7 @@ class PopUpExceptionsOptionsView extends SettingsView {
 
         // Header
         mBinding.headerLayout.setBackClickListener(view -> {
-            mDelegate.showView(new PrivacyOptionsView(getContext(), mWidgetManager));
+            mDelegate.showView(SettingViewType.PRIVACY);
         });
 
         // Adapters
@@ -121,5 +121,10 @@ class PopUpExceptionsOptionsView extends SettingsView {
         }
 
     };
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.POPUP_EXCEPTIONS;
+    }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/PrivacyOptionsView.java
@@ -35,7 +35,6 @@ class PrivacyOptionsView extends SettingsView {
 
     private OptionsPrivacyBinding mBinding;
     private ArrayList<Pair<SwitchSetting, String>> mPermissionButtons;
-    private SettingsView mPopUpsBlockingExceptions;
 
     public PrivacyOptionsView(Context aContext, WidgetManagerDelegate aWidgetManager) {
         super(aContext, aWidgetManager);
@@ -85,8 +84,6 @@ class PrivacyOptionsView extends SettingsView {
         TextView permissionsTitleText = findViewById(R.id.permissionsTitle);
         permissionsTitleText.setText(getContext().getString(R.string.security_options_permissions_title, getContext().getString(R.string.app_name)));
 
-        mPopUpsBlockingExceptions = new PopUpExceptionsOptionsView(getContext(), mWidgetManager);
-
         mPermissionButtons = new ArrayList<>();
         mPermissionButtons.add(Pair.create(findViewById(R.id.cameraPermissionSwitch), Manifest.permission.CAMERA));
         mPermissionButtons.add(Pair.create(findViewById(R.id.microphonePermissionSwitch), Manifest.permission.RECORD_AUDIO));
@@ -128,7 +125,7 @@ class PrivacyOptionsView extends SettingsView {
         mBinding.popUpsBlockingSwitch.setOnCheckedChangeListener(mPopUpsBlockingListener);
         setPopUpsBlocking(SettingsStore.getInstance(getContext()).isPopUpsBlockingEnabled(), false);
 
-        mBinding.popUpsBlockingExceptionsButton.setOnClickListener(v -> mDelegate.showView(mPopUpsBlockingExceptions));
+        mBinding.popUpsBlockingExceptionsButton.setOnClickListener(v -> mDelegate.showView(SettingViewType.POPUP_EXCEPTIONS));
 
         mBinding.restoreTabsSwitch.setOnCheckedChangeListener(mRestoreTabsListener);
         setRestoreTabs(SettingsStore.getInstance(getContext()).isRestoreTabsEnabled(), false);
@@ -353,5 +350,10 @@ class PrivacyOptionsView extends SettingsView {
             activity.getApplication().unregisterActivityLifecycleCallbacks(mLifeCycleListener);
         }
     };
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.PRIVACY;
+    }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsView.java
@@ -13,7 +13,23 @@ import org.mozilla.vrbrowser.ui.views.CustomScrollView;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
 
-abstract class SettingsView extends FrameLayout {
+public abstract class SettingsView extends FrameLayout {
+
+    public enum SettingViewType {
+        MAIN,
+        LANGUAGE,
+        LANGUAGE_DISPLAY,
+        LANGUAGE_CONTENT,
+        LANGUAGE_VOICE,
+        DISPLAY,
+        PRIVACY,
+        POPUP_EXCEPTIONS,
+        DEVELOPER,
+        FXA,
+        ENVIRONMENT,
+        CONTROLLER
+    }
+
     protected Delegate mDelegate;
     protected WidgetManagerDelegate mWidgetManager;
     protected CustomScrollView mScrollbar;
@@ -23,7 +39,7 @@ abstract class SettingsView extends FrameLayout {
         void exitWholeSettings();
         void showRestartDialog();
         void showAlert(String aTitle, String aMessage);
-        void showView(SettingsView view);
+        void showView(SettingsView.SettingViewType type);
     }
 
     public SettingsView(@NonNull Context context, WidgetManagerDelegate aWidgetManager) {
@@ -95,5 +111,7 @@ abstract class SettingsView extends FrameLayout {
     protected void updateUI() {
         removeAllViews();
     }
+
+    protected abstract SettingViewType getType();
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -229,7 +229,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        
+
         showView(mOpenDialog);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/SettingsWidget.java
@@ -55,10 +55,6 @@ import mozilla.components.concept.sync.Profile;
 
 public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
 
-    public enum SettingDialog {
-        MAIN, LANGUAGE, DISPLAY, PRIVACY, DEVELOPER, FXA, ENVIRONMENT, CONTROLLER
-    }
-
     private SettingsBinding mBinding;
     private AudioEngine mAudio;
     private SettingsView mCurrentView;
@@ -67,6 +63,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     private RestartDialogWidget mRestartDialog;
     private Accounts mAccounts;
     private Executor mUIThreadExecutor;
+    private SettingsView.SettingViewType mOpenDialog;
 
     class VersionGestureListener extends GestureDetector.SimpleOnGestureListener {
 
@@ -100,6 +97,8 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     @SuppressLint("ClickableViewAccessibility")
     private void initialize() {
         updateUI();
+
+        mOpenDialog = SettingsView.SettingViewType.MAIN;
 
         mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
         mAccounts.addAccountListener(mAccountObserver);
@@ -165,7 +164,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
 
-            showEnvironmentOptionsDialog();
+            showView(SettingsView.SettingViewType.ENVIRONMENT);
         });
 
         try {
@@ -221,7 +220,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
 
-            showControllerOptionsDialog();
+            showView(SettingsView.SettingViewType.CONTROLLER);
         });
 
         mCurrentView = null;
@@ -230,8 +229,8 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-
-        updateUI();
+        
+        showView(mOpenDialog);
     }
 
     @Override
@@ -257,7 +256,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     }
 
     private void onSettingsPrivacyClick() {
-        showView(new PrivacyOptionsView(getContext(), mWidgetManager));
+        showView(SettingsView.SettingViewType.PRIVACY);
     }
 
     private void onSettingsReportClick() {
@@ -320,7 +319,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
                 break;
 
             case SIGNED_IN:
-                post(this::showFXAOptionsDialog);
+                post(() -> showView(SettingsView.SettingViewType.FXA));
                 break;
         }
     }
@@ -377,24 +376,67 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
     }
 
     private void onDeveloperOptionsClick() {
-        showDeveloperOptionsDialog();
+        showView(SettingsView.SettingViewType.DEVELOPER);
     }
 
     private void onLanguageOptionsClick() {
-        showLanguageOptionsDialog();
+        showView(SettingsView.SettingViewType.LANGUAGE);
     }
 
     private void onDisplayOptionsClick() {
-        showDisplayOptionsDialog();
+        showView(SettingsView.SettingViewType.DISPLAY);
     }
 
-    public void showView(SettingsView aView) {
+    @Override
+    public void showView(SettingsView.SettingViewType aType) {
+        switch (aType) {
+            case MAIN:
+                showView((SettingsView) null);
+                break;
+            case LANGUAGE:
+                showView(new LanguageOptionsView(getContext(), mWidgetManager));
+                break;
+            case LANGUAGE_DISPLAY:
+                showView(new DisplayLanguageOptionsView(getContext(), mWidgetManager));
+                break;
+            case LANGUAGE_CONTENT:
+                showView(new ContentLanguageOptionsView(getContext(), mWidgetManager));
+                break;
+            case LANGUAGE_VOICE:
+                showView(new VoiceSearchLanguageOptionsView(getContext(), mWidgetManager));
+                break;
+            case DISPLAY:
+                showView(new DisplayOptionsView(getContext(), mWidgetManager));
+                break;
+            case PRIVACY:
+                showView(new PrivacyOptionsView(getContext(), mWidgetManager));
+                break;
+            case POPUP_EXCEPTIONS:
+                showView(new PopUpExceptionsOptionsView(getContext(), mWidgetManager));
+                break;
+            case DEVELOPER:
+                showView(new DeveloperOptionsView(getContext(), mWidgetManager));
+                break;
+            case FXA:
+                showView(new FxAAccountOptionsView(getContext(), mWidgetManager));
+                break;
+            case ENVIRONMENT:
+                showView(new EnvironmentOptionsView(getContext(), mWidgetManager));
+                break;
+            case CONTROLLER:
+                showView(new ControllerOptionsView(getContext(), mWidgetManager));
+                break;
+        }
+    }
+
+    private void showView(SettingsView aView) {
         if (mCurrentView != null) {
             mCurrentView.onHidden();
             this.removeView(mCurrentView);
         }
         mCurrentView = aView;
         if (mCurrentView != null) {
+            mOpenDialog = aView.getType();
             Point viewDimensions = mCurrentView.getDimensions();
             mViewMarginH = mWidgetPlacement.width - viewDimensions.x;
             mViewMarginH = WidgetPlacement.convertDpToPixel(getContext(), mViewMarginH);
@@ -410,69 +452,18 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
             mBinding.optionsLayout.setVisibility(View.GONE);
 
         } else {
+            updateUI();
             mBinding.optionsLayout.setVisibility(View.VISIBLE);
             updateCurrentAccountState();
         }
     }
 
-    private void showPrivacyOptionsDialog() {
-        showView(new PrivacyOptionsView(getContext(), mWidgetManager));
-    }
-
-    private void showDeveloperOptionsDialog() {
-        showView(new DeveloperOptionsView(getContext(), mWidgetManager));
-    }
-
-    private void showControllerOptionsDialog() {
-        showView(new ControllerOptionsView(getContext(), mWidgetManager));
-    }
-
-    private void showLanguageOptionsDialog() {
-        LanguageOptionsView view = new LanguageOptionsView(getContext(), mWidgetManager);
-        view.setDelegate(this);
-        showView(view);
-    }
-
-    private void showDisplayOptionsDialog() {
-        showView(new DisplayOptionsView(getContext(), mWidgetManager));
-    }
-
-    private void showEnvironmentOptionsDialog() {
-        showView(new EnvironmentOptionsView(getContext(), mWidgetManager));
-    }
-
-    private void showFXAOptionsDialog() {
-        showView(new FxAAccountOptionsView(getContext(), mWidgetManager));
-    }
-
-    public void show(@ShowFlags int aShowFlags, @NonNull SettingDialog settingDialog) {
+    public void show(@ShowFlags int aShowFlags, @NonNull SettingsView.SettingViewType settingDialog) {
         if (!isVisible()) {
             show(aShowFlags);
         }
 
-        switch (settingDialog) {
-            case LANGUAGE:
-                showLanguageOptionsDialog();
-                break;
-            case DISPLAY:
-                showDisplayOptionsDialog();
-                break;
-            case PRIVACY:
-                showPrivacyOptionsDialog();
-                break;
-            case DEVELOPER:
-                showDeveloperOptionsDialog();
-                break;
-            case FXA:
-                showFXAOptionsDialog();
-                break;
-            case ENVIRONMENT:
-                showEnvironmentOptionsDialog();
-                break;
-            case CONTROLLER:
-                showControllerOptionsDialog();
-                break;
-        }
+        showView(settingDialog);
     }
 
     @Override
@@ -488,13 +479,13 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
         if (mCurrentView != null) {
             if (!mCurrentView.isEditing()) {
                 if (isLanguagesSubView(mCurrentView)) {
-                    showLanguageOptionsDialog();
+                    showView(SettingsView.SettingViewType.LANGUAGE);
 
                 } else if (isPrivacySubView(mCurrentView)) {
-                    showPrivacyOptionsDialog();
+                    showView(SettingsView.SettingViewType.PRIVACY);
 
                 } else {
-                    showView(null);
+                    showView(SettingsView.SettingViewType.MAIN);
                 }
             }
         } else {
@@ -504,7 +495,7 @@ public class SettingsWidget extends UIDialog implements SettingsView.Delegate {
 
     @Override
     public void exitWholeSettings() {
-        showView(null);
+        showView(SettingsView.SettingViewType.MAIN);
         hide(UIWidget.REMOVE_WIDGET);
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/VoiceSearchLanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/VoiceSearchLanguageOptionsView.java
@@ -46,7 +46,7 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
 
         // Header
         mBinding.headerLayout.setBackClickListener(view -> {
-            mDelegate.showView(new LanguageOptionsView(getContext(), mWidgetManager));
+            mDelegate.showView(SettingViewType.LANGUAGE);
         });
         mBinding.headerLayout.setHelpClickListener(view -> {
             SessionStore.get().getActiveSession().loadUri(getResources().getString(R.string.sumo_language_voice_url));
@@ -106,6 +106,11 @@ class VoiceSearchLanguageOptionsView extends SettingsView {
     public Point getDimensions() {
         return new Point( WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_width),
                 WidgetPlacement.dpDimension(getContext(), R.dimen.settings_dialog_height));
+    }
+
+    @Override
+    protected SettingViewType getType() {
+        return SettingViewType.LANGUAGE_VOICE;
     }
     
 }


### PR DESCRIPTION
Before this after a config change or a language change settings were reset to the main settings panel and bookmarks and history panels were closed. This PR fixes that.