### PR TITLE
Don't calculate reorientation matrix when recentering on G2

### DIFF
--- a/app/src/picovr/cpp/DeviceDelegatePicoVR.cpp
+++ b/app/src/picovr/cpp/DeviceDelegatePicoVR.cpp
@@ -292,9 +292,7 @@ DeviceDelegatePicoVR::GetReorientTransform() const {
 
 void
 DeviceDelegatePicoVR::SetReorientTransform(const vrb::Matrix& aMatrix) {
-  if (m.type == k6DofHeadSet) {
-    m.reorientMatrix = aMatrix;
-  }
+  m.reorientMatrix = aMatrix;
 }
 
 void
@@ -368,7 +366,11 @@ DeviceDelegatePicoVR::StartFrame() {
 
   if (m.renderMode == device::RenderMode::StandAlone) {
     if (m.recentered) {
-      m.reorientMatrix = DeviceUtils::CalculateReorientationMatrix(head, kAverageHeight);
+      if (m.type == k6DofHeadSet) {
+        m.reorientMatrix = DeviceUtils::CalculateReorientationMatrix(head, kAverageHeight);
+      } else {
+        m.reorientMatrix = vrb::Matrix::Identity();
+      }
     }
     head.TranslateInPlace(m.headOffset);
   }


### PR DESCRIPTION
Fixes #2853