### PR TITLE
Add fallback to destructive database migration.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/db/AppDatabase.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/db/AppDatabase.java
@@ -58,6 +58,7 @@ public abstract class AppDatabase extends RoomDatabase {
                         super.onDestructiveMigration(db);
                     }
                 })
+                .fallbackToDestructiveMigration()
                 .build();
     }
 


### PR DESCRIPTION
There is a second version of the database in https://github.com/MozillaReality/FirefoxReality/pull/3019 and if QA or a user downgrades FxR currently it can crash because current master has not any migration fallback