### PR TITLE
Fixes #2722 Use a dark overlay in a hover tab in select mode

### DIFF
--- a/app/src/main/res/drawable/tab_overlay_checked.xml
+++ b/app/src/main/res/drawable/tab_overlay_checked.xml
@@ -2,6 +2,7 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:state_pressed="true">
         <shape>
+            <solid android:color="#AA000000" />
             <stroke android:color="@color/rhino" android:width="2dp" />
         </shape>
     </item>

--- a/app/src/main/res/drawable/tab_overlay_unchecked.xml
+++ b/app/src/main/res/drawable/tab_overlay_unchecked.xml
@@ -8,7 +8,7 @@
     </item>
     <item android:state_hovered="true" android:state_pressed="false">
         <shape>
-            <stroke android:color="@color/rhino" android:width="2dp" />
+            <solid android:color="#AA000000" />
         </shape>
     </item>
     <item android:state_hovered="false" android:state_pressed="false">


### PR DESCRIPTION
Fixes #2722 We can ask for design if necessary, this is just the most obvious way to quickly fix it.