### PR TITLE
Make sure domains without protocol are force to https

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/search/suggestions/SuggestionsProvider.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/search/suggestions/SuggestionsProvider.java
@@ -60,7 +60,7 @@ public class SuggestionsProvider {
 
     private String getSearchURLOrDomain(String text) {
         if (UrlUtils.isDomain(text)) {
-            return text;
+            return UrlUtils.ensureHttps(text);
         } else if (UrlUtils.isIPUri(text)) {
             return text;
         } else {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -334,7 +334,7 @@ public class NavigationURLBar extends FrameLayout {
 
         String url;
         if ((UrlUtils.isDomain(text) || UrlUtils.isIPUri(text)) && !text.contains(" ")) {
-            url = text;
+            url = UrlUtils.ensureHttps(text);
             TelemetryWrapper.urlBarEvent(true);
             GleanMetricsService.urlBarEvent(true);
         } else if (text.startsWith("about:") || text.startsWith("resource://")) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
@@ -92,6 +92,24 @@ public class UrlUtils {
                localhostPattern.matcher(uri).find();
     }
 
+    /**
+     * Add HTTPS protocol in case there it is a domain URI without protocol
+     * Keep the protocol otherwise.
+     * @param aUri The input uri
+     * @return The output uri
+     */
+    public static String ensureHttps(@NonNull final String aUri) {
+        String output = aUri;
+        URI uri = URI.create(aUri);
+        if (uri.getScheme() == null && isDomain(aUri)) {
+            String[] parts = uri.getSchemeSpecificPart().split("//");
+            output = parts[parts.length-1];
+            output = "https://" + output;
+        }
+
+        return output;
+    }
+
     public static boolean isPrivateAboutPage(@NonNull Context context,  @NonNull String uri) {
         InternalPages.PageResources pageResources = InternalPages.PageResources.create(R.raw.private_mode, R.raw.private_style);
         byte[] privatePageBytes = InternalPages.createAboutPage(context, pageResources);


### PR DESCRIPTION
We get a lot of http->https forwarded history entries because the InlineAutocompleEditText return domains without protocol. This PR forces all domains without protocol to https so we don't have many http->https forward history entries.