### PR TITLE
Fix thread of Windows exit/enter immersive calls. Avoid superfluos call.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -961,7 +961,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             return;
         }
         mIsPresentingImmersive = true;
-        mWindows.enterImmersiveMode();
+        runOnUiThread(() -> mWindows.enterImmersiveMode());
+
         TelemetryWrapper.startImmersive();
         GleanMetricsService.startImmersive();
         PauseCompositorRunnable runnable = new PauseCompositorRunnable();
@@ -985,7 +986,8 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             return;
         }
         mIsPresentingImmersive = false;
-        mWindows.exitImmersiveMode();
+        runOnUiThread(() -> mWindows.exitImmersiveMode());
+
         // Show the window in front of you when you exit immersive mode.
         resetUIYaw();
 

--- a/app/src/main/cpp/ExternalVR.cpp
+++ b/app/src/main/cpp/ExternalVR.cpp
@@ -127,7 +127,7 @@ struct ExternalVR::State {
   vrb::Vector eyeOffsets[device::EyeCount];
   uint64_t lastFrameId = 0;
   bool firstPresentingFrame = false;
-  bool compositorEnabled = false;
+  bool compositorEnabled = true;
   bool waitingForExit = false;
 
   State() {


### PR DESCRIPTION
I found a superfluous ResumeCompositor call when starting the app. Also mWindows `enterImmersiveMode` and `exitImmersiveMode` calls are called in the render thread instead of UI. They can internally call some Gecko functions