### PR TITLE
Fixes #2809 Check the Android version before adding the long click fix

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UIButton.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/UIButton.java
@@ -83,17 +83,20 @@ public class UIButton extends AppCompatImageButton implements CustomUIButton {
 
         mBackground = getBackground();
 
-        setLongClickable(false);
-        setOnTouchListener((v, event) -> {
-            if (event.getAction() == MotionEvent.ACTION_UP) {
-                long time = event.getEventTime() - event.getDownTime();
-                if (time > ViewConfiguration.getLongPressTimeout()) {
-                    performClick();
+        // Android >8 doesn't perform a click when long clicking in ImageViews even if long click is disabled
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            setLongClickable(false);
+            setOnTouchListener((v, event) -> {
+                if (event.getAction() == MotionEvent.ACTION_UP) {
+                    long time = event.getEventTime() - event.getDownTime();
+                    if (time > ViewConfiguration.getLongPressTimeout()) {
+                        performClick();
+                    }
                 }
-            }
 
-            return false;
-        });
+                return false;
+            });
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
Fixes #2809 Fixing my own mistake of not adding the version check when adding the Android 8 long click fix to UIButton.