### PR TITLE
Update to new usage of Glean Gradle plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
+deps.telemetry.glean_unittests = "org.mozilla.telemetry:glean-forUnitTests:$project.ext.glean_version"
+
 def getGitHash = { ->
     def stdout = new ByteArrayOutputStream()
     exec {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Accounts.kt
@@ -296,7 +296,7 @@ class Accounts constructor(val context: Context) {
 
     fun pollForEventsAsync(): CompletableFuture<Boolean?>? {
         return CoroutineScope(Dispatchers.Main).future {
-            services.accountManager.authenticatedAccount()?.deviceConstellation()?.pollForEventsAsync()?.await()
+            services.accountManager.authenticatedAccount()?.deviceConstellation()?.pollForCommandsAsync()?.await()
         }
     }
 
@@ -368,8 +368,8 @@ class Accounts constructor(val context: Context) {
                 }
 
                 targets?.forEach { it ->
-                    constellation.sendEventToDeviceAsync(
-                            it.id, DeviceEventOutgoing.SendTab(title, url)
+                    constellation.sendCommandToDeviceAsync(
+                            it.id, DeviceCommandOutgoing.SendTab(title, url)
                     ).await().also { if (it) GleanMetricsService.FxA.sentTab() }
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/BookmarksStore.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/BookmarksStore.kt
@@ -83,7 +83,7 @@ class BookmarksStore constructor(val context: Context) {
     }
 
     // Update the folder strings after a language update
-    fun onConfigurationChanged(newConfig: Configuration) {
+    fun onConfigurationChanged() {
         titles = rootTitles(context)
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Places.kt
@@ -23,7 +23,7 @@ class Places(var context: Context) {
     var history = PlacesHistoryStorage(context)
 
     fun clear() {
-        val files = context.filesDir.listFiles { dir, name ->
+        val files = context.filesDir.listFiles { _, name ->
             name.matches("places\\.sqlite.*".toRegex())
         }
         for (file in files) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -278,7 +278,7 @@ public class SessionStore implements GeckoSession.PermissionDelegate{
             mRuntime.configurationChanged(newConfig);
         }
 
-        mBookmarksStore.onConfigurationChanged(newConfig);
+        mBookmarksStore.onConfigurationChanged();
     }
 
     // Session Settings

--- a/app/src/common/shared/org/mozilla/vrbrowser/geolocation/GeolocationWrapper.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/geolocation/GeolocationWrapper.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.launch
+import mozilla.components.service.location.LocationService
 import mozilla.components.service.location.MozillaLocationService
 import org.mozilla.vrbrowser.browser.engine.EngineProvider
 import org.mozilla.vrbrowser.browser.SettingsStore
@@ -22,12 +23,12 @@ object GeolocationWrapper {
         CoroutineScope(Dispatchers.IO).launch {
             locationService.fetchRegion(true)?.run {
                 val data: GeolocationData = GeolocationData.create(countryCode, countryName)
-                SettingsStore.getInstance(context).setGeolocationData(data.toString())
+                SettingsStore.getInstance(context).geolocationData = data.toString()
             }
         }
     }
 
-    fun get(context: Context): CompletableFuture<MozillaLocationService.Region?> =
+    fun get(context: Context): CompletableFuture<LocationService.Region?> =
         GlobalScope.future {
             val locationService = MozillaLocationService(
                     context,

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -84,9 +84,9 @@ public class GleanMetricsService {
             }
 
             if (domainMap.add(UrlUtils.stripCommonSubdomains(uriLink.getHost()))) {
-                Url.INSTANCE.getDomains().add();
+                Url.INSTANCE.domains().add();
             }
-            Url.INSTANCE.getVisits().add();
+            Url.INSTANCE.visits().add();
 
         } catch (IllegalArgumentException e) {
             Log.e(LOGTAG, "Invalid URL", e);
@@ -96,7 +96,7 @@ public class GleanMetricsService {
 
     public static void sessionStop() {
         domainMap.clear();
-        Pings.INSTANCE.getSessionEnd().send();
+        Pings.INSTANCE.sessionEnd().send();
     }
 
     @UiThread
@@ -153,11 +153,11 @@ public class GleanMetricsService {
     }
 
     public static void newWindowOpenEvent() {
-        Control.INSTANCE.getOpenNewWindow().add();
+        Control.INSTANCE.openNewWindow().add();
     }
 
     private static void setStartupMetrics() {
-        Distribution.INSTANCE.getChannelName().set(DeviceType.isOculusBuild() ? "oculusvr" : BuildConfig.FLAVOR_platform);
+        Distribution.INSTANCE.channelName().set(DeviceType.isOculusBuild() ? "oculusvr" : BuildConfig.FLAVOR_platform);
     }
 
     @VisibleForTesting
@@ -168,29 +168,29 @@ public class GleanMetricsService {
     public static class FxA {
 
         public static void signIn() {
-            FirefoxAccount.INSTANCE.getSignIn().record();
+            FirefoxAccount.INSTANCE.signIn().record();
         }
 
         public static void signInResult(boolean status) {
             Map<FirefoxAccount.signInResultKeys, String> map = new HashMap<>();
             map.put(FirefoxAccount.signInResultKeys.state, String.valueOf(status));
-            FirefoxAccount.INSTANCE.getSignInResult().record(map);
+            FirefoxAccount.INSTANCE.signInResult().record(map);
         }
 
         public static void signOut() {
-            FirefoxAccount.INSTANCE.getSignOut().record();
+            FirefoxAccount.INSTANCE.signOut().record();
         }
 
         public static void bookmarksSyncStatus(boolean status) {
-            FirefoxAccount.INSTANCE.getBookmarksSyncStatus().set(status);
+            FirefoxAccount.INSTANCE.bookmarksSyncStatus().set(status);
         }
 
         public static void historySyncStatus(boolean status) {
-            FirefoxAccount.INSTANCE.getHistorySyncStatus().set(status);
+            FirefoxAccount.INSTANCE.historySyncStatus().set(status);
         }
 
         public static void sentTab() {
-            FirefoxAccount.INSTANCE.getTabSent().add();
+            FirefoxAccount.INSTANCE.tabSent().add();
         }
 
         public static void receivedTab(@NonNull mozilla.components.concept.sync.DeviceType source) {
@@ -217,7 +217,7 @@ public class GleanMetricsService {
         }
 
         public static void activatedEvent() {
-            org.mozilla.vrbrowser.GleanMetrics.Tabs.INSTANCE.getActivated().add();
+            org.mozilla.vrbrowser.GleanMetrics.Tabs.INSTANCE.activated().add();
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     apply from: 'versions.gradle'
     addRepos(repositories)
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "org.mozilla.components:tooling-glean-gradle:$versions.android_components"
         classpath "$deps.kotlin.plugin"
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     addRepos(repositories)
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.1'
-        classpath "org.mozilla.telemetry:glean-gradle-plugin:$versions.telemetry"
+        classpath "org.mozilla.components:tooling-glean-gradle:$versions.android_components"
         classpath "$deps.kotlin.plugin"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -63,6 +63,16 @@ The following metrics are added to the ping:
 This ping is sent at the end of a session (when Firefox Reality switches to the background). We usually send search and UI control metrics at the end of a session.
 
 
+This ping includes the [client id](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section).
+
+**Data reviews for this ping:**
+
+- <https://github.com/MozillaReality/FirefoxReality/pull/2241#issuecomment-557740258>
+
+**Bugs related to this ping:**
+
+- <https://github.com/MozillaReality/FirefoxReality/issues/2230>
+
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,8 +14,11 @@ This means you might have to go searching through the dependency tree to get a f
 
 
 ## baseline
+
 This is a built-in ping that is assembled out of the box by the Glean SDK.
+
 See the Glean SDK documentation for the [`baseline` ping](https://mozilla.github.io/glean/book/user/pings/baseline.html).
+
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |
@@ -23,8 +26,11 @@ The following metrics are added to the ping:
 | distribution.channel_name |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The distribution channel name of this application. We use this field to recognize Firefox Reality is distributed to which channels, such as wavevr, oculusvr, etc.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/1854#issuecomment-546214568), [2](https://github.com/MozillaReality/FirefoxReality/pull/3199#issuecomment-617938749)||2020-11-01 |
 
 ## events
+
 This is a built-in ping that is assembled out of the box by the Glean SDK.
+
 See the Glean SDK documentation for the [`events` ping](https://mozilla.github.io/glean/book/user/pings/events.html).
+
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |
@@ -35,8 +41,11 @@ The following metrics are added to the ping:
 | firefox_account.sign_out |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user pressed the sign out button on the sync account page and was successfully signed out of FxA  |[1](https://github.com/MozillaReality/FirefoxReality/pull/2327#issuecomment-559103837), [2](https://github.com/MozillaReality/FirefoxReality/pull/3199#issuecomment-617938749)||2020-11-01 |
 
 ## metrics
+
 This is a built-in ping that is assembled out of the box by the Glean SDK.
+
 See the Glean SDK documentation for the [`metrics` ping](https://mozilla.github.io/glean/book/user/pings/metrics.html).
+
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |
@@ -50,7 +59,9 @@ The following metrics are added to the ping:
 | url.query_type |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Counting how many URLs are visited in a day, by input method.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/2241#issuecomment-557740258), [2](https://github.com/MozillaReality/FirefoxReality/pull/3199#issuecomment-617938749)|<ul><li>type_link</li><li>type_query</li><li>voice_query</li></ul>|2020-11-01 |
 
 ## session-end
+
 This ping is sent at the end of a session (when Firefox Reality switches to the background). We usually send search and UI control metrics at the end of a session.
+
 
 The following metrics are added to the ping:
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -25,13 +25,13 @@ def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
 versions.gecko_view = "78.0.20200507085231"
-versions.android_components = "37.0.0"
+versions.android_components = "40.0.0"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.
 // The version number below tracks the application-services version
 // that we depend on directly for its rustlog package, and it's important
 // that it be kept insync with the version used by android-components above.
-versions.mozilla_appservices = "0.48.2"
+versions.mozilla_appservices = "0.58.2"
 versions.mozilla_speech = "1.0.11"
 versions.openwnn = "1.3.7"
 versions.room = "2.2.0"

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "78.0.20200507085231"
+versions.gecko_view = "78.0.20200514094044"
 versions.android_components = "40.0.0"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,8 +24,8 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "78.0.20200514094044"
-versions.android_components = "28.0.1"
+versions.gecko_view = "78.0.20200507085231"
+versions.android_components = "37.0.0"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.
 // The version number below tracks the application-services version
@@ -51,7 +51,6 @@ versions.snakeyaml = "1.24"
 versions.gson = "2.8.5"
 versions.robolectric = "4.2.1"
 versions.work = "2.2.0"
-versions.telemetry = "24.1.0"
 ext.versions = versions
 
 def deps = [:]
@@ -148,7 +147,6 @@ kotlin.coroutines_jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version
 deps.kotlin = kotlin
 
 def telemetry = [:]
-telemetry.glean_unittests = "org.mozilla.telemetry:glean-forUnitTests:$versions.telemetry"
 deps.telemetry = telemetry
 
 deps.constraint_layout = "androidx.constraintlayout:constraintlayout:$versions.constraint_layout"


### PR DESCRIPTION
Fixes #2697 

This modifies the build to use the Glean Gradle plugin that ships with android-components, rather than directly from Glean.

This means that updating android-components should be much smoother going forward.  Right now, you have to make sure that the version of Glean forUnitTests is the correct one for a particular version of android-components.  With this change, only the version of android-components needs to be updated, and the correct version of other Glean dependencies will be determined automatically.

I'm submitting this as a draft because it does require upgrading android-components to get this feature, and there seems to be plenty of other unrelated breakage that this upgrade causes.

When you are ready to devote effort to updating android-components, this PR should be ready to use then.

Cc: @Dexterp37