### PR TITLE
Fixes #2726 Restore the hover state after send button is clicked in a tab view

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/TabView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/TabView.java
@@ -220,6 +220,12 @@ public class TabView extends RelativeLayout implements GeckoSession.ContentDeleg
         mIsPrivateMode = privateMode;
     }
 
+    public void reset() {
+        mSendTabButton.setHovered(false);
+        mCloseButton.setHovered(false);
+        updateState();
+    }
+
     @Override
     public void setSelected(boolean selected) {
         super.setSelected(selected);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -299,6 +299,8 @@ public class TabsWidget extends UIDialog {
                     mSendTabDialog.setSessionId(aSender.getSession().getId());
                     mSendTabDialog.mWidgetPlacement.parentHandle = mWidgetManager.getFocusedWindow().getHandle();
                     mSendTabDialog.show(UIWidget.REQUEST_FOCUS);
+
+                    holder.tabView.reset();
                 }
             });
         }


### PR DESCRIPTION
Fixes #2726 Restore the hover state after send button is clicked in a tab view