### PR TITLE
Fixes #3110 Fixes #3112 Do not handle fullscreen updates if Window is not attached yet

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -113,6 +113,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     private Executor mUIThreadExecutor;
     private ArrayList<NavigationListener> mNavigationListeners;
     private TrackingProtectionStore mTrackingDelegate;
+    private boolean mIsWindowAttached;
 
     public NavigationBarWidget(Context aContext) {
         super(aContext);
@@ -137,6 +138,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
                 .get(TrayViewModel.class);
 
         updateUI();
+
+        mIsWindowAttached = false;
 
         mAppContext = aContext.getApplicationContext();
 
@@ -484,6 +487,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             mViewModel.getUrl().removeObserver(mUrlObserver);
             mViewModel = null;
         }
+
+        mIsWindowAttached = false;
     }
 
     @Override
@@ -519,6 +524,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
             setUpSession(getSession());
         }
         handleWindowResize();
+
+        mIsWindowAttached = true;
     }
 
     private Session getSession() {
@@ -793,6 +800,10 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     // Content delegate
 
     private Observer<ObservableBoolean> mIsFullscreenObserver = isFullScreen -> {
+        if (!mIsWindowAttached) {
+            return;
+        }
+
         if (isFullScreen.get()) {
             enterFullScreenMode();
 


### PR DESCRIPTION
Fixes #3110 Fixes #3112 Do not handle fullscreen updates if Window is not attached yet