### PR TITLE
Fixes #2861 Fix panels being closed on pause

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -437,9 +437,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             // Also prevents a deadlock in onDestroy when the BrowserWidget is released.
             exitImmersiveSync();
         }
-        // If we are in fullscreen or immersive VR video, we need to consume their back handlers
-        // before pausing to prevent the windows from getting stuck in fullscreen mode.
-        flushBackHandlers();
 
         mAudioEngine.pauseEngine();
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/VectorClippedEventDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/VectorClippedEventDelegate.java
@@ -138,7 +138,7 @@ public class VectorClippedEventDelegate implements View.OnHoverListener, View.On
     }
 
     public boolean isInside(MotionEvent event) {
-        return mRegion.contains((int)event.getX(),(int) event.getY());
+        return event != null && mRegion != null && mRegion.contains((int)event.getX(),(int) event.getY());
     }
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -401,6 +401,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     public void onPause() {
         super.onPause();
         mBinding.navigationBarNavigation.urlBar.onPause();
+        exitFullScreenMode();
+        exitVRVideo();
     }
 
     @Override
@@ -600,7 +602,7 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
     }
 
     private void exitFullScreenMode() {
-        if (mAttachedWindow == null) {
+        if (mAttachedWindow == null || !mViewModel.getIsFullscreen().getValue().get()) {
             return;
         }
 

--- a/app/src/main/res/layout/navigation_bar_fullscreen.xml
+++ b/app/src/main/res/layout/navigation_bar_fullscreen.xml
@@ -15,7 +15,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:background="@drawable/resize_bar_background"
-        android:visibility="gone">
+        app:visibleGone="@{viewmodel.isFullscreen}">
 
         <FrameLayout
             android:layout_width="5dp"


### PR DESCRIPTION
Fixes #2861 Flushing the back handlers on Pause was closing the library panels before saving the state.
https://github.com/MozillaReality/FirefoxReality/blob/277000d756884fbfc68b4fc307f219dd7946c79c/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java#L440-L442

Instead of that we just exit the full-screen or immersive mode in onPause.

The related issue is prior to this code so shouldn't be the cause but I couldn't really reproduce it after fixing it so I might have been fixed by other patch.