### PR TITLE
Dual controller typing

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -807,7 +807,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Keep
     @SuppressWarnings("unused")
-    void handleMotionEvent(final int aHandle, final int aDevice, final boolean aPressed, final float aX, final float aY) {
+    void handleMotionEvent(final int aHandle, final int aDevice, final boolean aFocused, final boolean aPressed, final float aX, final float aY) {
         runOnUiThread(() -> {
             Widget widget = mWidgets.get(aHandle);
             if (!isWidgetInputEnabled(widget)) {
@@ -819,12 +819,14 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             final float y = aY / scale;
 
             if (widget == null) {
-                MotionEventGenerator.dispatch(mRootWidget, aDevice, aPressed, x, y);
+                MotionEventGenerator.dispatch(mRootWidget, aDevice, aFocused, aPressed, x, y);
+
             } else if (widget.getBorderWidth() > 0) {
                 final int border = widget.getBorderWidth();
-                MotionEventGenerator.dispatch(widget, aDevice, aPressed, x - border, y - border);
+                MotionEventGenerator.dispatch(widget, aDevice, aFocused, aPressed, x - border, y - border);
+
             } else {
-                MotionEventGenerator.dispatch(widget, aDevice, aPressed, x, y);
+                MotionEventGenerator.dispatch(widget, aDevice, aFocused, aPressed, x, y);
             }
         });
     }
@@ -839,7 +841,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
             if (widget != null) {
                 float scrollDirection = mSettings.getScrollDirection() == 0 ? 1.0f : -1.0f;
-                MotionEventGenerator.dispatchScroll(widget, aDevice, aX * scrollDirection, aY * scrollDirection);
+                MotionEventGenerator.dispatchScroll(widget, aDevice, true,aX * scrollDirection, aY * scrollDirection);
             } else {
                 Log.e(LOGTAG, "Failed to find widget for scroll event: " + aHandle);
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/input/MotionEventGenerator.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/input/MotionEventGenerator.java
@@ -7,15 +7,15 @@ package org.mozilla.vrbrowser.input;
 
 import android.os.SystemClock;
 import android.util.Log;
-import android.view.MotionEvent;
-import android.view.InputDevice;
 import android.util.SparseArray;
+import android.view.InputDevice;
+import android.view.MotionEvent;
 
+import org.mozilla.vrbrowser.ui.widgets.KeyboardWidget;
 import org.mozilla.vrbrowser.ui.widgets.Widget;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.util.Arrays;
-import java.util.List;
 
 public class MotionEventGenerator {
     static final String LOGTAG = SystemUtils.createLogtag(MotionEventGenerator.class);
@@ -53,11 +53,11 @@ public class MotionEventGenerator {
     private static SparseArray<Device> devices = new SparseArray<>();
 
 
-    private static void generateEvent(Widget aWidget, Device aDevice, int aAction, boolean aGeneric) {
-        generateEvent(aWidget, aDevice, aAction, aGeneric, aDevice.mCoords);
+    private static void generateEvent(Widget aWidget, Device aDevice, boolean aFocused, int aAction, boolean aGeneric) {
+        generateEvent(aWidget, aDevice, aFocused, aAction, aGeneric, aDevice.mCoords);
     }
 
-    private static void generateEvent(Widget aWidget, Device aDevice, int aAction, boolean aGeneric, MotionEvent.PointerCoords[] aCoords) {
+    private static void generateEvent(Widget aWidget, Device aDevice, boolean aFocused, int aAction, boolean aGeneric, MotionEvent.PointerCoords[] aCoords) {
         MotionEvent event = MotionEvent.obtain(
                 /*mDownTime*/ aDevice.mDownTime,
                 /*eventTime*/ SystemClock.uptimeMillis(),
@@ -69,19 +69,24 @@ public class MotionEventGenerator {
                 /*buttonState*/ 0,
                 /*xPrecision*/ 0,
                 /*yPrecision*/ 0,
-                /*deviceId*/ 0, // aDevice.mDevice,
+                /*deviceId*/ aDevice.mDevice,
                 /*edgeFlags*/ 0,
                 /*source*/ InputDevice.SOURCE_TOUCHSCREEN,
                 /*flags*/ 0);
         if (aGeneric) {
-            aWidget.handleHoverEvent(event);
+            if (aWidget instanceof KeyboardWidget) {
+                aWidget.handleHoverEvent(event);
+
+            } else if (aFocused) {
+                aWidget.handleHoverEvent(event);
+            }
         } else {
             aWidget.handleTouchEvent(event);
         }
         event.recycle();
     }
 
-    public static void dispatch(Widget aWidget, int aDevice, boolean aPressed, float aX, float aY) {
+    public static void dispatch(Widget aWidget, int aDevice, boolean aFocused, boolean aPressed, float aX, float aY) {
         Device device = devices.get(aDevice);
         if (device == null) {
             device = new Device(aDevice);
@@ -99,10 +104,10 @@ public class MotionEventGenerator {
         }
         if (!aPressed && (device.mPreviousWidget != null) && (device.mPreviousWidget != aWidget)) {
             if (device.mWasPressed) {
-                generateEvent(device.mPreviousWidget, device, MotionEvent.ACTION_CANCEL, false);
+                generateEvent(device.mPreviousWidget, device, aFocused, MotionEvent.ACTION_CANCEL, false);
                 device.mWasPressed = false;
             }
-            generateEvent(device.mPreviousWidget, device, MotionEvent.ACTION_HOVER_EXIT, true, device.mMouseOutCoords);
+            generateEvent(device.mPreviousWidget, device, aFocused, MotionEvent.ACTION_HOVER_EXIT, true, device.mMouseOutCoords);
             device.mPreviousWidget = null;
         }
         if (aWidget == null) {
@@ -110,22 +115,22 @@ public class MotionEventGenerator {
             return;
         }
         if (aWidget != device.mPreviousWidget && !aPressed) {
-            generateEvent(aWidget, device, MotionEvent.ACTION_HOVER_ENTER, true);
+            generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_ENTER, true);
         }
         if (aPressed && !device.mWasPressed) {
             device.mDownTime = SystemClock.uptimeMillis();
             device.mWasPressed = true;
-            generateEvent(aWidget, device, MotionEvent.ACTION_HOVER_EXIT, true);
-            generateEvent(aWidget, device, MotionEvent.ACTION_DOWN, false);
+            generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_EXIT, true);
+            generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_DOWN, false);
             device.mTouchStartWidget = aWidget;
         } else if (!aPressed && device.mWasPressed) {
             device.mWasPressed = false;
-            generateEvent(device.mTouchStartWidget, device, MotionEvent.ACTION_UP, false);
-            generateEvent(aWidget, device, MotionEvent.ACTION_HOVER_ENTER, true);
+            generateEvent(device.mTouchStartWidget, device, aFocused, MotionEvent.ACTION_UP, false);
+            generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_ENTER, true);
         } else if (moving && aPressed) {
-            generateEvent(aWidget, device, MotionEvent.ACTION_MOVE, false);
+            generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_MOVE, false);
         } else if (moving) {
-            generateEvent(aWidget, device, MotionEvent.ACTION_HOVER_MOVE, true);
+            generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_HOVER_MOVE, true);
         } else {
             Log.e("VRB", "Unknown touch event action");
             return;
@@ -133,7 +138,7 @@ public class MotionEventGenerator {
         device.mPreviousWidget = aWidget;
     }
 
-    public static void dispatchScroll(Widget aWidget, int aDevice, float aX, float aY) {
+    public static void dispatchScroll(Widget aWidget, int aDevice, boolean aFocused, float aX, float aY) {
         Device device = devices.get(aDevice);
         if (device == null) {
             device = new Device(aDevice);
@@ -142,7 +147,7 @@ public class MotionEventGenerator {
         device.mPreviousWidget = aWidget;
         device.mCoords[0].setAxisValue(MotionEvent.AXIS_VSCROLL, aY);
         device.mCoords[0].setAxisValue(MotionEvent.AXIS_HSCROLL, aX);
-        generateEvent(aWidget, device, MotionEvent.ACTION_SCROLL, true);
+        generateEvent(aWidget, device, aFocused, MotionEvent.ACTION_SCROLL, true);
         device.mCoords[0].setAxisValue(MotionEvent.AXIS_VSCROLL, 0.0f);
         device.mCoords[0].setAxisValue(MotionEvent.AXIS_HSCROLL, 0.0f);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -63,9 +63,11 @@ import org.mozilla.vrbrowser.ui.views.CustomKeyboardView;
 import org.mozilla.vrbrowser.ui.views.KeyboardSelectorView;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.VoiceSearchWidget;
 import org.mozilla.vrbrowser.utils.StringUtils;
+import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKeyboardActionListener, AutoCompletionView.Delegate,
@@ -94,6 +96,9 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     private AutoCompletionView mAutoCompletionView;
     private KeyboardSelectorView mLanguageSelectorView;
     private KeyboardSelectorView mDomainSelectorView;
+    private LinearLayout mControlButtons;
+    private ImageView mAutocompletionLayer;
+    private ImageView mKeyboardNumericLayer;
 
     private int mKeyWidth;
     private int mKeyboardPopupTopMargin;
@@ -109,6 +114,11 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     private boolean mInternalDeleteHint = false;
     private Session mSession;
     private boolean mInputRestarted = false;
+    public int mPopUpHoverDeviceId = -1;
+    public int mLanguageHoverDeviceId = -1;
+    public int mDomainHoverDeviceId = -1;
+    public int mAutoCompleteHoverDeviceId = -1;
+    public int mControlHoverDeviceId = -1;
 
     private class MoveTouchListener implements OnTouchListener {
         @Override
@@ -133,7 +143,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         }
     }
 
-    private class MoveHoverListener implements OnHoverListener {
+    private class ControlButtonHoverListener implements OnHoverListener {
         @Override
         public boolean onHover(View v, MotionEvent event) {
             switch (event.getAction()) {
@@ -144,6 +154,88 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
                     v.setHovered(false);
             }
             return false;
+        }
+    }
+
+    private int updateLastDeviceId(View view, int deviceId, int x, int y, int value) {
+        if (view.getVisibility() == VISIBLE && ViewUtils.isInsideView(view, x, y)) {
+            if (value == -1) {
+                return deviceId;
+            }
+        } else {
+            if (deviceId == value) {
+                return -1;
+            }
+        }
+
+        return value;
+    }
+
+    public boolean isValidPointer(int deviceId, int eventDeviceId) {
+        return deviceId == -1 || deviceId == eventDeviceId;
+    }
+
+    private void clearKeyboardHover() {
+        if (mKeyboardView.isHovered()) {
+            mKeyboardView.setHovered(false);
+        }
+        if (mKeyboardNumericView.isHovered()) {
+            mKeyboardNumericView.setHovered(false);
+        }
+    }
+
+    @Override
+    public void handleHoverEvent(MotionEvent aEvent) {
+        int x = (int)aEvent.getRawX();
+        int y = (int)aEvent.getRawY();
+
+        int prevAutocompleteDeviceId = mAutoCompleteHoverDeviceId;
+        int prevControlButtonsDeviceId = mControlHoverDeviceId;
+
+        mPopUpHoverDeviceId = updateLastDeviceId(mPopupKeyboardView, aEvent.getDeviceId(), x, y, mPopUpHoverDeviceId);
+        mLanguageHoverDeviceId = updateLastDeviceId(mLanguageSelectorView, aEvent.getDeviceId(), x, y, mLanguageHoverDeviceId);
+        mDomainHoverDeviceId = updateLastDeviceId(mDomainSelectorView, aEvent.getDeviceId(), x, y, mDomainHoverDeviceId);
+        mAutoCompleteHoverDeviceId = updateLastDeviceId(mAutoCompletionView, aEvent.getDeviceId(), x, y, mAutoCompleteHoverDeviceId);
+        mControlHoverDeviceId = updateLastDeviceId(mControlButtons, aEvent.getDeviceId(), x, y, mControlHoverDeviceId);
+
+        if (mPopupKeyboardView.getVisibility() == VISIBLE) {
+            if (isValidPointer(mPopUpHoverDeviceId, aEvent.getDeviceId()) &&
+                    isValidPointer(mControlHoverDeviceId, aEvent.getDeviceId())) {
+                clearKeyboardHover();
+                super.handleHoverEvent(aEvent);
+            }
+
+        } else if (mLanguageSelectorView.getVisibility() == VISIBLE) {
+            if (isValidPointer(mLanguageHoverDeviceId, aEvent.getDeviceId()) &&
+                    isValidPointer(mControlHoverDeviceId, aEvent.getDeviceId())) {
+                clearKeyboardHover();
+                super.handleHoverEvent(aEvent);
+            }
+
+        } else if (mDomainSelectorView.getVisibility() == VISIBLE) {
+            if (isValidPointer(mDomainHoverDeviceId, aEvent.getDeviceId()) &&
+                    isValidPointer(mControlHoverDeviceId, aEvent.getDeviceId())) {
+                clearKeyboardHover();
+                super.handleHoverEvent(aEvent);
+            }
+
+        } else if (mAutoCompletionView.getVisibility() == VISIBLE) {
+            if (isValidPointer(mAutoCompleteHoverDeviceId, aEvent.getDeviceId()) &&
+                    isValidPointer(mControlHoverDeviceId, aEvent.getDeviceId())) {
+                if (prevAutocompleteDeviceId != mAutoCompleteHoverDeviceId ||
+                        prevControlButtonsDeviceId != mControlHoverDeviceId) {
+                    clearKeyboardHover();
+                }
+                super.handleHoverEvent(aEvent);
+            }
+
+        } else {
+            if (isValidPointer(mControlHoverDeviceId, aEvent.getDeviceId())) {
+                if (prevControlButtonsDeviceId != mControlHoverDeviceId) {
+                    clearKeyboardHover();
+                }
+                super.handleHoverEvent(aEvent);
+            }
         }
     }
 
@@ -172,6 +264,8 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mKeyboardNumericView = findViewById(R.id.keyboardNumeric);
         mPopupKeyboardView = findViewById(R.id.popupKeyboard);
         mPopupKeyboardLayer = findViewById(R.id.popupKeyboardLayer);
+        mAutocompletionLayer = findViewById(R.id.autoCompletionOverlay);
+        mKeyboardNumericLayer = findViewById(R.id.numericKeyboardOverlay);
         mLanguageSelectorView = findViewById(R.id.langSelectorView);
         mKeyboardLayout = findViewById(R.id.keyboardLayout);
         mKeyboardContainer = findViewById(R.id.keyboardContainer);
@@ -179,6 +273,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mAutoCompletionView = findViewById(R.id.autoCompletionView);
         mAutoCompletionView.setExtendedHeight((int)(mWidgetPlacement.height * mWidgetPlacement.density));
         mAutoCompletionView.setDelegate(this);
+        mControlButtons = findViewById(R.id.controlButtons);
 
         mDomainSelectorView = findViewById(R.id.domainSelectorView);
         mDomainSelectorView.setDelegate(this::handleDomainChange);
@@ -239,9 +334,10 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mCapsLockOnIcon = getResources().getDrawable(R.drawable.ic_icon_keyboard_caps, getContext().getTheme());
         mCloseKeyboardButton = findViewById(R.id.keyboardCloseButton);
         mCloseKeyboardButton.setOnClickListener(v -> dismiss());
+        mCloseKeyboardButton.setOnHoverListener(new ControlButtonHoverListener());
         mKeyboardMoveButton = findViewById(R.id.keyboardMoveButton);
         mKeyboardMoveButton.setOnTouchListener(new MoveTouchListener());
-        mKeyboardMoveButton.setOnHoverListener(new MoveHoverListener());
+        mKeyboardMoveButton.setOnHoverListener(new ControlButtonHoverListener());
         mKeyWidth = getResources().getDimensionPixelSize(R.dimen.keyboard_key_width);
         mKeyboardPopupTopMargin  = getResources().getDimensionPixelSize(R.dimen.keyboard_key_pressed_padding) * 2;
 
@@ -255,6 +351,8 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mKeyboardView.setVisibility(View.VISIBLE);
         mKeyboardNumericView.setKeyboard(mKeyboardNumeric);
 
+        mAutocompletionLayer.setOnClickListener(view -> hideOverlays());
+        mKeyboardNumericLayer.setOnClickListener(view -> hideOverlays());
         mPopupKeyboardLayer.setOnClickListener(view -> hideOverlays());
         hideOverlays();
 
@@ -381,7 +479,9 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     }
 
     public void dismiss() {
-        if (mPopupKeyboardLayer.getVisibility() == VISIBLE) {
+        if (mPopupKeyboardLayer.getVisibility() == VISIBLE ||
+                mAutocompletionLayer.getVisibility() == VISIBLE ||
+                mKeyboardNumericLayer.getVisibility() == VISIBLE) {
             hideOverlays();
             return;
         }
@@ -420,8 +520,14 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
     private void hideOverlays() {
         mPopupKeyboardView.setVisibility(View.GONE);
         mPopupKeyboardLayer.setVisibility(View.GONE);
+        mAutocompletionLayer.setVisibility(View.GONE);
+        mKeyboardNumericLayer.setVisibility(View.GONE);
         mLanguageSelectorView.setVisibility(View.GONE);
         mDomainSelectorView.setVisibility(View.GONE);
+
+        mPopUpHoverDeviceId = -1;
+        mLanguageHoverDeviceId = -1;
+        mDomainHoverDeviceId = -1;
     }
 
     protected void onDismiss() {
@@ -468,6 +574,9 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             mPopupKeyboardView.setShifted(mIsCapsLock || mKeyboardView.isShifted());
             mPopupKeyboardView.setVisibility(View.VISIBLE);
             mPopupKeyboardLayer.setVisibility(View.VISIBLE);
+            mKeyboardNumericLayer.setVisibility(View.VISIBLE);
+            mAutocompletionLayer.setVisibility(mAutoCompletionView.getVisibility());
+            mPopUpHoverDeviceId = -1;
 
             mIsLongPress = true;
 
@@ -699,6 +808,9 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mLanguageSelectorView.setSelectedItem(mCurrentKeyboard);
         mLanguageSelectorView.setVisibility(View.VISIBLE);
         mPopupKeyboardLayer.setVisibility(View.VISIBLE);
+        mKeyboardNumericLayer.setVisibility(View.VISIBLE);
+        mAutocompletionLayer.setVisibility(mAutoCompletionView.getVisibility());
+        mLanguageHoverDeviceId = -1;
     }
 
     private void handleEmojiInput() {
@@ -716,6 +828,9 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
         mDomainSelectorView.setVisibility(View.VISIBLE);
         mPopupKeyboardLayer.setVisibility(View.VISIBLE);
+        mKeyboardNumericLayer.setVisibility(View.VISIBLE);
+        mAutocompletionLayer.setVisibility(mAutoCompletionView.getVisibility());
+        mDomainHoverDeviceId = -1;
     }
 
     private void handleLanguageChange(KeyboardInterface aKeyboard) {
@@ -988,6 +1103,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     private void setAutoCompletionVisible(boolean aVisible) {
         mAutoCompletionView.setVisibility(aVisible ? View.VISIBLE : View.GONE);
+        mAutoCompleteHoverDeviceId = -1;
     }
 
     // Must be called in the input thread, see postInputCommand.

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -67,7 +67,6 @@ import org.mozilla.vrbrowser.utils.ViewUtils;
 
 import java.util.ArrayList;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKeyboardActionListener, AutoCompletionView.Delegate,
@@ -1187,6 +1186,11 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean supportsMultipleInputDevices() {
+        return true;
     }
 
     // GeckoSession.TextInputDelegate

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -755,7 +755,12 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
                 }
             }
         }
-        mKeyboardView.setShifted(isShifted || mIsCapsLock);
+
+        // setShifted trigger a full keyboard redraw.
+        // To avoid this we only call setShifted if it's state has changed.
+        if (mKeyboardView.isShifted() != isShifted) {
+            mKeyboardView.setShifted(isShifted || mIsCapsLock);
+        }
     }
 
     private void handleBackspace() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Widget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Widget.java
@@ -38,4 +38,5 @@ public interface Widget {
     default void detachFromWindow() {}
     default void attachToWindow(@NonNull WindowWidget window) {}
     int getBorderWidth();
+    default boolean supportsMultipleInputDevices() { return false; }
 }

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -200,9 +200,11 @@ ControllerContainer::CreateController(const int32_t aControllerIndex, const int3
   CreationContextPtr create = m.context.lock();
   controller.transform = Transform::Create(create);
   controller.pointer = Pointer::Create(create);
+  controller.pointer->SetVisible(true);
   if ((m.models.size() >= aModelIndex) && m.models[aModelIndex]) {
     controller.transform->AddNode(m.models[aModelIndex]);
     controller.beamToggle = vrb::Toggle::Create(create);
+    controller.beamToggle->ToggleAll(true);
     if (aBeamTransform.IsIdentity()) {
       controller.beamParent = controller.beamToggle;
     } else {
@@ -212,7 +214,6 @@ ControllerContainer::CreateController(const int32_t aControllerIndex, const int3
       controller.beamToggle->AddNode(beamTransform);
     }
     controller.transform->AddNode(controller.beamToggle);
-    controller.beamToggle->ToggleAll(false);
     if (m.beamModel && controller.beamParent) {
       controller.beamParent->AddNode(m.beamModel);
     }
@@ -235,20 +236,7 @@ ControllerContainer::SetFocused(const int32_t aControllerIndex) {
     return;
   }
   for (Controller& controller: m.list) {
-    bool show = false;
-    if (controller.index == aControllerIndex) {
-      controller.focused = true;
-      show = true;
-    } else  {
-      controller.focused = false;
-    }
-
-    if (controller.beamToggle) {
-      controller.beamToggle->ToggleAll(show);
-    }
-    if (controller.pointer) {
-      controller.pointer->SetVisible(show);
-    }
+    controller.focused = controller.index == aControllerIndex;
   }
 }
 
@@ -454,6 +442,7 @@ void ControllerContainer::SetPointerColor(const vrb::Color& aColor) const {
 
 void
 ControllerContainer::SetVisible(const bool aVisible) {
+  VRB_LOG("[ControllerContainer] SetVisible %d", aVisible)
   if (m.visible == aVisible) {
     return;
   }

--- a/app/src/main/cpp/VRBrowser.cpp
+++ b/app/src/main/cpp/VRBrowser.cpp
@@ -15,7 +15,7 @@ const char* kDispatchCreateWidgetSignature = "(ILandroid/graphics/SurfaceTexture
 const char* kDispatchCreateWidgetLayerName = "dispatchCreateWidgetLayer";
 const char* kDispatchCreateWidgetLayerSignature = "(ILandroid/view/Surface;IIJ)V";
 const char* kHandleMotionEventName = "handleMotionEvent";
-const char* kHandleMotionEventSignature = "(IIZFF)V";
+const char* kHandleMotionEventSignature = "(IIZZFF)V";
 const char* kHandleScrollEventName = "handleScrollEvent";
 const char* kHandleScrollEventSignature = "(IIFF)V";
 const char* kHandleAudioPoseName = "handleAudioPose";
@@ -175,9 +175,9 @@ VRBrowser::DispatchCreateWidgetLayer(jint aWidgetHandle, jobject aSurface, jint 
 
 
 void
-VRBrowser::HandleMotionEvent(jint aWidgetHandle, jint aController, jboolean aPressed, jfloat aX, jfloat aY) {
+VRBrowser::HandleMotionEvent(jint aWidgetHandle, jint aController, jboolean aFocused, jboolean aPressed, jfloat aX, jfloat aY) {
   if (!ValidateMethodID(sEnv, sActivity, sHandleMotionEvent, __FUNCTION__)) { return; }
-  sEnv->CallVoidMethod(sActivity, sHandleMotionEvent, aWidgetHandle, aController, aPressed, aX, aY);
+  sEnv->CallVoidMethod(sActivity, sHandleMotionEvent, aWidgetHandle, aController, aFocused, aPressed, aX, aY);
   CheckJNIException(sEnv, __FUNCTION__);
 }
 

--- a/app/src/main/cpp/VRBrowser.h
+++ b/app/src/main/cpp/VRBrowser.h
@@ -20,7 +20,7 @@ void InitializeJava(JNIEnv* aEnv, jobject aActivity);
 void ShutdownJava();
 void DispatchCreateWidget(jint aWidgetHandle, jobject aSurfaceTexture, jint aWidth, jint aHeight);
 void DispatchCreateWidgetLayer(jint aWidgetHandle, jobject aSurface, jint aWidth, jint aHeight, const std::function<void()>& aFirstCompositeCallback);
-void HandleMotionEvent(jint aWidgetHandle, jint aController, jboolean aPressed, jfloat aX, jfloat aY);
+void HandleMotionEvent(jint aWidgetHandle, jint aController, jboolean aFocused, jboolean aPressed, jfloat aX, jfloat aY);
 void HandleScrollEvent(jint aWidgetHandle, jint aController, jfloat aX, jfloat aY);
 void HandleAudioPose(jfloat qx, jfloat qy, jfloat qz, jfloat qw, jfloat px, jfloat py, jfloat pz);
 void HandleGesture(jint aType);

--- a/app/src/main/res/layout/autocompletion_bar.xml
+++ b/app/src/main/res/layout/autocompletion_bar.xml
@@ -6,7 +6,7 @@
     android:gravity="center_horizontal"
     android:padding="0dp"
     android:orientation="vertical">
-    
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="@dimen/autocompletion_widget_line_height"

--- a/app/src/main/res/layout/keyboard.xml
+++ b/app/src/main/res/layout/keyboard.xml
@@ -12,6 +12,7 @@
             android:layout_marginTop="0dp"
             android:orientation="horizontal">
             <LinearLayout
+                android:id="@+id/controlButtons"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
@@ -104,16 +105,29 @@
                 android:layout_height="0dp"
                 android:layout_weight="1" />
 
-            <org.mozilla.vrbrowser.ui.views.CustomKeyboardView
-                android:id="@+id/keyboardNumeric"
+            <FrameLayout
                 android:layout_width="@dimen/keyboard_numeric_width"
-                android:layout_height="match_parent"
-                android:padding="15dp"
-                android:background="@drawable/keyboard_background"
-                android:keyBackground="@drawable/keyboard_key_background"
-                android:shadowColor="@android:color/transparent"
-                android:shadowRadius="0.0"
-                android:verticalCorrection="0dp"/>
+                android:layout_height="match_parent">
+                <org.mozilla.vrbrowser.ui.views.CustomKeyboardView
+                    android:id="@+id/keyboardNumeric"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="15dp"
+                    android:background="@drawable/keyboard_background"
+                    android:keyBackground="@drawable/keyboard_key_background"
+                    android:shadowColor="@android:color/transparent"
+                    android:shadowRadius="0.0"
+                    android:verticalCorrection="0dp"/>
+                <ImageView
+                    android:id="@+id/numericKeyboardOverlay"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="15dp"
+                    android:layout_gravity="center"
+                    android:background="@drawable/dialog_background"
+                    android:alpha="0.5"
+                    android:visibility="gone"/>
+            </FrameLayout>
 
         </LinearLayout>
 
@@ -122,9 +136,16 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/autocompletion_widget_line_height"
             android:layout_marginStart="38dp"
-            android:visibility="gone">
-
-        </org.mozilla.vrbrowser.ui.views.AutoCompletionView>
+            android:visibility="gone"/>
+        <ImageView
+            android:id="@+id/autoCompletionOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/autocompletion_widget_line_height"
+            android:layout_marginStart="38dp"
+            android:layout_gravity="center"
+            android:background="@drawable/dialog_background"
+            android:alpha="0.5"
+            android:visibility="gone"/>
     </RelativeLayout>
 
 


### PR DESCRIPTION
Closes #2645 Adds support for dual controller typing. 

Android doesn't support multiple device input in a clean way. The viewgroup clears the hovers from the other hovered items when a new child is hovered which causes a hover fight when more than one device is hovering elements from the same layout. When the view drawing is handled this is easier to workaround but in our case that would mean to rewrite quite a lot of code at this point. 

This implementation add support for dual hovering for the keyboard views (characters, symbols and numbers) and for the rest of the views in the keyboard widget (domains, languages and autocompletion) the first device entering them has preference.