### PR TITLE
Prevent omni.ja compression in APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -347,6 +347,10 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
     }
+
+    aaptOptions {
+        noCompress 'ja'
+    }
 }
 
 configurations {


### PR DESCRIPTION
This is supposed to reduce Gecko start time.