### PR TITLE
Download improvements

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
@@ -217,10 +217,7 @@ public class DownloadsManager {
             Cursor c = mDownloadManager.query(query);
 
             while (c.moveToNext()) {
-                int status = c.getInt(c.getColumnIndex(DownloadManager.COLUMN_STATUS));
-                if (status == DownloadManager.STATUS_RUNNING) {
-                    mMainHandler.post(() -> notifyDownloadsUpdate());
-                }
+                mMainHandler.post(() -> notifyDownloadsUpdate());
             }
             c.close();
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <application
         android:name=".VRBrowserApplication"
         android:allowBackup="true"
+        android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1697,4 +1697,20 @@ the Select` button. When clicked it closes all the previously selected tabs -->
 
     <!-- This string is displayed in the button to dismiss the download error dialog. -->
     <string name="download_error_ok">Ok</string>
+
+    <!-- This string is displayed in the downloads panel, in the download status when the download has failed. -->
+    <string name="download_status_failed">Failed</string>
+
+    <!-- This string is displayed in the downloads panel, in the download status when the download is paused. -->
+    <string name="download_status_paused">Paused</string>
+
+    <!-- This string is displayed in the downloads panel, in the download status when the download is pending. -->
+    <string name="download_status_pending">Pending</string>
+
+    <!-- This string is displayed in the downloads panel, in the download status when the resource is no longer available. -->
+    <string name="download_status_unavailable">Unavailable</string>
+
+    <!-- This string is displayed in the downloads panel, in the download status when an unknown error happened. -->
+    <string name="download_status_unknown_error">Unknown error</string>
+
 </resources>


### PR DESCRIPTION
- Adds information about the download status in the progress field. Prior to this we weren't properly showing the download status , just a blank entry with 0.00kb downloaded bytes. Now when the download is not yet in progress or finished the progress should show the status.
- Allow HTTP downloads in Android > 9. Android 9 Download Manager doesn't handle downloads using HTTP using explicitly set.