### PR TITLE
Fixes #3202 Hide interstitial when immersive mode exits

### DIFF
--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -260,6 +260,7 @@ BrowserWorld::State::CheckBackButton() {
 bool
 BrowserWorld::State::CheckExitImmersive() {
   if (exitImmersiveRequested && externalVR->IsPresenting()) {
+    webXRInterstialState = WebXRInterstialState::HIDDEN;
     externalVR->StopPresenting();
     blitter->StopPresenting();
     exitImmersiveRequested = false;


### PR DESCRIPTION
Fixes #3202 Make sure the interstitial is hidden when the immersive session is exited.

STRs:
- Open the Spiderman game
- Enter the VR session
- Click the home button
- Resume the app
- Enter the VR session