### PR TITLE
Fixes #3169 Hide Tracking icon for file URIs

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
@@ -15,6 +15,7 @@ import androidx.annotation.Nullable;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.browser.SettingsStore;
 
+import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -124,16 +125,22 @@ public class UrlUtils {
         }
 
         if (URLUtil.isValidUrl(aUri)) {
-            try {
-                URI uri = URI.create(aUri);
-                URL url = new URL(
-                        uri.getScheme() != null ? uri.getScheme() : "",
-                        uri.getAuthority() != null ? uri.getAuthority() : "",
-                        "");
-                return url.toString();
+            if (UrlUtils.isFileUri(aUri)) {
+                File file = new File(aUri);
+                return file.getName();
 
-            } catch (MalformedURLException | IllegalArgumentException e) {
-                return "";
+            } else {
+                try {
+                    URI uri = URI.create(aUri);
+                    URL url = new URL(
+                            uri.getScheme() != null ? uri.getScheme() : "",
+                            uri.getAuthority() != null ? uri.getAuthority() : "",
+                            "");
+                    return url.toString();
+
+                } catch (MalformedURLException | IllegalArgumentException e) {
+                    return "";
+                }
             }
 
         } else {

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -41,7 +41,7 @@
                 android:layout_marginStart="2dp"
                 android:addStatesFromChildren="true"
                 android:orientation="horizontal"
-                app:visibleGone="@{!viewmodel.isLibraryVisible &amp;&amp; !UrlUtils.isContentFeed(context, viewmodel.url.toString())}">
+                app:visibleGone="@{!viewmodel.isFocused &amp;&amp; viewmodel.isUrlBarButtonsVisible}">
 
                 <org.mozilla.vrbrowser.ui.views.UIButton
                     android:id="@+id/tracking"
@@ -143,8 +143,7 @@
                 <View
                     android:layout_width="4dp"
                     android:layout_height="match_parent"
-                    app:visibleGone="@{!UrlUtils.isHomeUri(context, viewmodel.url.toString())}"/>
-
+                    app:visibleGone="@{!viewmodel.isUrlBarIconsVisible}"/>
             </LinearLayout>
 
             <View
@@ -152,7 +151,7 @@
                 android:layout_width="15dp"
                 android:layout_height="match_parent"
                 android:layout_toEndOf="@id/startButtonsLayout"
-                app:visibleGone="@{(!settingsViewmodel.isTrackingProtectionEnabled &amp;&amp; !viewmodel.isPopUpAvailable &amp;&amp; !viewmodel.isWebXRUsed) || viewmodel.isLibraryVisible || UrlUtils.isHomeUri(context, viewmodel.url.toString())}"/>
+                app:visibleGone="@{!viewmodel.isUrlBarButtonsVisible || viewmodel.isFocused}"/>
 
             <LinearLayout
                 android:id="@+id/icons"
@@ -161,7 +160,7 @@
                 android:orientation="horizontal"
                 android:layout_toEndOf="@id/padding"
                 android:layout_centerVertical="true"
-                app:visibleGone="@{!viewmodel.isFocused}">
+                app:visibleGone="@{viewmodel.isUrlBarIconsVisible &amp;&amp; !viewmodel.isFocused}">
                 <ImageView
                     android:id="@+id/loadingView"
                     android:layout_width="24dp"


### PR DESCRIPTION
Fixes #3169  This PR refactors the URL buttons (etp, popups, webxr, drm) and icons (loading, ssl) visibility rules to the view model as it has grown quite a lot and makes the XML very crowded and hard to read.

Also adds a number of fixes:
- Hides the ETP icon for file URIs
- Hides the URL buttons if the URL bar is focused
- Shows the file name in the title bar for file URIs (instead of just file://)