### PR TITLE
Fix user agent override

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -49,7 +49,7 @@ public class SettingsStore {
     public final static boolean REMOTE_DEBUGGING_DEFAULT = false;
     public final static boolean CONSOLE_LOGS_DEFAULT = false;
     public final static boolean ENV_OVERRIDE_DEFAULT = false;
-    public final static boolean MULTIPROCESS_DEFAULT = false;
+    public final static boolean MULTIPROCESS_DEFAULT = true;
     public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT = true;
     public final static boolean PERFORMANCE_MONITOR_DEFAULT = true;
     public final static boolean DRM_PLAYBACK_DEFAULT = false;
@@ -277,8 +277,13 @@ public class SettingsStore {
     }
 
     public void setUaMode(int mode) {
+        int checkedMode = mode;
+        if ((mode != GeckoSessionSettings.USER_AGENT_MODE_VR) && (mode != GeckoSessionSettings.USER_AGENT_MODE_MOBILE)) {
+            Log.e(LOGTAG, "User agent mode: " + mode + " is not supported.");
+            checkedMode = UA_MODE_DEFAULT;
+        }
         SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putInt(mContext.getString(R.string.settings_key_user_agent_version), mode);
+        editor.putInt(mContext.getString(R.string.settings_key_user_agent_version), checkedMode);
         editor.commit();
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -817,7 +817,8 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             mState.mSettings.setViewportMode(GeckoSessionSettings.VIEWPORT_MODE_MOBILE);
         }
         mState.mSession.getSettings().setViewportMode(mState.mSettings.getViewportMode());
-        mState.mSession.loadUri(overrideUri != null ? overrideUri : mState.mUri, GeckoSession.LOAD_FLAGS_BYPASS_CACHE | GeckoSession.LOAD_FLAGS_REPLACE_HISTORY);
+        // FIXME The GeckoSession.LOAD_FLAGS_REPLACE_HISTORY flag fails due to https://bugzilla.mozilla.org/show_bug.cgi?id=1618664
+        mState.mSession.loadUri(overrideUri != null ? overrideUri : mState.mUri, GeckoSession.LOAD_FLAGS_BYPASS_CACHE); //  | GeckoSession.LOAD_FLAGS_REPLACE_HISTORY);
     }
 
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
@@ -90,7 +90,7 @@ class SessionSettings {
             return this;
         }
 
-        public Builder withTrackingProteccion(boolean isTrackingProtectionEnabled){
+        public Builder withTrackingProtection(boolean isTrackingProtectionEnabled){
             this.isTrackingProtectionEnabled = isTrackingProtectionEnabled;
             return this;
         }
@@ -127,7 +127,7 @@ class SessionSettings {
 
             return new SessionSettings.Builder()
                     .withPrivateBrowsing(false)
-                    .withTrackingProteccion(SettingsStore.getInstance(context).isTrackingProtectionEnabled())
+                    .withTrackingProtection(SettingsStore.getInstance(context).isTrackingProtectionEnabled())
                     .withSuspendMediaWhenInactive(true)
                     .withUserAgent(ua)
                     .withViewport(viewport)

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -1005,8 +1005,9 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             public void onSwitchMode() {
                 int uaMode = mAttachedWindow.getSession().getUaMode();
                 if (uaMode == GeckoSessionSettings.USER_AGENT_MODE_DESKTOP) {
-                    mHamburgerMenu.setUAMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
-                    mAttachedWindow.getSession().setUaMode(GeckoSessionSettings.USER_AGENT_MODE_MOBILE);
+                    final int defaultUaMode = SettingsStore.getInstance(mAppContext).getUaMode();
+                    mHamburgerMenu.setUAMode(defaultUaMode);
+                    mAttachedWindow.getSession().setUaMode(defaultUaMode);
 
                 } else {
                     mHamburgerMenu.setUAMode(GeckoSessionSettings.USER_AGENT_MODE_DESKTOP);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DisplayOptionsView.java
@@ -254,7 +254,7 @@ class DisplayOptionsView extends SettingsView {
         mBinding.uaRadio.setChecked(checkId, doApply);
         mBinding.uaRadio.setOnCheckedChangeListener(mUaModeListener);
 
-        SettingsStore.getInstance(getContext()).setUaMode(checkId);
+        SettingsStore.getInstance(getContext()).setUaMode((Integer)mBinding.uaRadio.getValueForId(checkId));
     }
 
     private void setMSAAMode(int checkedId, boolean doApply) {

--- a/app/src/main/res/layout/options_display.xml
+++ b/app/src/main/res/layout/options_display.xml
@@ -58,7 +58,7 @@
                     android:layout_height="wrap_content"
                     app:description="@string/developer_options_msaa"
                     app:options="@array/developer_options_msaa"
-                    app:values="@array/developer_options_ua_mode_values" />
+                    app:values="@array/developer_options_msaa_mode_values" />
 
                 <org.mozilla.vrbrowser.ui.views.settings.SwitchSetting
                     android:id="@+id/autoplaySwitch"

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -11,14 +11,14 @@
     <string name="settings_key_remote_debugging" translatable="false">settings_remote_debugging</string>
     <string name="settings_key_console_logs" translatable="false">settings_console_logs</string>
     <string name="settings_key_environment_override" translatable="false">settings_environment_override</string>
-    <string name="settings_key_multiprocess_e10s" translatable="false">settings_environment_multiprocess_e10s_v2</string>
+    <string name="settings_key_multiprocess_e10s" translatable="false">settings_environment_multiprocess_e10s_v3</string>
     <string name="settings_key_performance_monitor" translatable="false">settings_performance_monitor</string>
     <string name="settings_key_servo" translatable="false">settings_environment_servo</string>
     <string name="settings_key_drm_playback" translatable="false">settings_key_drm_playback</string>
     <string name="settings_key_tracking_protection" translatable="false">settings_tracking_protection</string>
     <string name="settings_key_speech_data_collection" translatable="false">settings_key_speech_data_collection</string>
     <string name="settings_key_speech_data_collection_reviewed" translatable="false">settings_key_speech_data_collection_accept</string>
-    <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version</string>
+    <string name="settings_key_user_agent_version" translatable="false">settings_user_agent_version_v2</string>
     <string name="settings_key_input_mode" translatable="false">settings_touch_mode</string>
     <string name="settings_key_display_density" translatable="false">settings_display_density</string>
     <string name="settings_key_display_dpi" translatable="false">settings_display_dpi</string>>

--- a/app/src/main/res/values/options_values.xml
+++ b/app/src/main/res/values/options_values.xml
@@ -52,13 +52,11 @@
     <!-- Environments Options -->
     <string-array name="developer_options_ua_modes" translatable="false">
         <item>@string/developer_options_ua_mobile</item>
-        <item>@string/developer_options_ua_desktop</item>
         <item>@string/developer_options_ua_vr</item>
     </string-array>
 
     <integer-array name="developer_options_ua_mode_values" translatable="false">
         <item>0</item>
-        <item>1</item>
         <item>2</item>
     </integer-array>
 
@@ -68,6 +66,12 @@
         <item>@string/developer_options_msaa_2</item>
         <item>@string/developer_options_msaa_4</item>
     </string-array>
+
+    <integer-array name="developer_options_msaa_mode_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
 
     <!-- Foveated Levels -->
     <string-array name="developer_options_foveated_options" translatable="false">


### PR DESCRIPTION
This patch enables e10s which fixes a bug in setting the user agent in GV.
Additionally, it remove the option for making the desktop user agent the default.
The user must use the desktop switch in the hamburger menu now.

Fixes #2885