### PR TITLE
Work around GeckoSession.reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE) bug

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -686,12 +686,16 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     public void loadUri(String aUri) {
+        loadUri(aUri, GeckoSession.LOAD_FLAGS_NONE);
+    }
+
+    public void loadUri(String aUri, int flags) {
         if (aUri == null) {
             aUri = getHomeUri();
         }
         if (mState.mSession != null) {
             Log.d(LOGTAG, "Loading URI: " + aUri);
-            mState.mSession.loadUri(aUri);
+            mState.mSession.loadUri(aUri, flags);
         }
     }
 
@@ -824,7 +828,9 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         if (overrideUri != null) {
             mState.mSession.loadUri(overrideUri, GeckoSession.LOAD_FLAGS_BYPASS_CACHE | GeckoSession.LOAD_FLAGS_REPLACE_HISTORY);
         } else {
-            mState.mSession.reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
+            // mState.mSession.reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
+            mState.mSession.loadUri(mState.mUri, GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
+
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -195,8 +195,13 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             if (mViewModel.getIsLoading().getValue().get()) {
                 getSession().stop();
             } else {
-                int flags = SettingsStore.getInstance(mAppContext).isBypassCacheOnReloadEnabled() ? GeckoSession.LOAD_FLAGS_BYPASS_CACHE : GeckoSession.LOAD_FLAGS_NONE;
-                getSession().reload(flags);
+                if (SettingsStore.getInstance(mAppContext).isBypassCacheOnReloadEnabled()) {
+                    getSession().loadUri(getSession().getCurrentUri(), GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
+                } else {
+                    // int flags = SettingsStore.getInstance(mAppContext).isBypassCacheOnReloadEnabled() ? GeckoSession.LOAD_FLAGS_BYPASS_CACHE : GeckoSession.LOAD_FLAGS_NONE;
+                    // getSession().reload(flags);
+                    getSession().reload(GeckoSession.LOAD_FLAGS_NONE);
+                }
             }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
@@ -209,7 +214,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             if (mViewModel.getIsLoading().getValue().get()) {
                 getSession().stop();
             } else {
-                getSession().reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
+                // getSession().reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
+                getSession().loadUri(getSession().getCurrentUri(), GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
             }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);


### PR DESCRIPTION
Due to https://bugzilla.mozilla.org/show_bug.cgi?id=1623712 need to
use GeckoSession.loadUri instead.

Fixes #3003