### PR TITLE
Fixes #2794 Dismiss Library panels when navigating back/forward

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -304,6 +304,22 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     protected void initializeWidgets() {
         UISurfaceTextureRenderer.setUseHardwareAcceleration(SettingsStore.getInstance(getBaseContext()).isUIHardwareAccelerationEnabled());
         UISurfaceTextureRenderer.setRenderActive(true);
+
+        // Empty widget just for handling focus on empty space
+        mRootWidget = new RootWidget(this);
+        mRootWidget.setClickCallback(() -> {
+            for (WorldClickListener listener: mWorldClickListeners) {
+                listener.onWorldClick();
+            }
+        });
+
+        // Create Browser navigation widget
+        mNavigationBar = new NavigationBarWidget(this);
+
+        // Create keyboard widget
+        mKeyboard = new KeyboardWidget(this);
+
+        // Windows
         mWindows = new Windows(this);
         mWindows.setDelegate(new Windows.Delegate() {
             @Override
@@ -339,24 +355,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
         });
 
-        // Create Browser navigation widget
-        mNavigationBar = new NavigationBarWidget(this);
-
-        // Create keyboard widget
-        mKeyboard = new KeyboardWidget(this);
-
         // Create the tray
         mTray = new TrayWidget(this);
-
-        // Empty widget just for handling focus on empty space
-        mRootWidget = new RootWidget(this);
-        mRootWidget.setClickCallback(() -> {
-            for (WorldClickListener listener: mWorldClickListeners) {
-                listener.onWorldClick();
-            }
-        });
-
-        // Add widget listeners
         mTray.addListeners(mWindows);
         mTray.setAddWindowVisible(mWindows.canOpenNewWindow());
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -622,6 +622,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 session.getTextInput().setView(this);
             }
             mSession.updateLastUse();
+            mWidgetManager.getNavigationBar().addNavigationBarListener(mNavigationBarListener);
+
+        } else {
+            mWidgetManager.getNavigationBar().removeNavigationBarListener(mNavigationBarListener);
         }
 
         hideContextMenus();
@@ -915,6 +919,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
         mBookmarksView.removeBookmarksListener(mBookmarksListener);
         mHistoryView.removeHistoryListener(mHistoryListener);
+        mWidgetManager.getNavigationBar().removeNavigationBarListener(mNavigationBarListener);
         mPromptDelegate.detachFromWindow();
         super.releaseWidget();
     }
@@ -1412,6 +1417,33 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         @Override
         public void onClickItem(@NonNull View view, @NonNull VisitInfo item) {
             hideHistory();
+        }
+    };
+
+    private NavigationBarWidget.NavigationListener mNavigationBarListener = new NavigationBarWidget.NavigationListener() {
+        @Override
+        public void onBack() {
+            hideLibraryPanels();
+        }
+
+        @Override
+        public void onForward() {
+            hideLibraryPanels();
+        }
+
+        @Override
+        public void onReload() {
+            hideLibraryPanels();
+        }
+
+        @Override
+        public void onStop() {
+            // Nothing to do
+        }
+
+        @Override
+        public void onHome() {
+            hideLibraryPanels();
         }
     };
 


### PR DESCRIPTION
Fixes #2794 Back/Forward don't trigger an onLoadRequest so we need to implement a navigation bar listener to get those. Any other GV navigation event we could rely on gets dumped at initialization time and closes the library panels when restoring.