### PR TITLE
Update Bookmarks strings after a language change

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -513,9 +513,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
         LocaleUtils.update(this, language);
 
-        mWidgets.forEach((i, widget) -> widget.onConfigurationChanged(newConfig));
-
         SessionStore.get().onConfigurationChanged(newConfig);
+        mWidgets.forEach((i, widget) -> widget.onConfigurationChanged(newConfig));
 
         super.onConfigurationChanged(newConfig);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/BookmarksStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/BookmarksStore.kt
@@ -6,6 +6,7 @@
 package org.mozilla.vrbrowser.browser
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Handler
 import android.os.Looper
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -60,7 +61,7 @@ class BookmarksStore constructor(val context: Context) {
 
     private val listeners = ArrayList<BookmarkListener>()
     private var storage = (context.applicationContext as VRBrowserApplication).places.bookmarks
-    private val titles = rootTitles(context)
+    private var titles = rootTitles(context)
     private val accountManager = (context.applicationContext as VRBrowserApplication).services.accountManager
 
     // Bookmarks might have changed during sync, so notify our listeners.
@@ -79,6 +80,11 @@ class BookmarksStore constructor(val context: Context) {
         accountManager.registerForSyncEvents(
             syncStatusObserver, ProcessLifecycleOwner.get(), false
         )
+    }
+
+    // Update the folder strings after a language update
+    fun onConfigurationChanged(newConfig: Configuration) {
+        titles = rootTitles(context)
     }
 
     interface BookmarkListener {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -241,6 +241,8 @@ public class SessionStore implements GeckoSession.PermissionDelegate {
         if (mRuntime != null) {
             mRuntime.configurationChanged(newConfig);
         }
+
+        mBookmarksStore.onConfigurationChanged(newConfig);
     }
 
     // Session Settings


### PR DESCRIPTION
Now after a language change the bookmark titles should be updated correctly.