### PR TITLE
Fixes #2810 Dismiss the library menu when the list is focused

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/BookmarksView.java
@@ -109,6 +109,10 @@ public class BookmarksView extends FrameLayout implements BookmarksStore.Bookmar
         mBinding.setCallback(mBookmarksCallback);
         mBookmarkAdapter = new BookmarkAdapter(mBookmarkItemCallback, getContext());
         mBinding.bookmarksList.setAdapter(mBookmarkAdapter);
+        mBinding.bookmarksList.setOnTouchListener((v, event) -> {
+            v.requestFocusFromTouch();
+            return false;
+        });
         mBinding.bookmarksList.addOnScrollListener(mScrollListener);
         mBinding.bookmarksList.setHasFixedSize(true);
         mBinding.bookmarksList.setItemViewCacheSize(20);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/HistoryView.java
@@ -114,6 +114,10 @@ public class HistoryView extends FrameLayout implements HistoryStore.HistoryList
         mBinding.setCallback(mHistoryCallback);
         mHistoryAdapter = new HistoryAdapter(mHistoryItemCallback, getContext());
         mBinding.historyList.setAdapter(mHistoryAdapter);
+        mBinding.historyList.setOnTouchListener((v, event) -> {
+            v.requestFocusFromTouch();
+            return false;
+        });
         mBinding.historyList.addOnScrollListener(mScrollListener);
         mBinding.historyList.setHasFixedSize(true);
         mBinding.historyList.setItemViewCacheSize(20);


### PR DESCRIPTION
Fixes #2810 Dismiss the library menu when the list is focused. Verified that this didn't regress #2250