### PR TITLE
Fixes #2933 Avoid saving FXA login sessions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -39,7 +39,9 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import mozilla.components.concept.sync.AccountObserver;
 import mozilla.components.concept.sync.AuthType;
@@ -59,6 +61,11 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     private static final int TAB_ADDED_NOTIFICATION_ID = 0;
     private static final int TAB_SENT_NOTIFICATION_ID = 1;
     private static final int BOOKMARK_ADDED_NOTIFICATION_ID = 2;
+
+    // Restore URLs blacklist
+    private static final List<String> SAVE_BLACKLIST = Stream.of(
+      "https://accounts.firefox.com/oauth/"
+    ).collect(Collectors.toList());
 
     class WindowState {
         WindowPlacement placement;
@@ -185,11 +192,17 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             state.privateMode = mPrivateMode;
             state.focusedWindowPlacement = mFocusedWindow.isFullScreen() ?  mFocusedWindow.getWindowPlacementBeforeFullscreen() : mFocusedWindow.getWindowPlacement();
             ArrayList<Session> sessions = SessionStore.get().getSortedSessions(false);
-            state.tabs = sessions.stream().map(Session::getSessionState).collect(Collectors.toCollection(ArrayList::new));
+            state.tabs = sessions.stream()
+                    .map(Session::getSessionState)
+                    .filter(sessionState -> SAVE_BLACKLIST.stream().noneMatch(uri -> sessionState.mUri.startsWith(uri)))
+                    .collect(Collectors.toCollection(ArrayList::new));
             for (WindowWidget window : mRegularWindows) {
-                WindowState windowState = new WindowState();
-                windowState.load(window, state, sessions.indexOf(window.getSession()));
-                state.regularWindowsState.add(windowState);
+                if (window.getSession() != null &&
+                        SAVE_BLACKLIST.stream().noneMatch(uri -> window.getSession().getCurrentUri().startsWith(uri))) {
+                    WindowState windowState = new WindowState();
+                    windowState.load(window, state, sessions.indexOf(window.getSession()));
+                    state.regularWindowsState.add(windowState);
+                }
             }
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             gson.toJson(state, writer);


### PR DESCRIPTION
Fixes #2933 Avoid saving FXA login sessions.

We weren't handling the `finishAuthenticationAsync` result where FxA notifies of this error. At that point the only thing that we can do is to deny the request load (if we allow it shows the success page) and notify the user. It doesn't look good to show an alert and leave the user with a loading login page so as a workaround we just avoid restoring FxA oauth flow sessions.

Ideally we should get a redirect to an error page but we get a redirect to the success page even in the case where `finishAuthenticationAsync` fails, I've notified the FxA team about that.