### PR TITLE
Add support for Oculus Focus Awareness

### DIFF
--- a/app/src/oculusvrArmDebug/AndroidManifest.xml
+++ b/app/src/oculusvrArmDebug/AndroidManifest.xml
@@ -5,8 +5,9 @@
     <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
     <uses-permission android:name="${permissionToRemove}" tools:node="remove" />
     <application>
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <activity android:name=".VRBrowserActivity" android:screenOrientation="landscape">
+            <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
         </activity>
     </application>

--- a/app/src/oculusvrArmRelease/AndroidManifest.xml
+++ b/app/src/oculusvrArmRelease/AndroidManifest.xml
@@ -30,6 +30,7 @@
             android:supportsPictureInPicture="false"
             tools:node="replace"
             >
+            <meta-data android:name="com.oculus.vr.focusaware" android:value="true" />
             <meta-data android:name="android.app.lib_name" android:value="native-lib" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
From the docs:
To enable overlay for testing purposes, enter the following commands in a terminal:

Go to Setting -> See All -> Experiments and enable New Universal Menu

adb shell setprop debug.oculus.dbg_enable_overlay 1
adb shell am force-stop com.oculus.vrshell

After entering these commands, if an app has overlay support enabled in its app manifest, pressing the Oculus button from inside the app will cause the Universal Menu to be displayed as an overlay.

To disable overlay support, enter the following commands:

adb shell setprop debug.oculus.dbg_enable_overlay 0
adb shell am force-stop com.oculus.vrshell