### PR TITLE
Fix potential duplicated StartFrame() call

### DIFF
--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -127,7 +127,6 @@ struct ExternalVR::State {
   vrb::Vector eyeOffsets[device::EyeCount];
   uint64_t lastFrameId = 0;
   bool firstPresentingFrame = false;
-  bool wasFirstPresentingFrame = false;
   bool compositorEnabled = false;
   bool waitingForExit = false;
 
@@ -456,7 +455,6 @@ ExternalVR::WaitFrameResult() {
   m.PullBrowserStateWhileLocked();
   while (true) {
     if (!IsPresenting() || m.browser.layerState[0].layer_stereo_immersive.frameId != m.lastFrameId) {
-      m.wasFirstPresentingFrame = m.firstPresentingFrame;
       m.firstPresentingFrame = false;
       m.system.displayState.lastSubmittedFrameSuccessful = true;
       m.system.displayState.lastSubmittedFrameId = m.browser.layerState[0].layer_stereo_immersive.frameId;
@@ -480,10 +478,6 @@ ExternalVR::WaitFrameResult() {
   }
   m.lastFrameId = m.browser.layerState[0].layer_stereo_immersive.frameId;
   return true;
-}
-
-bool ExternalVR::WasFirstPresentingFrame() const {
-  return m.wasFirstPresentingFrame;
 }
 
 void

--- a/app/src/main/cpp/ExternalVR.h
+++ b/app/src/main/cpp/ExternalVR.h
@@ -55,7 +55,6 @@ public:
   VRState GetVRState() const;
   void PushFramePoses(const vrb::Matrix& aHeadTransform, const std::vector<Controller>& aControllers, const double aTimestamp);
   bool WaitFrameResult();
-  bool WasFirstPresentingFrame() const;
   void GetFrameResult(int32_t& aSurfaceHandle,
                       int32_t& aTextureWidth,
                       int32_t& aTextureHeight,


### PR DESCRIPTION
The `WasFirstPresentingFrame` check is fragile, it can cause a duplicated StartFrame call in some specific frame. 

Also fixes  #3043