### PR TITLE
Fix deadlock when managing tabs with library panel open

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1585,8 +1585,14 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             mUIThreadExecutor.execute(mFirstDrawCallback);
             mFirstDrawCallback = null;
             mAfterFirstPaint = true;
-            mSetViewQueuedCalls.forEach(Runnable::run);
-            mSetViewQueuedCalls.clear();
+            // view queue calls need to be delayed to avoid a deadlock
+            // caused by GeckoSession.syncResumeResizeCompositor()
+            // See: https://github.com/MozillaReality/FirefoxReality/issues/2889
+            mUIThreadExecutor.execute(() -> {
+                mSetViewQueuedCalls.forEach(Runnable::run);
+                mSetViewQueuedCalls.clear();
+            });
+
         }
     }
 


### PR DESCRIPTION
Fixes #2889