### PR TITLE
Fixes #3052 Avoid double fullscreen call

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -415,7 +415,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
                 getSession().exitFullScreen();
             }
             mAttachedWindow.restoreBeforeFullscreenPlacement();
-            mAttachedWindow.setIsFullScreen(false);
             mWidgetManager.popBackHandler(mFullScreenBackHandler);
         }
 
@@ -557,7 +556,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     private void enterFullScreenMode() {
         mWidgetManager.pushBackHandler(mFullScreenBackHandler);
-        mAttachedWindow.setIsFullScreen(true);
+
         AnimationHelper.fadeIn(mBinding.navigationBarFullscreen.fullScreenModeContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
 
         AnimationHelper.fadeOut(mBinding.navigationBarNavigation.navigationBarContainer, 0, null);
@@ -610,7 +609,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
         mWidgetManager.updateWidget(mAttachedWindow);
 
-        mAttachedWindow.setIsFullScreen(false);
         mWidgetManager.popBackHandler(mFullScreenBackHandler);
 
         AnimationHelper.fadeIn(mBinding.navigationBarNavigation.navigationBarContainer, AnimationHelper.FADE_ANIMATION_DURATION, null);
@@ -799,16 +797,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
 
     // Content delegate
 
-    @Override
-    public void onFullScreen(@NonNull GeckoSession session, boolean aFullScreen) {
-        mViewModel.setIsFullscreen(aFullScreen);
-    }
-
     private Observer<ObservableBoolean> mIsFullscreenObserver = isFullScreen -> {
         if (isFullScreen.get()) {
-            if (!mAttachedWindow.isFullScreen()) {
-                enterFullScreenMode();
-            }
+            enterFullScreenMode();
+
             if (mAttachedWindow.isResizing()) {
                 exitResizeMode(ResizeAction.KEEP_SIZE);
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -130,7 +130,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     private WidgetPlacement mPlacementBeforeFullscreen;
     private WidgetPlacement mPlacementBeforeResize;
     private boolean mIsResizing;
-    private boolean mIsFullScreen;
     private boolean mAfterFirstPaint;
     private boolean mCaptureOnPageStop;
     private PromptDelegate mPromptDelegate;
@@ -192,7 +191,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mPlacementBeforeFullscreen = new WidgetPlacement(aContext);
         mPlacementBeforeResize = new WidgetPlacement(aContext);
         mIsResizing = false;
-        mIsFullScreen = false;
         initializeWidgetPlacement(mWidgetPlacement);
         if (mSession.isPrivateMode()) {
             mWidgetPlacement.clearColor = ViewUtils.ARGBtoRGBA(getContext().getColor(R.color.window_private_clear_color));
@@ -889,8 +887,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public void setIsFullScreen(boolean isFullScreen) {
-        if (isFullScreen != mIsFullScreen) {
-            mIsFullScreen = isFullScreen;
+        if (mViewModel.getIsFullscreen().getValue().get() != isFullScreen) {
             mViewModel.setIsFullscreen(isFullScreen);
             for (WindowListener listener: mListeners) {
                 listener.onFullScreen(this, isFullScreen);
@@ -899,7 +896,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     public boolean isFullScreen() {
-        return mIsFullScreen;
+        return mViewModel.getIsFullscreen().getValue().get();
     }
 
     public void addWindowListener(WindowListener aListener) {
@@ -1553,6 +1550,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     }
 
     // GeckoSession.ContentDelegate
+
+    @Override
+    public void onFullScreen(@NonNull GeckoSession session, boolean aFullScreen) {
+        setIsFullScreen(aFullScreen);
+    }
 
     @Override
     public void onContextMenu(GeckoSession session, int screenX, int screenY, ContextElement element) {


### PR DESCRIPTION
Fixes #3052 We were getting duplicated fullscreen change events because we were handling the fullscreen flow in a quite convoluted way where both the navigation bar and the window updated the viewmodel state. I've simplified it and make the window the owner of that property update