### PR TITLE
Fixes #3241 Fixes #3240 Download fixes

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -729,7 +729,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                         new String[]{
                                 getString(R.string.exit_confirm_dialog_button_cancel),
                                 getString(R.string.exit_confirm_dialog_button_quit),
-                        }, index -> {
+                        }, (index, isChecked) -> {
                             if (index == PromptDialogWidget.POSITIVE) {
                                 VRBrowserActivity.super.onBackPressed();
                             }
@@ -1150,7 +1150,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                 mWindows.getFocusedWindow().showAlert(
                         getString(R.string.not_entitled_title),
                         getString(R.string.not_entitled_message, getString(R.string.app_name)),
-                        index -> finish());
+                        (index, isChecked) -> finish());
             }
         });
     }
@@ -1176,7 +1176,10 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             }
             window.getSession().loadHomePage();
             final String[] buttons = {getString(R.string.ok_button), getString(R.string.performance_unblock_page)};
-            window.showConfirmPrompt(getString(R.string.performance_title), getString(R.string.performance_message), buttons, index -> {
+            window.showConfirmPrompt(getString(R.string.performance_title),
+                    getString(R.string.performance_message),
+                    buttons,
+                    (index, isChecked) -> {
                 if (index == PromptDialogWidget.NEGATIVE) {
                     mPoorPerformanceWhiteList.add(originalUri);
                     window.getSession().loadUri(originalUri);

--- a/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
@@ -117,37 +117,30 @@ public class DownloadsManager {
         return null;
     }
 
-    public void removeDownload(long downloadId) {
-        mDownloadManager.remove(downloadId);
-        notifyDownloadsUpdate();
-    }
-
-    public void removeAllDownloads() {
-        if (getDownloads().size() > 0) {
-            mDownloadManager.remove(getDownloads().stream().mapToLong(Download::getId).toArray());
-            notifyDownloadsUpdate();
-        }
-    }
-
-    public void clearDownload(long downloadId) {
+    public void removeDownload(long downloadId, boolean deleteFiles) {
         Download download = getDownload(downloadId);
         if (download != null) {
-            File file = new File(UrlUtils.stripProtocol(download.getOutputFile()));
-            if (file.exists()) {
-                File newFile = new File(UrlUtils.stripProtocol(download.getOutputFile().concat(".bak")));
-                file.renameTo(newFile);
+            if (!deleteFiles) {
+                File file = new File(UrlUtils.stripProtocol(download.getOutputFile()));
+                if (file.exists()) {
+                    File newFile = new File(UrlUtils.stripProtocol(download.getOutputFile().concat(".bak")));
+                    file.renameTo(newFile);
+                    mDownloadManager.remove(downloadId);
+                    newFile.renameTo(file);
+
+                } else {
+                    mDownloadManager.remove(downloadId);
+                }
+
+            } else {
                 mDownloadManager.remove(downloadId);
-                newFile.renameTo(file);
             }
         }
         notifyDownloadsUpdate();
     }
 
-    public void clearAllDownloads() {
-        getDownloads().forEach(download -> {
-            clearDownload(download.getId());
-        });
-        notifyDownloadsUpdate();
+    public void removeAllDownloads(boolean deleteFiles) {
+        getDownloads().forEach(download -> removeDownload(download.getId(), deleteFiles));
     }
 
     @Nullable

--- a/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
@@ -210,17 +210,8 @@ public class DownloadsManager {
         mListeners.forEach(listener -> listener.onDownloadError(error, file));
     }
 
-    private Runnable mDownloadUpdateTask = new Runnable() {
-        @Override
-        public void run() {
-            DownloadManager.Query query = new DownloadManager.Query();
-            Cursor c = mDownloadManager.query(query);
-
-            while (c.moveToNext()) {
-                mMainHandler.post(() -> notifyDownloadsUpdate());
-            }
-            c.close();
-        }
+    private Runnable mDownloadUpdateTask = () -> {
+        mMainHandler.post(this::notifyDownloadsUpdate);
     };
 
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/DownloadsAdapter.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/adapters/DownloadsAdapter.java
@@ -77,18 +77,16 @@ public class DownloadsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
                 @Override
                 public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
-                    return mDownloadsList.get(oldItemPosition).getUri().equals(downloadsList.get(newItemPosition).getUri());
+                    return mDownloadsList.get(oldItemPosition).getId() == downloadsList.get(newItemPosition).getId();
                 }
 
                 @Override
                 public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
                     Download newDownloadItem = downloadsList.get(newItemPosition);
                     Download oldDownloadItem = mDownloadsList.get(oldItemPosition);
-                    return newDownloadItem.getLastModified() == oldDownloadItem.getLastModified()
-                            && Objects.equals(newDownloadItem.getTitle(), oldDownloadItem.getTitle())
-                            && Objects.equals(newDownloadItem.getDescription(), oldDownloadItem.getDescription())
-                            && Objects.equals(newDownloadItem.getOutputFile(), oldDownloadItem.getOutputFile())
-                            && Objects.equals(newDownloadItem.getUri(), oldDownloadItem.getUri());
+                    return newDownloadItem.getProgress() == oldDownloadItem.getProgress()
+                            && newDownloadItem.getStatus() == oldDownloadItem.getStatus()
+                            && newDownloadItem.getFilename().equals(oldDownloadItem.getFilename());
                 }
             });
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
@@ -161,9 +161,9 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                             getContext().getString(R.string.download_delete_confirm_delete)
                     },
                     getContext().getString(R.string.download_delete_file_confirm_checkbox),
-                    index -> {
+                    (index, isChecked) -> {
                         if (index == PromptDialogWidget.POSITIVE) {
-                            mDownloadsManager.removeDownload(item.getId());
+                            mDownloadsManager.removeDownload(item.getId(), isChecked);
                         }
                     }
             );
@@ -207,9 +207,9 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                             getContext().getString(R.string.download_delete_confirm_delete)
                     },
                     getContext().getString(R.string.download_delete_all_confirm_checkbox),
-                    index -> {
+                    (index, isChecked) -> {
                         if (index == PromptDialogWidget.POSITIVE) {
-                            mDownloadsManager.clearAllDownloads();
+                            mDownloadsManager.removeAllDownloads(isChecked);
                         }
                     }
             );
@@ -293,9 +293,9 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                             getContext().getString(R.string.download_delete_confirm_delete)
                     },
                     getContext().getString(R.string.download_delete_file_confirm_checkbox),
-                    index -> {
+                    (index, isChecked) -> {
                         if (index == PromptDialogWidget.POSITIVE) {
-                            mDownloadsManager.removeDownload(item.getDownloadsId());
+                            mDownloadsManager.removeDownload(item.getDownloadsId(), isChecked);
                         }
                     }
             );

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
@@ -380,7 +380,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
     public void onDownloadError(@NonNull String error, @NonNull String filename) {
         Log.e(LOGTAG, error);
         mWidgetManager.getFocusedWindow().showAlert(
-                getContext().getString(R.string.download_error_title, filename),
+                getContext().getString(R.string.download_error_title),
                 error,
                 null
         );

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
@@ -209,7 +209,8 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                     getContext().getString(R.string.download_delete_all_confirm_checkbox),
                     (index, isChecked) -> {
                         if (index == PromptDialogWidget.POSITIVE) {
-                            mDownloadsManager.removeAllDownloads(isChecked);
+                            mViewModel.setIsEmpty(true);
+                            post(() -> mDownloadsManager.removeAllDownloads(isChecked));
                         }
                     }
             );

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -499,13 +499,15 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
     }
 
     private void showNotification(int notificationId, UIButton button, String string) {
-        NotificationManager.Notification notification = new NotificationManager.Builder(this)
-                .withView(button)
-                .withDensity(R.dimen.tray_tooltip_density)
-                .withString(string)
-                .withPosition(NotificationManager.Notification.TOP)
-                .withZTranslation(25.0f).build();
-        NotificationManager.show(notificationId, notification);
+        if (isVisible()) {
+            NotificationManager.Notification notification = new NotificationManager.Builder(this)
+                    .withView(button)
+                    .withDensity(R.dimen.tray_tooltip_density)
+                    .withString(string)
+                    .withPosition(NotificationManager.Notification.TOP)
+                    .withZTranslation(25.0f).build();
+            NotificationManager.show(notificationId, notification);
+        }
     }
 
     private void hideNotifications() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -528,16 +528,26 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
     @Override
     public void onDownloadsUpdate(@NonNull List<Download> downloads) {
-        long inProgressNum = downloads.stream().filter(item -> item.getStatus() == Download.RUNNING).count();
+        long inProgressNum = downloads.stream().filter(item ->
+                item.getStatus() == Download.RUNNING ||
+                        item.getStatus() == Download.PAUSED ||
+                        item.getStatus() == Download.PENDING).count();
         mTrayViewModel.setDownloadsNumber((int)inProgressNum);
         if (inProgressNum == 0) {
             mBinding.downloadsButton.setLevel(0);
 
         } else {
-            long size = downloads.stream().filter(item -> item.getStatus() == Download.RUNNING).mapToLong(Download::getSizeBytes).sum();
-            long downloaded = downloads.stream().filter(item -> item.getStatus() == Download.RUNNING).mapToLong(Download::getDownloadedBytes).sum();
-            long percent = downloaded*100/size;
-            mBinding.downloadsButton.setLevel((int)percent*100);
+            long size = downloads.stream()
+                    .filter(item -> item.getStatus() == Download.RUNNING)
+                    .mapToLong(Download::getSizeBytes)
+                    .sum();
+            long downloaded = downloads.stream().filter(item -> item.getStatus() == Download.RUNNING)
+                    .mapToLong(Download::getDownloadedBytes)
+                    .sum();
+            if (size > 0) {
+                long percent = downloaded*100/size;
+                mBinding.downloadsButton.setLevel((int)percent*100);
+            }
         }
     }
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1265,10 +1265,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         }
         mAlertDialog.setTitle(title);
         mAlertDialog.setBody(msg);
