### PR TITLE
Ensure fullscreen and immersive VR video is exited on pause

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -1192,9 +1192,14 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
     @Override
     public void onCrash(@NonNull GeckoSession session) {
-        Log.e(LOGTAG,"Child crashed. Creating new session");
+        Log.e(LOGTAG,"Child crashed. Recreating session");
         recreateSession();
-        loadUri(getHomeUri());
+    }
+
+    @Override
+    public void onKill(@NonNull GeckoSession session) {
+        Log.e(LOGTAG,"Child killed. Recreating session");
+        recreateSession();
     }
 
     @Override


### PR DESCRIPTION
Fixes #3154

Previously if the content process was killed or crashed while the
application was paused, the windows would still be in fullscreen
and/or immersive VR video mode while the recreated GeckoSession
would not. This partially fixes the issue by ensuring fullscreen
and VR immersive video is exited on pause so the windows do not
get into a bad state if the crash/kills while the application is
backgrounded.