### PR TITLE
Show last letters of the selected language. Fixes #2945

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/LanguageOptionsView.java
@@ -123,7 +123,7 @@ class LanguageOptionsView extends SettingsView {
             return text.indexOf("[");
         }
 
-        return text.length() - 1;
+        return text.length();
     }
 
     private SpannableStringBuilder getSpannedLanguageText(@NonNull String language) {


### PR DESCRIPTION
1. updated getLanguageIndex function so that for text without '(' or '[' function returns full length of text instead of lenth -1 so that the getSpannedLanguageText generates the full text with bold