-        mAlertDialog.setButtonsDelegate(index -> {
+        mAlertDialog.setButtonsDelegate((index, isChecked) -> {
             mAlertDialog.hide(REMOVE_WIDGET);
             if (callback != null) {
-                callback.onButtonClicked(index);
+                callback.onButtonClicked(index, isChecked);
             }
             mAlertDialog.releaseWidget();
             mAlertDialog = null;
@@ -1345,10 +1345,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mConfirmDialog.setTitle(title);
         mConfirmDialog.setBody(msg);
         mConfirmDialog.setButtons(btnMsg);
-        mConfirmDialog.setButtonsDelegate(index -> {
+        mConfirmDialog.setButtonsDelegate((index, isChecked) -> {
             mConfirmDialog.hide(REMOVE_WIDGET);
             if (callback != null) {
-                callback.onButtonClicked(index);
+                callback.onButtonClicked(index, isChecked);
             }
             mConfirmDialog.releaseWidget();
             mConfirmDialog = null;
@@ -1371,10 +1371,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         mAppDialog.setTitle(title);
         mAppDialog.setBody(description);
         mAppDialog.setButtons(btnMsg);
-        mAppDialog.setButtonsDelegate(index -> {
+        mAppDialog.setButtonsDelegate((index, isChecked) -> {
             mAppDialog.hide(REMOVE_WIDGET);
             if (buttonsCallback != null) {
-                buttonsCallback.onButtonClicked(index);
+                buttonsCallback.onButtonClicked(index, isChecked);
             }
             mAppDialog.releaseWidget();
         });
@@ -1399,7 +1399,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                         getContext().getString(R.string.drm_first_use_do_not_allow),
                         getContext().getString(R.string.drm_first_use_allow),
                 },
-                index -> {
+                (index, isChecked) -> {
                     // We remove the prefs listener before the first DRM update to avoid reloading the session
                     mPrefs.unregisterOnSharedPreferenceChangeListener(this);
                     SettingsStore.getInstance(getContext()).setDrmContentPlaybackEnabled(index == PromptDialogWidget.POSITIVE);
@@ -1541,7 +1541,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                         new String[]{
                                 getResources().getString(R.string.download_confirm_cancel),
                                 getResources().getString(R.string.download_confirm_download)},
-                        index ->  {
+                        (index, isChecked) ->  {
                             if (index == PromptDialogWidget.POSITIVE) {
                                 mDownloadsManager.startDownload(downloadJob);
                             }
@@ -1649,7 +1649,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                     new String[]{
                             getResources().getString(R.string.download_open_file_unsupported_cancel),
                             getResources().getString(R.string.download_open_file_unsupported_open)
-                    }, index -> {
+                    }, (index, isChecked) -> {
                         if (index == PromptDialogWidget.POSITIVE) {
                             Uri contentUri = FileProvider.getUriForFile(
                                     getContext(),

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1360,7 +1360,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             mNoInternetDialog.setDescriptionVisible(false);
             mNoInternetDialog.setTitle(R.string.no_internet_title);
             mNoInternetDialog.setBody(R.string.no_internet_message);
-            mNoInternetDialog.setButtonsDelegate(index -> {
+            mNoInternetDialog.setButtonsDelegate((index, isChecked) -> {
                 mNoInternetDialog.hide(UIWidget.REMOVE_WIDGET);
                 mNoInternetDialog.releaseWidget();
                 mNoInternetDialog = null;

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/CrashDialogWidget.java
@@ -48,7 +48,7 @@ public class CrashDialogWidget extends PromptDialogWidget {
                 R.string.do_not_sent_button,
                 R.string.send_data_button
         });
-        setButtonsDelegate(index -> {
+        setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
                 if (mFiles != null) {
                     SystemUtils.clearCrashFiles(getContext(), mFiles);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PermissionWidget.java
@@ -43,7 +43,7 @@ public class PermissionWidget extends PromptDialogWidget {
                 R.string.permission_reject,
                 R.string.permission_allow
         });
-        setButtonsDelegate(index -> {
+        setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
                 // Do not allow
                 handlePermissionResult(false);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PromptDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/PromptDialogWidget.java
@@ -24,7 +24,7 @@ import org.mozilla.vrbrowser.utils.ViewUtils;
 public class PromptDialogWidget extends UIDialog {
 
     public interface Delegate {
-        void onButtonClicked(int index);
+        void onButtonClicked(int index, boolean isChecked);
         default void onDismiss() {}
     }
 
@@ -54,12 +54,12 @@ public class PromptDialogWidget extends UIDialog {
 
         mBinding.leftButton.setOnClickListener(v ->  {
             if (mAppDialogDelegate != null) {
-                mAppDialogDelegate.onButtonClicked(NEGATIVE);
+                mAppDialogDelegate.onButtonClicked(NEGATIVE, isChecked());
             }
         });
         mBinding.rightButton.setOnClickListener(v -> {
             if (mAppDialogDelegate != null) {
-                mAppDialogDelegate.onButtonClicked(POSITIVE);
+                mAppDialogDelegate.onButtonClicked(POSITIVE, isChecked());
             }
         });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/RestartDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/RestartDialogWidget.java
@@ -25,7 +25,7 @@ public class RestartDialogWidget extends PromptDialogWidget {
                 R.string.restart_later_dialog_button,
                 R.string.restart_now_dialog_button
         });
-        setButtonsDelegate(index -> {
+        setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
                 onDismiss();
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SignOutDialogWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/SignOutDialogWidget.java
@@ -47,7 +47,7 @@ public class SignOutDialogWidget extends PromptDialogWidget {
                 R.string.fxa_signout_confirmation_signout,
                 R.string.fxa_signout_confirmation_cancel
         });
-        setButtonsDelegate(index -> {
+        setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
                 try {
                     Objects.requireNonNull(mAccounts.logoutAsync()).thenAcceptAsync(unit -> {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/VoiceSearchWidget.java
@@ -296,7 +296,7 @@ public class VoiceSearchWidget extends UIDialog implements WidgetManagerDelegate
                     new int[]{
                             R.string.voice_samples_collect_dialog_do_not_allow,
                             R.string.voice_samples_collect_dialog_allow},
-                    index -> {
+                    (index, isChecked) -> {
                         SettingsStore.getInstance(getContext()).setSpeechDataCollectionReviewed(true);
                         if (index == PromptDialogWidget.POSITIVE) {
                             SettingsStore.getInstance(getContext()).setSpeechDataCollectionEnabled(true);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/dialogs/WhatsNewWidget.java
@@ -46,7 +46,7 @@ public class WhatsNewWidget extends PromptDialogWidget {
                 R.string.whats_new_button_start_browsing,
                 R.string.whats_new_button_sign_in
         });
-        setButtonsDelegate(index -> {
+        setButtonsDelegate((index, isChecked) -> {
             if (index == PromptDialogWidget.NEGATIVE) {
                 onDismiss();
 

--- a/app/src/main/res/layout/tray.xml
+++ b/app/src/main/res/layout/tray.xml
@@ -102,7 +102,7 @@
                     app:autoSizeMaxTextSize="10sp"
                     app:autoSizeStepGranularity="2sp"
                     android:background="@drawable/downloads_badge"
-                    android:text="@{(traymodel.downloadsNumber &lt; 100) ? String.valueOf(traymodel.downloadsNumber) : @string/ellipsis"
+                    android:text="@{(traymodel.downloadsNumber &lt; 100) ? String.valueOf(traymodel.downloadsNumber) : @string/ellipsis}"
                     visibleGone="@{traymodel.downloadsNumber > 0}"/>
             </RelativeLayout>
 


### PR DESCRIPTION
Fixes #3241 Fixes #3240 Download fixes
- Avoiding unnecessary cursor loop. Should fix the performance issue
- Fixes a typo in the tray badge when downloads number was > 100
- Report all pending downloads, we were only reporting the running ones
- Fixes deleting downloaded files when the checkbox is ticked
- Avoid showing notifications in the tray if it's not visible
- Shows an empty downloads list faster when clearing all the downloads