### PR TITLE
Fixes #2757 Remove the notification Id when closed by a back button click

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NotificationManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NotificationManager.java
@@ -149,6 +149,7 @@ public class NotificationManager {
         }
 
         TooltipWidget notificationView = new TooltipWidget(notification.mParent.getContext(), notification.mLayoutRes);
+        notificationView.setDelegate(() -> hide(notificationId));
 
         notification.mParent.requestFocus();
         notification.mParent.requestFocusFromTouch();


### PR DESCRIPTION
Fixes #2757 Remove the notification Id when closed by a back button click