### PR TITLE
Add support for GWE enabled MozillaSpeechLibrary

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
@@ -5,11 +5,7 @@
 package org.mozilla.vrbrowser.browser.engine
 
 import android.content.Context
-import mozilla.components.concept.fetch.Client
-import org.mozilla.geckoview.ContentBlocking
-import org.mozilla.geckoview.GeckoRuntime
-import org.mozilla.geckoview.GeckoRuntimeSettings
-import org.mozilla.geckoview.WebExtension
+import org.mozilla.geckoview.*
 import org.mozilla.vrbrowser.BuildConfig
 import org.mozilla.vrbrowser.browser.SettingsStore
 import org.mozilla.vrbrowser.crashreporting.CrashReporterService
@@ -19,6 +15,7 @@ object EngineProvider {
     private val WEB_EXTENSIONS = arrayOf("webcompat_vimeo", "webcompat_youtube")
 
     private var runtime: GeckoRuntime? = null
+    private var executor: GeckoWebExecutor? = null
 
     @Synchronized
     fun getOrCreateRuntime(context: Context): GeckoRuntime {
@@ -61,8 +58,20 @@ object EngineProvider {
         return runtime!!
     }
 
-    fun createClient(context: Context): Client {
-        val runtime = getOrCreateRuntime(context)
-        return GeckoViewFetchClient(context, runtime)
+    fun createGeckoWebExecutor(context: Context): GeckoWebExecutor {
+        return GeckoWebExecutor(getOrCreateRuntime(context))
     }
+
+    fun getDefaultGeckoWebExecutor(context: Context): GeckoWebExecutor {
+        if (executor == null) {
+            executor = createGeckoWebExecutor(context)
+        }
+
+        return executor!!
+    }
+
+    fun createClient(context: Context): GeckoViewFetchClient {
+        return GeckoViewFetchClient(context)
+    }
+
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/GeckoViewFetchClient.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/GeckoViewFetchClient.kt
@@ -6,13 +6,7 @@ package org.mozilla.vrbrowser.browser.engine
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import mozilla.components.concept.fetch.Client
-import mozilla.components.concept.fetch.Headers
-import mozilla.components.concept.fetch.MutableHeaders
-import mozilla.components.concept.fetch.Request
-import mozilla.components.concept.fetch.Response
-
-import org.mozilla.geckoview.GeckoRuntime
+import mozilla.components.concept.fetch.*
 import org.mozilla.geckoview.GeckoWebExecutor
 import org.mozilla.geckoview.WebRequest
 import org.mozilla.geckoview.WebRequest.CACHE_MODE_DEFAULT
@@ -30,12 +24,11 @@ import java.util.concurrent.TimeoutException
  */
 class GeckoViewFetchClient(
     context: Context,
-    runtime: GeckoRuntime = GeckoRuntime.getDefault(context),
     private val maxReadTimeOut: Pair<Long, TimeUnit> = Pair(MAX_READ_TIMEOUT_MINUTES, TimeUnit.MINUTES)
 ) : Client() {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal var executor: GeckoWebExecutor = GeckoWebExecutor(runtime)
+    internal var executor: GeckoWebExecutor = EngineProvider.createGeckoWebExecutor(context)
 
     @Throws(IOException::class)
     override fun fetch(request: Request): Response {

--- a/app/src/common/shared/org/mozilla/vrbrowser/geolocation/GeolocationWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/geolocation/GeolocationWrapper.java
@@ -2,11 +2,12 @@ package org.mozilla.vrbrowser.geolocation;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.SettingsStore;
-
-import androidx.annotation.NonNull;
+import org.mozilla.vrbrowser.browser.engine.EngineProvider;
 
 public class GeolocationWrapper {
 
@@ -24,8 +25,8 @@ public class GeolocationWrapper {
                                final int maxRetries) {
         if (retryCount <= maxRetries - 1) {
             GeolocationClient.getGeolocation(
+                    EngineProvider.INSTANCE.getDefaultGeckoWebExecutor(aContext),
                     endPoint,
-                    MAX_RETRIES,
                     (data) -> {
                         if (data == null) {
                             if (retryCount <= maxRetries) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/search/SearchEngineWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/search/SearchEngineWrapper.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserApplication;
 import org.mozilla.vrbrowser.browser.SettingsStore;
+import org.mozilla.vrbrowser.browser.engine.EngineProvider;
 import org.mozilla.vrbrowser.geolocation.GeolocationData;
 import org.mozilla.vrbrowser.search.suggestions.SuggestionsClient;
 import org.mozilla.vrbrowser.utils.SystemUtils;
@@ -118,7 +119,10 @@ public class SearchEngineWrapper implements SharedPreferences.OnSharedPreference
         // TODO: Use mSuggestionsClient.getSuggestions when fixed in browser-search.
         String query = getSuggestionURL(aQuery);
         mUIThreadExecutor.execute(() ->
-                SuggestionsClient.getSuggestions(mSearchEngine, query).thenAcceptAsync(future::complete));
+                SuggestionsClient.getSuggestions(
+                        EngineProvider.INSTANCE.getDefaultGeckoWebExecutor(mContext),
+                        mSearchEngine,
+                        query).thenAcceptAsync(future::complete));
 
         return future;
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -28,6 +28,7 @@ import com.mozilla.speechlibrary.STTResult;
 import org.mozilla.gecko.util.ThreadUtils;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.SettingsStore;
+import org.mozilla.vrbrowser.browser.engine.EngineProvider;
 import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.databinding.VoiceSearchDialogBinding;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
@@ -86,6 +87,7 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
         mWidgetManager.addPermissionListener(this);
 
         mMozillaSpeechService = MozillaSpeechService.getInstance();
+        mMozillaSpeechService.setGeckoWebExecutor(EngineProvider.INSTANCE.createGeckoWebExecutor(getContext()));
         mMozillaSpeechService.setProductTag(getContext().getString(R.string.voice_app_id));
 
         mSearchingAnimation = new RotateAnimation(0, 360f,

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -183,7 +183,8 @@
     <string name="keyboard_nl_NL_popup_i" translatable="false">ìíiïîįī</string>
 
     <!-- SEARCH ENGINES -->
-    <string name="geolocation_api_url" translatable="false">https://location.services.mozilla.com/v1/country</string>
+    <!-- The MLS policy has been updated and now we can't use it without an API key anymore -->
+    <string name="geolocation_api_url" translatable="false">https://location.services.mozilla.com/v1/country?key=fff72d56-b040-4205-9a11-82feda9d83a3</string>
     <!-- Google -->
     <string name="search_google_params" translatable="false">q=%1$s&amp;client=firefox-b-o</string>
     <string name="search_google_us_params" translatable="false">q=%1$s&amp;client=firefox-b-1-o</string>

--- a/versions.gradle
+++ b/versions.gradle
@@ -33,7 +33,7 @@ versions.android_components = "28.0.1"
 // forUnitTest variant), and it's important that it be kept in
 // sync with the version used by android-components above.
 versions.mozilla_appservices = "0.48.2"
-versions.mozilla_speech = "1.0.10"
+versions.mozilla_speech = "1.0.11"
 versions.openwnn = "1.3.7"
 versions.google_vr = "1.190.0"
 versions.room = "2.2.0"


### PR DESCRIPTION
Fixes #1580 MozillaSpeechLibrary has now support for GeckoWebExecutor where available so we can safely remove all the http client dependencies that we were using from com.loopj.android and cz.mesebera.android.

This PR migrates all usage of those libraries to GWE and bumps the MozillaSpeechLibrary version to 1.0.11 which already implements support for GWE. mozilla/androidspeech#27

At some point the MLS stopped supporting requests without an API key, I saw it while debugging the GWE migration of the client. I've request an API to the MLS team. This will remain a draft until we get an API key for FxR.