### PR TITLE
Support for dragging outside the widget bounds

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -398,8 +398,8 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
                             controller.lastButtonState & ControllerDelegate::BUTTON_TOUCHPAD;
 
     bool isResizing = resizingWidget && resizingWidget->IsResizingActive();
-    bool isDragging = pressed && wasPressed && controller.widget;
-    if (isDragging && !isResizing) {
+    bool isDragging = pressed && wasPressed && controller.widget && !isResizing;
+    if (isDragging) {
       WidgetPtr widget = GetWidget(controller.widget);
       vrb::Vector result;
       vrb::Vector normal;

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -392,26 +392,47 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
     vrb::Vector hitPoint;
     vrb::Vector hitNormal;
 
-    for (const WidgetPtr& widget: widgets) {
-      if (resizingWidget && resizingWidget->IsResizingActive() && resizingWidget != widget) {
-        // Don't interact with other widgets when resizing gesture is active.
-        continue;
-      }
-      if (movingWidget && movingWidget->GetWidget() != widget) {
-        // Don't interact with other widgets when moving gesture is active.
-        continue;
-      }
+    const bool pressed = controller.buttonState & ControllerDelegate::BUTTON_TRIGGER ||
+                         controller.buttonState & ControllerDelegate::BUTTON_TOUCHPAD;
+    const bool wasPressed = controller.lastButtonState & ControllerDelegate::BUTTON_TRIGGER ||
+                            controller.lastButtonState & ControllerDelegate::BUTTON_TOUCHPAD;
+
+    bool isResizing = resizingWidget && resizingWidget->IsResizingActive();
+    bool isDragging = pressed && wasPressed && controller.widget;
+    if (isDragging && !isResizing) {
+      WidgetPtr widget = GetWidget(controller.widget);
       vrb::Vector result;
       vrb::Vector normal;
       float distance = 0.0f;
       bool isInWidget = false;
-      const bool clamp = !widget->IsResizing() && !movingWidget;
-      if (widget->TestControllerIntersection(start, direction, result, normal, clamp, isInWidget, distance)) {
-        if (isInWidget && (distance < hitDistance)) {
-          hitWidget = widget;
-          hitDistance = distance;
-          hitPoint = result;
-          hitNormal = normal;
+      if (widget->TestControllerIntersection(start, direction, result, normal, false, isInWidget, distance)) {
+        hitWidget = widget;
+        hitPoint = result;
+        hitNormal = normal;
+      }
+
+    } else {
+      for (const WidgetPtr& widget: widgets) {
+        if (isResizing && resizingWidget != widget) {
+          // Don't interact with other widgets when resizing gesture is active.
+          continue;
+        }
+        if (movingWidget && movingWidget->GetWidget() != widget) {
+          // Don't interact with other widgets when moving gesture is active.
+          continue;
+        }
+        vrb::Vector result;
+        vrb::Vector normal;
+        float distance = 0.0f;
+        bool isInWidget = false;
+        const bool clamp = !widget->IsResizing() && !movingWidget;
+        if (widget->TestControllerIntersection(start, direction, result, normal, clamp, isInWidget, distance)) {
+          if (isInWidget && (distance < hitDistance)) {
+            hitWidget = widget;
+            hitDistance = distance;
+            hitPoint = result;
+            hitNormal = normal;
+          }
         }
       }
     }
@@ -432,11 +453,6 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
         controller.pointer->SetScale(hitPoint, device->GetHeadTransform());
       }
     }
-
-    const bool pressed = controller.buttonState & ControllerDelegate::BUTTON_TRIGGER ||
-                         controller.buttonState & ControllerDelegate::BUTTON_TOUCHPAD;
-    const bool wasPressed = controller.lastButtonState & ControllerDelegate::BUTTON_TRIGGER ||
-                              controller.lastButtonState & ControllerDelegate::BUTTON_TOUCHPAD;
 
     if (movingWidget && movingWidget->IsMoving(controller.index)) {
       if (!pressed && wasPressed) {
@@ -469,7 +485,7 @@ BrowserWorld::State::UpdateControllers(bool& aRelayoutWidgets) {
       }
     } else if (hitWidget) {
       float theX = 0.0f, theY = 0.0f;
-      hitWidget->ConvertToWidgetCoordinates(hitPoint, theX, theY);
+      hitWidget->ConvertToWidgetCoordinates(hitPoint, theX, theY, !isDragging);
       const uint32_t handle = hitWidget->GetHandle();
       if (!pressed && wasPressed) {
         controller.inDeadZone = true;

--- a/app/src/main/cpp/Cylinder.cpp
+++ b/app/src/main/cpp/Cylinder.cpp
@@ -482,10 +482,10 @@ Cylinder::ConvertToQuadCoordinates(const vrb::Vector& point, float& aX, float& a
     if (ratioX < 0.0f) {
       ratioX = 0.0f;
     }
-
-    aX = ratioX * m.textureWidth;
-    aY = ratioY * m.textureHeight;
   }
+
+  aX = ratioX * m.textureWidth;
+  aY = ratioY * m.textureHeight;
 }
 
 void

--- a/app/src/main/cpp/Widget.cpp
+++ b/app/src/main/cpp/Widget.cpp
@@ -338,12 +338,12 @@ Widget::TestControllerIntersection(const vrb::Vector& aStartPoint, const vrb::Ve
 }
 
 void
-Widget::ConvertToWidgetCoordinates(const vrb::Vector& point, float& aX, float& aY) const {
+Widget::ConvertToWidgetCoordinates(const vrb::Vector& point, float& aX, float& aY, bool aClamp) const {
   bool clamp = !m.resizing;
   if (m.quad) {
-    m.quad->ConvertToQuadCoordinates(point, aX, aY, clamp);
+    m.quad->ConvertToQuadCoordinates(point, aX, aY, clamp && aClamp);
   } else {
-    m.cylinder->ConvertToQuadCoordinates(point, aX, aY, clamp);
+    m.cylinder->ConvertToQuadCoordinates(point, aX, aY, clamp && aClamp);
   }
 }
 

--- a/app/src/main/cpp/Widget.h
+++ b/app/src/main/cpp/Widget.h
@@ -53,7 +53,7 @@ public:
   void GetWorldSize(float& aWidth, float& aHeight) const;
   bool TestControllerIntersection(const vrb::Vector& aStartPoint, const vrb::Vector& aDirection, vrb::Vector& aResult, vrb::Vector& aNormal,
                                   const bool aClamp, bool& aIsInWidget, float& aDistance) const;
-  void ConvertToWidgetCoordinates(const vrb::Vector& aPoint, float& aX, float& aY) const;
+  void ConvertToWidgetCoordinates(const vrb::Vector& aPoint, float& aX, float& aY, bool aClamp = true) const;
   vrb::Vector ConvertToWorldCoordinates(const vrb::Vector& aLocalPoint) const;
   vrb::Vector ConvertToWorldCoordinates(const float aWidgetX, const float aWidgetY) const;
   const vrb::Matrix GetTransform() const;


### PR DESCRIPTION
When you are press and drag outside the widget bounds the input stops. This adds support for dragging outside the widget bounds. I think it is a more natural behavior for the input.

I started this branch a while ago so I guess it's a good moment to share and check if this is something that we like.