### PR TITLE
Fixes #2794 Close library panels when a new request is loaded

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1614,6 +1614,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             } else {
                 hideLibraryPanels();
             }
+            
+        } else {
+            hideLibraryPanels();
         }
 
         if ("file".equalsIgnoreCase(uri.getScheme()) &&


### PR DESCRIPTION
Fixes #2794 Close library panels when a new request is loaded