### PR TITLE
Fixes #2829 Hide all notifications when clicking on tray actions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NotificationManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NotificationManager.java
@@ -14,15 +14,15 @@ import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.widgets.NotificationManager.Notification.NotificationPosition;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NotificationManager {
 
     private static final int DEFAULT_DURATION = 3000;
 
-    private static HashMap<Integer, NotificationData> mData = new HashMap<>();
+    private static ConcurrentHashMap<Integer, NotificationData> mData = new ConcurrentHashMap<>();
 
     private static class NotificationData {
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -247,22 +247,27 @@ public class TrayWidget extends UIWidget implements SessionChangeListener, Widge
     }
 
     private void notifyBookmarksClicked() {
+        hideNotifications();
         mTrayListeners.forEach(TrayListener::onBookmarksClicked);
     }
 
     private void notifyHistoryClicked() {
+        hideNotifications();
         mTrayListeners.forEach(TrayListener::onHistoryClicked);
     }
 
     private void notifyTabsClicked() {
+        hideNotifications();
         mTrayListeners.forEach(TrayListener::onTabsClicked);
     }
 
     private void notifyPrivateBrowsingClicked() {
+        hideNotifications();
         mTrayListeners.forEach(TrayListener::onPrivateBrowsingClicked);
     }
 
     private void notifyAddWindowClicked() {
+        hideNotifications();
         mTrayListeners.forEach(TrayListener::onAddWindowClicked);
     }
 


### PR DESCRIPTION
Fixes #2829 Hide all notifications when clicking on tray actions. Also avoid concurrent modifications of the notifications map