### PR TITLE
Fixes #2545 Multiple media elements handling

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Media.java
@@ -23,11 +23,13 @@ public class Media implements MediaElement.Delegate {
     private MediaElement mMedia;
     private CopyOnWriteArrayList<MediaElement.Delegate> mMediaListeners;
     private ResizeDelegate mResizeDelegate;
+    private long mLastStateUpdate;
 
     public Media(@NonNull MediaElement aMediaElement) {
         mMedia = aMediaElement;
         mMediaListeners = new CopyOnWriteArrayList<>();
         aMediaElement.setDelegate(this);
+        mLastStateUpdate = 0;
     }
 
     public void addMediaListener(MediaElement.Delegate aListener) {
@@ -113,6 +115,10 @@ public class Media implements MediaElement.Delegate {
         mMedia.setMuted(aIsMuted);
     }
 
+    public long getLastStateUpdate() {
+        return mLastStateUpdate;
+    }
+
     public void unload() {
         mIsUnloaded = true;
         mMediaListeners.clear();
@@ -149,6 +155,7 @@ public class Media implements MediaElement.Delegate {
             mPlaying = false;
             mIsUnloaded = true;
         }
+        mLastStateUpdate = System.currentTimeMillis();
         mMediaListeners.forEach(listener -> listener.onPlaybackStateChange(mediaElement, playbackState));
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/VideoAvailabilityListener.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/VideoAvailabilityListener.java
@@ -1,5 +1,7 @@
 package org.mozilla.vrbrowser.browser;
 
+import androidx.annotation.NonNull;
+
 public interface VideoAvailabilityListener {
-    default void onVideoAvailabilityChanged(boolean aVideosAvailable) {}
+    default void onVideoAvailabilityChanged(@NonNull Media media, boolean aVideoAvailable) {}
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1754,6 +1754,8 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void onLocationChange(@NonNull GeckoSession session, @Nullable String url) {
         mViewModel.setUrl(url);
         mViewModel.setIsDrmUsed(false);
+        mViewModel.setIsMediaAvailable(false);
+        mViewModel.setIsMediaPlaying(false);
 
         if (StringUtils.isEmpty(url)) {
             mViewModel.setIsBookmarked(false);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1668,37 +1668,29 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
 
     // VideoAvailabilityListener
 
-    private Media mMedia;
-
     @Override
-    public void onVideoAvailabilityChanged(boolean aVideosAvailable) {
+    public void onVideoAvailabilityChanged(@NonNull Media aMedia, boolean aVideoAvailable) {
         boolean mediaAvailable;
         if (mSession != null) {
-            if (mMedia != null) {
-                mMedia.removeMediaListener(mMediaDelegate);
-            }
-
-            mMedia = mSession.getFullScreenVideo();
-            if (aVideosAvailable && mMedia != null) {
-                mMedia.addMediaListener(mMediaDelegate);
-                mediaAvailable = true;
+            if (aVideoAvailable) {
+                aMedia.addMediaListener(mMediaDelegate);
 
             } else {
-                mediaAvailable = false;
+                aMedia.removeMediaListener(mMediaDelegate);
             }
+            mediaAvailable = mSession.getActiveVideo() != null;
 
         } else {
             mediaAvailable = false;
         }
 
         if (mediaAvailable) {
-            if (mSession.getFullScreenVideo().isPlayed()) {
-                mViewModel.setIsMediaAvailable(true);
+            if (mSession.getActiveVideo().isPlayed()) {
                 mViewModel.setIsMediaPlaying(true);
             }
+            mViewModel.setIsMediaAvailable(true);
 
         } else {
-            mMedia = null;
             mViewModel.setIsMediaAvailable(false);
             mViewModel.setIsMediaPlaying(false);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1085,8 +1085,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     @Override
     public void onMediaPlayClicked(@NonNull TitleBarWidget titleBar) {
         for (WindowWidget window : getCurrentWindows()) {
-            if (window.getTitleBar() == titleBar) {
-                window.getSession().getFullScreenVideo().play();
+            if (window.getTitleBar() == titleBar &&
+                    window.getSession() != null &&
+                    window.getSession().getActiveVideo() != null) {
+                window.getSession().getActiveVideo().play();
             }
         }
     }
@@ -1094,8 +1096,10 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
     @Override
     public void onMediaPauseClicked(@NonNull TitleBarWidget titleBar) {
         for (WindowWidget window : getCurrentWindows()) {
-            if (window.getTitleBar() == titleBar) {
-                window.getSession().getFullScreenVideo().pause();
+            if (window.getTitleBar() == titleBar &&
+                    window.getSession() != null &&
+                    window.getSession().getActiveVideo() != null) {
+                window.getSession().getActiveVideo().pause();
             }
         }
     }


### PR DESCRIPTION
Fixes #2545 Fixes #2559 This PR improves the handling of multiple media elements state and address the issues with the title bar media controls in pages with multiple media elements.. 

We were currently only listening for events on the latest added media element. This PR adds support for listening on events from all the currently existing media elements and sending title bar media controls actions to the latest focused element.

STRs:
- Open a page with multiple media elements (ie. https://twitter.com/AFCAjax)
- Play the first media element
- Add a new window
- See the initial window title bar

Result: The title bar doesn't show the media controls
Expected: The title bar should show the media controls and they should action the active media element.

With this PR on pages with multiple media elements, the title bar media controls should always target the latest focused media element.