### PR TITLE
Use the default appservices megazord, not the deprecated fenix megazord.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -485,18 +485,6 @@ dependencies {
     implementation deps.android_components.glean
     implementation deps.app_services.rustlog
 
-    // For production builds, the native code for all `org.mozilla.appservices`
-    // dependencies gets compiled together into a single "megazord" build, and
-    // different megazords are published for different subsets of features. Ref
-    // https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html
-    // For now we can jut use the one that's specifically designed for Fenix.
-    implementation deps.app_services.megazord
-    modules {
-        module('org.mozilla.appservices:full-megazord') {
-            replacedBy('org.mozilla.appservices:fenix-megazord', 'prefer the fenix megazord, to reduce final application size')
-        }
-    }
-
     // TODO this should not be necessary at all, see Services.kt
     implementation deps.work.runtime
 
@@ -520,9 +508,9 @@ dependencies {
     testImplementation deps.junit
     testImplementation deps.atsl.core
     testImplementation deps.robolectric
-    testImplementation deps.app_services.megazord_forUnitTests
     testImplementation deps.app_services.rustlog
     testImplementation deps.android_components.support_test
+    testImplementation deps.android_components.support_test_appservices
     testImplementation deps.telemetry.glean_unittests
     testImplementation deps.work.testing
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -29,9 +29,8 @@ versions.android_components = "28.0.1"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.
 // The version number below tracks the application-services version
-// that we depend on directly for the fenix-megazord (and for it's
-// forUnitTest variant), and it's important that it be kept in
-// sync with the version used by android-components above.
+// that we depend on directly for its rustlog package, and it's important
+// that it be kept insync with the version used by android-components above.
 versions.mozilla_appservices = "0.48.2"
 versions.mozilla_speech = "1.0.10"
 versions.openwnn = "1.3.7"
@@ -78,11 +77,10 @@ android_components.lib_fetch = "org.mozilla.components:lib-fetch-httpurlconnecti
 android_components.support_rustlog = "org.mozilla.components:support-rustlog:$versions.android_components"
 android_components.support_rusthttp = "org.mozilla.components:support-rusthttp:$versions.android_components"
 android_components.support_test = "org.mozilla.components:support-test:$versions.android_components"
+android_components.support_test_appservices = "org.mozilla.components:support-test-appservices:$versions.android_components"
 deps.android_components = android_components
 
 def app_services = [:]
-app_services.megazord = "org.mozilla.appservices:fenix-megazord:${versions.mozilla_appservices}"
-app_services.megazord_forUnitTests = "org.mozilla.appservices:fenix-megazord-forUnitTests:${versions.mozilla_appservices}"
 app_services.rustlog = "org.mozilla.appservices:rustlog:${versions.mozilla_appservices}"
 deps.app_services = app_services
 


### PR DESCRIPTION
The custom "fenix" megazord contains all the same code as appears in
the default appservices megazord, so consumers who are using it are
adding complexity to their build process for no gain. The appservices
team intend to stop building the fenix megazord and instead encourage
consumers to use the default full megazord. See additional discussion
in https://github.com/mozilla/application-services/issues/1466.

This PR removes the megazord substitution rules, meaning FirefoxReality
will get the full megazord by default. Fenix is making a corresponding
change over in https://github.com/mozilla-mobile/fenix/pull/8742.