### PR TITLE
Calculate standingMatrix using local floor relative pose transform

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -894,6 +894,9 @@ DeviceDelegateOculusVR::StartFrame(const FramePrediction aPrediction) {
                                    device::InlineSession | device::ImmersiveVRSession;
     if (m.predictedTracking.Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED) {
       caps |= device::Position;
+      auto standing = vrapi_LocateTrackingSpace(m.ovr, VRAPI_TRACKING_SPACE_LOCAL_FLOOR);
+      vrb::Vector translation(-standing.Position.x, -standing.Position.y, -standing.Position.z);
+      m.immersiveDisplay->SetSittingToStandingTransform(vrb::Matrix::Translation(translation));
     } else {
       caps |= device::PositionEmulated;
     }


### PR DESCRIPTION
Improves Room Scale support for WebXR. Related Gecko PR: https://bugzilla.mozilla.org/show_bug.cgi?id=1626053