### PR TITLE
Adjusting zh-tw keyboard layout.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
@@ -44,7 +44,7 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
     @Override
     public CustomKeyboard getAlphabeticKeyboard() {
         if (mKeyboard == null) {
-            mKeyboard = new CustomKeyboard(mContext.getApplicationContext(), R.xml.keyboard_zhuyin);
+            mKeyboard = new CustomKeyboard(mContext.getApplicationContext(), R.xml.keyboard_qwerty_zhuyin);
             loadDatabase();
         }
         return mKeyboard;
@@ -153,7 +153,7 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
     @Override
     public String getSpaceKeyText(String aComposingText) {
         if (aComposingText == null || aComposingText.trim().isEmpty()) {
-            return StringUtils.getStringByLocale(mContext, R.string.settings_language_traditional_chinese, getLocale());
+            return "";
         } else {
             return mContext.getString(R.string.zhuyin_spacebar_selection);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
@@ -24,10 +24,17 @@ import java.util.regex.Pattern;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import jp.co.omronsoft.openwnn.ComposingText;
+import jp.co.omronsoft.openwnn.SymbolList;
+import jp.co.omronsoft.openwnn.WnnWord;
+
 public class ChineseZhuyinKeyboard extends BaseKeyboard {
     private static final String LOGTAG = SystemUtils.createLogtag(ChineseZhuyinKeyboard.class);
     private static final String nonZhuyinReg = "[^ㄅ-ㄩ˙ˊˇˋˉ]";
     private CustomKeyboard mKeyboard;
+    private CustomKeyboard mSymbolsKeyboard;
+    private SymbolList mSymbolsConverter;  // For Emoji characters.
+    private List<Words> mEmojiList = null;
     private DBWordHelper mWordDB;
     private DBPhraseHelper mPhraseDB;
     private HashMap<String, KeyMap> mKeymaps = new HashMap<>();
@@ -48,6 +55,17 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
             loadDatabase();
         }
         return mKeyboard;
+    }
+
+    @Nullable
+    @Override
+    public CustomKeyboard getSymbolsKeyboard() {
+        if (mSymbolsKeyboard == null) {
+            mSymbolsKeyboard = new CustomKeyboard(mContext.getApplicationContext(), R.xml.keyboard_symbols_zhuyin);
+            // We use openwnn to provide us Emoji character although we are not using JPN keyboard.
+            mSymbolsConverter = new SymbolList(mContext, SymbolList.LANG_JA);
+        }
+        return mSymbolsKeyboard;
     }
 
     @Nullable
@@ -93,6 +111,31 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
         return result;
     }
 
+    @Override
+    public CandidatesResult getEmojiCandidates(String aComposingText) {
+        if (mEmojiList == null) {
+            List<Words> words = new ArrayList<>();
+            ComposingText text = new ComposingText();
+            mSymbolsConverter.convert(text);
+
+            int candidates = mSymbolsConverter.predict(text, 0, -1);
+            if (candidates > 0) {
+                WnnWord word;
+                while ((word = mSymbolsConverter.getNextCandidate()) != null) {
+                    words.add(new Words(1, word.stroke, word.candidate));
+                }
+                mEmojiList = words;
+            }
+        }
+
+        CandidatesResult result = new CandidatesResult();
+        result.words = mEmojiList;
+        result.action = CandidatesResult.Action.SHOW_CANDIDATES;
+        result.composing = aComposingText;
+
+        return result;
+    }
+
     private String GetTransCode(String aText) {
         String code = aText;
         String transCode = "";
@@ -112,6 +155,14 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
 
         if (aComposing.matches(nonZhuyinReg)) {
             return aComposing.replaceFirst(Pattern.quote(aCode), "");
+        }
+
+        if (mEmojiList != null) {
+            for (Words word : mEmojiList) {
+                if (word.code.equals(aCode)) {
+                    return "";
+                }
+            }
         }
 
         for (int i = 0; i <= aCode.length() - shift; i += shift) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -956,8 +956,10 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     private void updateSpecialKeyLabels() {
         String enterText = mCurrentKeyboard.getEnterKeyText(mEditorInfo.imeOptions, mComposingText);
+        String spaceText = mCurrentKeyboard.getSpaceKeyText(mComposingText);
         String modeChangeText = mCurrentKeyboard.getModeChangeKeyText();
         boolean changed = mCurrentKeyboard.getAlphabeticKeyboard().setEnterKeyLabel(enterText);
+        changed |= mCurrentKeyboard.getAlphabeticKeyboard().setSpaceKeyLabel(spaceText);
         CustomKeyboard symbolsKeyboard = getSymbolsKeyboard();
         changed |= symbolsKeyboard.setModeChangeKeyLabel(modeChangeText);
         symbolsKeyboard.setEnterKeyLabel(enterText);

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -25,6 +25,7 @@
     <item name="keyboard_world_width" format="float" type="dimen">3.25</item>
     <item name="keyboard_x" format="float" type="dimen">-0.15</item>
     <item name="keyboard_y" format="float" type="dimen">-0.45</item>
+    <item name="zhuyin_keyboard_y" format="float" type="dimen">-0.63</item>
     <item name="keyboard_z" format="float" type="dimen">-2.5</item>
     <item name="keyboard_world_rotation" format="float" type="dimen">-35.0</item>
     <dimen name="keyboard_height">188dp</dimen>
@@ -33,9 +34,10 @@
     <dimen name="keyboard_alphabetic_width_norwegian">540dp</dimen>
     <dimen name="keyboard_alphabetic_width_swedish">540dp</dimen>
     <dimen name="keyboard_alphabetic_width_finnish">540dp</dimen>
+    <dimen name="keyboard_alphabetic_width_zhuyin">470dp</dimen>
     <dimen name="keyboard_alphabetic_width_extra_column">564dp</dimen>
     <dimen name="keyboard_numeric_width">144dp</dimen>
-    <dimen name="keyboard_zhuyin_height">250dp</dimen>
+    <dimen name="keyboard_zhuyin_height">228dp</dimen>
     <dimen name="keyboard_horizontal_gap">4dp</dimen>
     <dimen name="keyboard_vertical_gap">4dp</dimen>
     <dimen name="keyboard_key_width">36dp</dimen>
@@ -44,10 +46,9 @@
     <dimen name="keyboard_language_rounded_corner">8dp</dimen>
     <dimen name="keyboard_key_space_width">166dp</dimen>
     <dimen name="keyboard_key_german_space_width">178dp</dimen>
-    <dimen name="keyboard_key_zhuyin_space_width">30dp</dimen>
-    <dimen name="keyboard_key_zhuyin_space_height">36dp</dimen>
-    <dimen name="keyboard_key_zhuyin_space_margin">8dp</dimen>
-    <dimen name="keyboard_key_zhuyin_enter_margin">28dp</dimen>
+    <dimen name="keyboard_key_zhuyin_space_width">50dp</dimen>
+    <dimen name="keyboard_key_zhuyin_space_height">70dp</dimen>
+    <dimen name="keyboard_key_zhuyin_enter_width">74dp</dimen>
     <dimen name="keyboard_key_backspace_width">50dp</dimen>
     <dimen name="keyboard_key_enter_width">72dp</dimen>
     <dimen name="keyboard_key_enter_width_small">62dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -82,7 +82,7 @@
     <string name="zhuyin_spacebar_selection" translatable="false">一聲</string>
     <string name="zhuyin_spacebar_space" translatable="false">空格</string>
     <string name="zhuyin_enter_completion" translatable="false">選定</string>
-    <string name="zhuyin_keyboard_mode_change" translatable="false">ㄅㄆㄇ</string>
+    <string name="zhuyin_keyboard_mode_change" translatable="false">注音</string>
 
     <string name="japanese_spacebar_selection" translatable="false">次変換</string>
     <string name="japanese_spacebar_space" translatable="false">空白</string>

--- a/app/src/main/res/xml/keyboard_numeric.xml
+++ b/app/src/main/res/xml/keyboard_numeric.xml
@@ -5,10 +5,9 @@
     android:keyWidth="@dimen/keyboard_key_width"
     android:keyHeight="@dimen/keyboard_key_height">
     <Row>
-        <Key android:codes="49" android:keyLabel="1"  android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
-        <Key android:codes="50" android:keyLabel="2"/>
-        <Key android:codes="51" android:keyLabel="3"/>
-
+        <Key android:codes="55" android:keyLabel="7" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
+        <Key android:codes="56" android:keyLabel="8"/>
+        <Key android:codes="57" android:keyLabel="9"/>
     </Row>
     <Row>
         <Key android:codes="52" android:keyLabel="4" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
@@ -16,9 +15,9 @@
         <Key android:codes="54" android:keyLabel="6"/>
     </Row>
     <Row>
-        <Key android:codes="55" android:keyLabel="7" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
-        <Key android:codes="56" android:keyLabel="8"/>
-        <Key android:codes="57" android:keyLabel="9"/>
+        <Key android:codes="49" android:keyLabel="1"  android:keyEdgeFlags="left" android:horizontalGap="0dp"/>
+        <Key android:codes="50" android:keyLabel="2"/>
+        <Key android:codes="51" android:keyLabel="3"/>
     </Row>
     <Row>
         <Key android:codes="35" android:keyLabel="#" android:keyEdgeFlags="left" android:horizontalGap="0dp"/>

--- a/app/src/main/res/xml/keyboard_qwerty_zhuyin.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_zhuyin.xml
@@ -3,8 +3,7 @@
     android:horizontalGap="@dimen/keyboard_horizontal_gap"
     android:verticalGap="@dimen/keyboard_vertical_gap"
     android:keyWidth="@dimen/keyboard_key_width"
-    android:keyHeight="@dimen/keyboard_key_height"
-    android:layout_height="@dimen/keyboard_zhuyin_height">
+    android:keyHeight="@dimen/keyboard_key_height">
     <Row>
         <Key android:codes="0x3105" android:keyLabel="ㄅ" android:keyEdgeFlags="left"/>
         <Key android:codes="0x3109" android:keyLabel="ㄉ"/>
@@ -17,10 +16,10 @@
         <Key android:codes="0x311E" android:keyLabel="ㄞ"/>
         <Key android:codes="0x3122" android:keyLabel="ㄢ"/>
         <Key android:codes="0x3126" android:keyLabel="ㄦ"/>
-        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width"/>
+        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:isRepeatable="true"/>
     </Row>
     <Row>
-        <Key android:codes="0x3106" android:keyLabel="ㄆ" android:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key android:codes="0x3106" android:keyLabel="ㄆ" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
         <Key android:codes="0x310A" android:keyLabel="ㄊ"/>
         <Key android:codes="0x310D" android:keyLabel="ㄍ"/>
         <Key android:codes="0x3110" android:keyLabel="ㄐ"/>
@@ -30,11 +29,12 @@
         <Key android:codes="0x311B" android:keyLabel="ㄛ"/>
         <Key android:codes="0x311F" android:keyLabel="ㄟ"/>
         <Key android:codes="0x3123" android:keyLabel="ㄣ"/>
-        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:horizontalGap="@dimen/keyboard_key_zhuyin_enter_margin" />
+        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_zhuyin_enter_width"/>
     </Row>
 
     <Row>
-        <Key android:codes="0x3107" android:keyLabel="ㄇ" android:horizontalGap="@dimen/keyboard_left_margin_2x"/>
+        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
+        <Key android:codes="0x3107" android:keyLabel="ㄇ"/>
         <Key android:codes="0x310B" android:keyLabel="ㄋ"/>
         <Key android:codes="0x310E" android:keyLabel="ㄎ"/>
         <Key android:codes="0x3111" android:keyLabel="ㄑ"/>
@@ -44,12 +44,11 @@
         <Key android:codes="0x311C" android:keyLabel="ㄜ"/>
         <Key android:codes="0x3120" android:keyLabel="ㄠ"/>
         <Key android:codes="0x3124" android:keyLabel="ㄤ"/>
-        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:keyHeight="@dimen/keyboard_key_zhuyin_space_height" android:isRepeatable="true" android:horizontalGap="@dimen/keyboard_key_zhuyin_space_margin"/>
+        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:keyHeight="@dimen/keyboard_key_zhuyin_space_height" android:isRepeatable="true"/>
     </Row>
 
     <Row>
-        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
-        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe"/>
+        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" android:keyEdgeFlags="left"/>
         <Key android:codes="0x3108" android:keyLabel="ㄈ"/>
         <Key android:codes="0x310C" android:keyLabel="ㄌ"/>
         <Key android:codes="0x310F" android:keyLabel="ㄏ"/>

--- a/app/src/main/res/xml/keyboard_symbols_zhuyin.xml
+++ b/app/src/main/res/xml/keyboard_symbols_zhuyin.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:horizontalGap="@dimen/keyboard_horizontal_gap"
+    android:verticalGap="@dimen/keyboard_vertical_gap"
+    android:keyWidth="@dimen/keyboard_key_width"
+    android:keyHeight="@dimen/keyboard_key_height">
+    <Row>
+        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
+        <Key android:codes="163" android:keyLabel="£"/>
+        <Key android:codes="165" android:keyLabel="¥"/>
+        <Key android:codes="36" android:keyLabel="$"/>
+        <Key android:codes="199" android:keyLabel="ç"/>
+        <Key android:codes="37" android:keyLabel="%"/>
+        <Key android:codes="38" android:keyLabel="&amp;"/>
+        <Key android:codes="40" android:keyLabel="("/>
+        <Key android:codes="41" android:keyLabel=")"/>
+        <Key android:codes="61" android:keyLabel="="/>
+        <Key android:codes="95" android:keyLabel="_"/>
+        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:isRepeatable="true"/>
+    </Row>
+    <Row>
+        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key android:codes="94" android:keyLabel="^" />
+        <Key android:codes="0x22ef" android:keyLabel="⋯" />
+        <Key android:codes="123" android:keyLabel="{"/>
+        <Key android:codes="125" android:keyLabel="}"/>
+        <Key android:codes="91" android:keyLabel="["/>
+        <Key android:codes="93" android:keyLabel="]"/>
+        <Key android:codes="124" android:keyLabel="|"/>
+        <Key android:codes="59" android:keyLabel=";"/>
+        <Key android:codes="58" android:keyLabel=":"/>
+        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_zhuyin_enter_width"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
+        <Key android:codes="0x300a" android:keyLabel="《"/>
+        <Key android:codes="0x300b" android:keyLabel="》"/>
+        <Key android:codes="96" android:keyLabel="`"/>
+        <Key android:codes="126" android:keyLabel="~"/>
+        <Key android:codes="39" android:keyLabel="'"/>
+        <Key android:codes="34" android:keyLabel="&quot;"/>
+        <Key android:codes="92" android:keyLabel="\\" />
+        <Key android:codes="45" android:keyLabel="-" />
+        <Key android:codes="43" android:keyLabel="+" />
+        <Key android:codes="47" android:keyLabel="/" />
+        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_zhuyin_space_width" android:keyHeight="@dimen/keyboard_key_zhuyin_space_height" android:isRepeatable="true"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe"/>
+        <Key android:codes="-13" android:keyLabel="^.^"/>
+        <Key android:codes="0x300C" android:keyLabel="「" />
+        <Key android:codes="0x300D" android:keyLabel="」" />
+        <Key android:codes="0xff64" android:keyLabel="､"/>
+        <Key android:codes="0xff61" android:keyLabel="｡"/>
+        <Key android:codes="0xff0c" android:keyLabel="，"/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="64" android:keyLabel="\@"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
Fixes #2714.

This makes more sense based on iOS zh-TW keyboard layout.

However, I still can see we have couple of questions on `KeyboardWidget`. @keianhzo  Please take a look at this screen recording (https://drive.google.com/file/d/1m43TsivrTurHQnA19aKykkDbhLhyQ7gI/view?usp=sharing)

- I can't be easy to adjust its placement and resize the KeyboardLayout according to the parameters from `KeyboardInterface`. Although I spend an afternoon, I still feel the width of `keyboardContainer` or `keyboardLayout` is not what I expect. [0:00 - 0:23 sec in the video]
- Pinyin and Japanese keyboards didn't be placed at the the same position as others. We can see there is an offset between it and others. [0:23 - 0:41 sec in the video] I have checked their UI definitions are the same with `keyboard_qwerty.xml`, but they are still wrong. That's odd.
