### PR TITLE
Fix leaked JNI local reference in GeckoSurfaceTexture

### DIFF
--- a/app/src/main/cpp/ExternalBlitter.cpp
+++ b/app/src/main/cpp/ExternalBlitter.cpp
@@ -160,6 +160,7 @@ ExternalBlitter::CancelFrame(const int32_t aSurfaceHandle) {
     surface = iter->second;
   } else {
     surface = GeckoSurfaceTexture::Create(aSurfaceHandle);
+    m.surfaceMap[aSurfaceHandle] = surface;
   }
 
   if (surface) {

--- a/app/src/main/cpp/GeckoSurfaceTexture.cpp
+++ b/app/src/main/cpp/GeckoSurfaceTexture.cpp
@@ -137,6 +137,7 @@ GeckoSurfaceTexture::Create(const int32_t aHandle) {
   }
   result = std::make_shared<vrb::ConcreteClass<GeckoSurfaceTexture, GeckoSurfaceTexture::State> >();
   result->m.surface = sEnv->NewGlobalRef(surface);
+  sEnv->DeleteLocalRef(surface);
   result->IncrementUse();
   return result;
 }


### PR DESCRIPTION
I hit a JNI reference overflow when working on exit from WebXR. This happens because exit is not working yet and the ExternalBlitter->cancelFrame() is called every frame, leading to a crash after some seconds.

The leak also happens in WebVR but in a slower pace

