### PR TITLE
Clear the URL bar if this file type is unsupported.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1728,8 +1728,6 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     @Override
     public void onPageStart(@NonNull GeckoSession geckoSession, @NonNull String aUri) {
         mCaptureOnPageStop = true;
-
-        mViewModel.setUrl(aUri);
         mViewModel.setIsLoading(true);
     }
 


### PR DESCRIPTION
Fixes #3248.

I hope using `postValue()` is right instead of `setValue()`