### PR TITLE
Force tracking protection for Private Sessions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/content/TrackingProtectionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/content/TrackingProtectionStore.java
@@ -226,18 +226,26 @@ public class TrackingProtectionStore implements DefaultLifecycleObserver,
 
     public void add(@NonNull Session session) {
         mContentBlockingController.addException(session.getGeckoSession());
-        mListeners.forEach(listener -> listener.onExcludedTrackingProtectionChange(
-                UrlUtils.getHost(session.getCurrentUri()),
-                true));
-        persist();
+        // Private sessions don't persist to the content blocking controller exceptions list so we just notify
+        if (session.isPrivateMode()) {
+            mListeners.forEach(listener -> listener.onExcludedTrackingProtectionChange(
+                    UrlUtils.getHost(session.getCurrentUri()),
+                    true));
+        } else {
+            persist();
+        }
     }
 
     public void remove(@NonNull Session session) {
         mContentBlockingController.removeException(session.getGeckoSession());
-        mListeners.forEach(listener -> listener.onExcludedTrackingProtectionChange(
-                UrlUtils.getHost(session.getCurrentUri()),
-                false));
-        persist();
+        // Private sessions don't persist to the content blocking controller exceptions list so we just notify
+        if (session.isPrivateMode()) {
+            mListeners.forEach(listener -> listener.onExcludedTrackingProtectionChange(
+                    UrlUtils.getHost(session.getCurrentUri()),
+                    true));
+        } else {
+            persist();
+        }
     }
 
     public void remove(@NonNull SitePermission permission) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -522,7 +522,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         mState = mState.recreate();
 
         TrackingProtectionPolicy policy = TrackingProtectionStore.getTrackingProtectionPolicy(mContext);
-        mState.mSettings.setTrackingProtectionEnabled(policy.shouldBlockContent());
+        mState.mSettings.setTrackingProtectionEnabled(mState.mSettings.isPrivateBrowsingEnabled() || policy.shouldBlockContent());
 
         restore();
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionSettings.java
@@ -89,11 +89,13 @@ class SessionSettings {
 
         public Builder withPrivateBrowsing(boolean enabled) {
             isPrivateBrowsingEnabled = enabled;
+            isTrackingProtectionEnabled = isPrivateBrowsingEnabled || isTrackingProtectionEnabled;
+
             return this;
         }
 
         public Builder withTrackingProtection(boolean isTrackingProtectionEnabled){
-            this.isTrackingProtectionEnabled = isTrackingProtectionEnabled;
+            this.isTrackingProtectionEnabled = isPrivateBrowsingEnabled || isTrackingProtectionEnabled;
             return this;
         }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -70,7 +70,7 @@ public class SessionStore implements GeckoSession.PermissionDelegate{
                 mSessions.forEach(existingSession -> {
                     String existingHost = UrlUtils.getHost(existingSession.getCurrentUri());
                     if (existingHost.equals(host)) {
-                        existingSession.recreateSession();
+                        existingSession.reload(GeckoSession.LOAD_FLAGS_BYPASS_CACHE);
                     }
                 });
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
@@ -317,6 +317,7 @@ public class WindowViewModel extends AndroidViewModel {
                             !isLibraryVisible.getValue().get() &&
                             !UrlUtils.isContentFeed(getApplication(), aUrl.toString()) &&
                             !UrlUtils.isFileUri(aUrl.toString()) &&
+                            !UrlUtils.isPrivateAboutPage(getApplication(), aUrl.toString()) &&
                             (
                                     (SettingsStore.getInstance(getApplication()).getTrackingProtectionLevel() != ContentBlocking.EtpLevel.NONE) ||
                                     isPopUpAvailable.getValue().get() ||

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -491,7 +491,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             mViewModel.getIsFullscreen().removeObserver(mIsFullscreenObserver);
             mViewModel.getIsActiveWindow().removeObserver(mIsActiveWindowObserver);
             mViewModel.getIsPopUpBlocked().removeObserver(mIsPopUpBlockedListener);
-            mViewModel.getUrl().removeObserver(mUrlObserver);
             mViewModel = null;
         }
 
@@ -518,7 +517,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         mViewModel.getIsFullscreen().observeForever( mIsFullscreenObserver);
         mViewModel.getIsActiveWindow().observeForever(mIsActiveWindowObserver);
         mViewModel.getIsPopUpBlocked().observeForever(mIsPopUpBlockedListener);
-        mViewModel.getUrl().observeForever(mUrlObserver);
         mBinding.navigationBarNavigation.urlBar.attachToWindow(mAttachedWindow);
 
         mTrackingDelegate.addListener(mTrackingListener);
@@ -803,6 +801,15 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         }
     }
 
+    // NavigationDelegate
+
+    @Override
+    public void onLocationChange(@NonNull GeckoSession geckoSession, @Nullable String s) {
+        if (getSession() != null && getSession().getGeckoSession() == geckoSession) {
+            updateTrackingProtection();
+        }
+    }
+
     // Content delegate
 
     private Observer<ObservableBoolean> mIsFullscreenObserver = isFullScreen -> {
@@ -834,8 +841,6 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             exitFullScreenMode();
         }
     };
-
-    private Observer<Spannable> mUrlObserver = sitePermissions -> updateTrackingProtection();
 
     private Observer<ObservableBoolean> mIsActiveWindowObserver = aIsActiveWindow -> updateTrackingProtection();
 

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -53,7 +53,7 @@
                     android:src="@{viewmodel.isTrackingEnabled ? @drawable/ic_icon_tracking_enabled : @drawable/ic_icon_tracking_disabled}"
                     app:privateMode="@{viewmodel.isPrivateSession}"
                     android:tint="@color/fog"
-                    app:visibleGone="@{settingsViewmodel.isTrackingProtectionEnabled}"
+                    app:visibleGone="@{!viewmodel.isPrivateSession &amp;&amp; settingsViewmodel.isTrackingProtectionEnabled &amp;&amp; !UrlUtils.isContentFeed(context, viewmodel.url.toString())}"
                     android:tooltipText="@{viewmodel.isTrackingEnabled ? @string/tracking_allowed_tooltip : @string/tracking_disabled_tooltip}" />
 
                 <LinearLayout

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -53,7 +53,7 @@
                     android:src="@{viewmodel.isTrackingEnabled ? @drawable/ic_icon_tracking_enabled : @drawable/ic_icon_tracking_disabled}"
                     app:privateMode="@{viewmodel.isPrivateSession}"
                     android:tint="@color/fog"
-                    app:visibleGone="@{!viewmodel.isPrivateSession &amp;&amp; settingsViewmodel.isTrackingProtectionEnabled &amp;&amp; !UrlUtils.isContentFeed(context, viewmodel.url.toString())}"
+                    app:visibleGone="@{!UrlUtils.isPrivateAboutPage(context, viewmodel.url.toString()) &amp;&amp; settingsViewmodel.isTrackingProtectionEnabled &amp;&amp; !UrlUtils.isContentFeed(context, viewmodel.url.toString())}"
                     android:tooltipText="@{viewmodel.isTrackingEnabled ? @string/tracking_allowed_tooltip : @string/tracking_disabled_tooltip}" />
 
                 <LinearLayout


### PR DESCRIPTION
Fixes #3064 Fixes #3062 Hide ETP button in PB and force tracking protection for Private Sessions based on https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop?as=u&utm_source=inproduct:
> Tracking content in Private Windows only. These trackers are hidden in ads, videos, and other in-page content. Blocking them can cause some websites to break. To add this protection in all windows, visit your privacy preferences and select Strict or Custom as explained below. 