### PR TITLE
Fix for getting invalid media requests for rejected permissions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
@@ -14,6 +14,7 @@ import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.ui.widgets.WidgetManagerDelegate;
 import org.mozilla.vrbrowser.ui.widgets.dialogs.PermissionWidget;
+import org.mozilla.vrbrowser.utils.DeviceType;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.util.ArrayList;
@@ -171,6 +172,14 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
                 aMediaCallback.reject();
             }
         };
+
+        // Temporary fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1621380
+        if ((DeviceType.isWaveBuild() || DeviceType.isPicoVR()) &&
+                (type == PermissionWidget.PermissionType.Camera ||
+                        type == PermissionWidget.PermissionType.CameraAndMicrophone)) {
+            callback.reject();
+            return;
+        }
 
         handlePermission(aUri, type, callback);
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PermissionDelegate.java
@@ -174,9 +174,8 @@ public class PermissionDelegate implements GeckoSession.PermissionDelegate, Widg
         };
 
         // Temporary fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1621380
-        if ((DeviceType.isWaveBuild() || DeviceType.isPicoVR()) &&
-                (type == PermissionWidget.PermissionType.Camera ||
-                        type == PermissionWidget.PermissionType.CameraAndMicrophone)) {
+        if ((type == PermissionWidget.PermissionType.Camera ||
+                type == PermissionWidget.PermissionType.CameraAndMicrophone)) {
             callback.reject();
             return;
         }


### PR DESCRIPTION
Fixes #2935 Fix for getting invalid media requests for rejected permissions.

Related GV issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1621380