### PR TITLE
Fix crash if onLoadError uri parameter is null

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -969,7 +969,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     @Override
-    public GeckoResult<String> onLoadError(@NonNull GeckoSession session, String uri,  @NonNull WebRequestError error) {
+    public GeckoResult<String> onLoadError(@NonNull GeckoSession session, @Nullable String uri,  @NonNull WebRequestError error) {
         Log.d(LOGTAG, "Session onLoadError: " + uri);
 
         return GeckoResult.fromValue(InternalPages.createErrorPageDataURI(mContext, uri, error.code));

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/InternalPages.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/InternalPages.java
@@ -3,6 +3,8 @@ package org.mozilla.vrbrowser.utils;
 import android.content.Context;
 import android.util.Base64;
 
+import androidx.annotation.Nullable;
+
 import org.mozilla.vrbrowser.R;
 
 import org.mozilla.geckoview.WebRequestError;
@@ -115,7 +117,7 @@ public class InternalPages {
     }
 
     public static String createErrorPageDataURI(Context context,
-                                                String uri,
+                                                @Nullable String uri,
                                                 int errorType) {
         String html = ErrorPages.INSTANCE.createErrorPage(
                 context,
@@ -134,9 +136,10 @@ public class InternalPages {
                 showSSLAdvanced = false;
         }
 
-        html = html
-                .replace("%url%", uri)
-                .replace("%advancedSSLStyle%", showSSLAdvanced ? "block" : "none");
+        if (uri != null) {
+            html = html.replace("%url%", uri);
+        }
+        html = html.replace("%advancedSSLStyle%", showSSLAdvanced ? "block" : "none");
 
         return "data:text/html;base64," + Base64.encodeToString(html.getBytes(), Base64.NO_WRAP);
     }


### PR DESCRIPTION
Crash report:
https://crash-stats.mozilla.com/report/index/edff4a20-a2d4-41a4-9dd5-773d10200319

I reproduced it sending invalid uris in intents