### PR TITLE
Fixes glitches when swhitching between regular and private modes

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -747,6 +747,8 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             setFirstPaint(aWindow, aWindow.getSession());
         }
         aWindow.setVisible(aVisible);
+        aWindow.getTitleBar().setVisible(aVisible);
+        aWindow.getTopBar().setVisible(aVisible);
     }
 
     private void placeWindow(@NonNull WindowWidget aWindow, WindowPlacement aPosition) {


### PR DESCRIPTION
When switching between multi-window regular an private modes, the top and title bars are still visible and cause and annoying glitch.