### PR TITLE
Add support for Oculus Focus Awareness

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -101,6 +101,7 @@ struct DeviceDelegateOculusVR::State {
   vrb::Color clearColor;
   float near = 0.1f;
   float far = 100.f;
+  bool hasEventFocus = true;
   std::vector<ControllerState> controllerStateList;
   crow::ElbowModelPtr elbow;
   ControllerDelegatePtr controller;
@@ -329,6 +330,13 @@ struct DeviceDelegateOculusVR::State {
       controllerState.enabled = false;
     }
 
+    if (!hasEventFocus) {
+      for (ControllerState& controllerState: controllerStateList) {
+        controller->SetVisible(controllerState.index, controllerState.enabled);
+      }
+      return;
+    }
+
     uint32_t count = 0;
     ovrInputCapabilityHeader capsHeader = {};
     while (vrapi_EnumerateInputDevices(ovr, count++, &capsHeader) >= 0) {
@@ -393,6 +401,10 @@ struct DeviceDelegateOculusVR::State {
   void UpdateControllers(const vrb::Matrix & head) {
     UpdateDeviceId();
     if (!controller) {
+      return;
+    }
+
+    if (!hasEventFocus) {
       return;
     }
 
@@ -793,6 +805,30 @@ DeviceDelegateOculusVR::SetCPULevel(const device::CPULevel aLevel) {
 
 void
 DeviceDelegateOculusVR::ProcessEvents() {
+  ovrEventDataBuffer eventDataBuffer = {};
+  ovrEventHeader* eventHeader = (ovrEventHeader*)(&eventDataBuffer);
+  // Poll for VrApi events at regular frequency
+  while (vrapi_PollEvent(eventHeader) == ovrSuccess) {
+
+    switch (eventHeader->EventType) {
+      case VRAPI_EVENT_FOCUS_GAINED:
+        // FOCUS_GAINED is sent when the application is in the foreground and has
+        // input focus. This may be due to a system overlay relinquishing focus
+        // back to the application.
+        m.hasEventFocus = true;
+        break;
+      case VRAPI_EVENT_FOCUS_LOST:
+        // FOCUS_LOST is sent when the application is no longer in the foreground and
+        // therefore does not have input focus. This may be due to a system overlay taking
+        // focus from the application. The application should take appropriate action when
+        // this occurs.
+        m.hasEventFocus = false;
+        break;
+      default:
+        break;
+    }
+  }
+
   ovrMessageHandle message;
   while ((message = ovr_PopMessage()) != nullptr) {
     switch (ovr_Message_GetType(message)) {
@@ -877,8 +913,6 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
 
   ovrMatrix4f matrix = vrapi_GetTransformFromPose(&m.predictedTracking.HeadPose.Pose);
   vrb::Matrix head = vrb::Matrix::FromRowMajor(matrix.M[0]);
-
-
 
   if (m.renderMode == device::RenderMode::StandAlone) {
     head.TranslateInPlace(kAverageHeight);

--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -5,8 +5,9 @@
     <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <uses-permission android:name="${permissionToRemove}" tools:node="remove" />
     <application>
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
+            <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
         </activity>
     </application>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -30,6 +30,7 @@
             android:supportsPictureInPicture="false"
             tools:node="replace"
             >
+            <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
From the docs:
To enable overlay for testing purposes, enter the following commands in a terminal:

adb shell setprop debug.oculus.dbg_enable_overlay 1
adb shell am force-stop com.oculus.vrshell

After entering these commands, if an app has overlay support enabled in its app manifest, pressing the Oculus button from inside the app will cause the Universal Menu to be displayed as an overlay.

To disable overlay support, enter the following commands:

adb shell setprop debug.oculus.dbg_enable_overlay 0
adb shell am force-stop com.oculus.vrshell