### PR TITLE
Remove the back handler for non focused views

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -630,6 +630,16 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         updateBorder();
 
         mViewModel.setIsActiveWindow(active);
+
+        // Remove tha back handler in case there is a library view visible, otherwise it gets dismissed
+        // when back is clicked even if other window is focused.
+        if (mView != null) {
+            if (active) {
+                mWidgetManager.pushBackHandler(mBackHandler);
+            } else {
+                mWidgetManager.popBackHandler(mBackHandler);
+            }
+        }
     }
 
     @Nullable


### PR DESCRIPTION
Remove the back handler for non focused views.

STRs:
- Open two windows
- Open History/Bookmarks in one of them
- Focus the other window
- Click on the back button

Expected result: We go back in history in the currently focused window

Actual result: The History/Bookmark panel is closed in the non focused window.