### PR TITLE
Fix for the Pico headset buttons

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/OffscreenDisplay.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/OffscreenDisplay.java
@@ -13,10 +13,12 @@ import android.hardware.display.VirtualDisplay;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.Display;
+import android.view.KeyEvent;
 import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 
+import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
 public class OffscreenDisplay {
@@ -131,6 +133,11 @@ public class OffscreenDisplay {
                                         | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
             } catch (Exception e) {
             }
+        }
+
+        @Override
+        public boolean dispatchKeyEvent(KeyEvent event) {
+            return ((VRBrowserActivity)mContext).dispatchKeyEvent(event);
         }
     }
 }

--- a/app/src/picovr/java/org/mozilla/vrbrowser/PlatformActivity.java
+++ b/app/src/picovr/java/org/mozilla/vrbrowser/PlatformActivity.java
@@ -122,7 +122,7 @@ public class PlatformActivity extends VRActivity implements RenderInterface, CVC
 
     @Override
     public void onBackPressed() {
-        super.onBackPressed();
+        // Eat the back button.
     }
 
     @Override

--- a/app/src/picovr/java/org/mozilla/vrbrowser/PlatformActivity.java
+++ b/app/src/picovr/java/org/mozilla/vrbrowser/PlatformActivity.java
@@ -122,7 +122,7 @@ public class PlatformActivity extends VRActivity implements RenderInterface, CVC
 
     @Override
     public void onBackPressed() {
-        // Eat the back button.
+        super.onBackPressed();
     }
 
     @Override


### PR DESCRIPTION
Related to #1080 

This PR fixes the issue with the headset button in Pico devices. Also re-enables the back button for quitting the app in Pico.

For some reason before the first back headset click the system `Window` has the `OffscreenPresentation` as the `Window.Callback` target. As we are not currently overriding `dispatchKeyEvent` in the `OffscreenPresentation`, that event gets lost. After that click it seems that the callback target is set to the `VRBBrowserActivity` and the following events are correctly forwarded.
Still unanswered why that first headset button press sets the `Activity` as the `Window.Callback`.