### PR TITLE
Fixes #3168 Context menu fixes

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1589,6 +1589,11 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void onContextMenu(GeckoSession session, int screenX, int screenY, ContextElement element) {
         hideContextMenus();
 
+        // We don't show the menu for blobs
+        if (UrlUtils.isBlobUri(element.srcUri)) {
+            return;
+        }
+
         mContextMenu = new ContextMenuWidget(getContext());
         mContextMenu.mWidgetPlacement.parentHandle = getHandle();
         mContextMenu.setDismissCallback(this::hideContextMenus);

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/UrlUtils.java
@@ -114,6 +114,10 @@ public class UrlUtils {
         return aUri != null && aUri.startsWith("file");
     }
 
+    public static Boolean isBlobUri(@Nullable String aUri) {
+        return aUri != null && aUri.startsWith("blob");
+    }
+
     public static Boolean isBlankUri(@Nullable Context context, @Nullable String aUri) {
         return context != null && aUri != null && aUri.equals(context.getString(R.string.about_blank));
     }


### PR DESCRIPTION
Fixes #3168 
- Don't show the context menu for blob elements (ie. Youtube  video)
- In case there is no linkUri, show srcUri as title
- Hide linkUri related menu items (open in new window, open in tab, download link) in case is null or empty