### PR TITLE
Only check device if it exists

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/input/MotionEventGenerator.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/input/MotionEventGenerator.java
@@ -155,7 +155,9 @@ public class MotionEventGenerator {
         boolean result = false;
         for (int i=0; i<devices.size(); i++) {
             if (i != deviceId) {
-                result |= devices.get(i).mTouchStartWidget != null;
+                if (devices.get(i) != null) {
+                    result |= devices.get(i).mTouchStartWidget != null;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes a crash where if one of the controllers has not been used and is
not part of the device table would cause a crash.