### PR TITLE
Call Glean initialize prior to set startup metrtics.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -46,13 +46,14 @@ public class GleanMetricsService {
         initialized = true;
 
         final boolean telemetryEnabled = SettingsStore.getInstance(aContext).isTelemetryEnabled();
+        Configuration config = new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT, BuildConfig.BUILD_TYPE);
+        Glean.INSTANCE.initialize(aContext, telemetryEnabled, config);
+
         if (telemetryEnabled) {
             GleanMetricsService.start();
         } else {
             GleanMetricsService.stop();
         }
-        Configuration config = new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT, BuildConfig.BUILD_TYPE);
-        Glean.INSTANCE.initialize(aContext, true, config);
     }
 
     // It would be called when users turn on/off the setting of telemetry.


### PR DESCRIPTION
Fixes #3129 

Based on the recent Glean updates ( https://github.com/mozilla/glean/blob/master/CHANGELOG.md#v2300-2020-01-07).

GleanMetricsService.start() need to be called after Glean system initialization.