### PR TITLE
Clear select and squeeze frame ids when it is not in the immersive mode.

### DIFF
--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -552,6 +552,10 @@ ControllerContainer::SetFrameId(const uint64_t aFrameId) {
     m.lastImmersiveFrameId = aFrameId ? aFrameId : m.immersiveFrameId;
   } else {
     m.lastImmersiveFrameId = 0;
+    for (Controller& controller: m.list) {
+      controller.selectActionStartFrameId = controller.selectActionStopFrameId = 0;
+      controller.squeezeActionStartFrameId = controller.squeezeActionStopFrameId = 0;
+    }
   }
   m.immersiveFrameId = aFrameId;
 }


### PR DESCRIPTION
We need to clear the last immersive action frame ids to be 0 if we are away from the immersive mode.