### PR TITLE
Do not display popup icons when a popup is launched on page leave

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/PromptDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/PromptDelegate.java
@@ -251,16 +251,11 @@ public class PromptDelegate implements
                 final String uri = UrlUtils.getHost(session.getCurrentUri());
                 SitePermission site = mAllowedPopUpSites.stream().filter((item) -> item.url.equals(uri)).findFirst().orElse(null);
                 if (site != null) {
-                    mAttachedWindow.postDelayed(() -> {
-                        result.complete(popupPrompt.confirm(AllowOrDeny.ALLOW));
-                        session.setPopUpState(SessionState.POPUP_ALLOWED);
-                    }, 500);
-
+                    result.complete(popupPrompt.confirm(AllowOrDeny.ALLOW));
+                    session.setPopUpState(SessionState.POPUP_ALLOWED);
                 } else {
-                    mAttachedWindow.postDelayed(() -> {
-                        result.complete(popupPrompt.confirm(AllowOrDeny.DENY));
-                        session.setPopUpState(SessionState.POPUP_BLOCKED);
-                    }, 500);
+                    result.complete(popupPrompt.confirm(AllowOrDeny.DENY));
+                    session.setPopUpState(SessionState.POPUP_BLOCKED);
                 }
 
             } else {


### PR DESCRIPTION
Fixes  #3250

I checked we match the Firefox Desktop behavior:

- Open http://popuptest.com/popuptest2.html
- Navigate to other place. Popup website triggers another popup on page leave.
- The popup is rejected and the notification/icon are not visible in the awesome bar