### PR TITLE
Fixes #3257 Fixes #3256 Make sure session listeners are set when first LoadRequest is called

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -1117,12 +1117,9 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             } else {
                 onCurrentSessionChange(null, aSession.getGeckoSession());
             }
-            setupListeners(mSession);
             for (WindowListener listener: mListeners) {
                 listener.onSessionChanged(oldSession, aSession);
             }
-
-
         }
         mCaptureOnPageStop = false;
         hideLibraryPanels();
@@ -1152,6 +1149,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
         // e.g. tab opened via window.open()
         aSession.updateLastUse();
         Session current = mSession;
+        setupListeners(aSession);
         setSession(aSession);
         SessionStore.get().setActiveSession(aSession);
         current.captureBackgroundBitmap(getWindowWidth(), getWindowHeight()).thenAccept(aVoid -> current.setActive(false));
@@ -1164,6 +1162,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
     public void onUnstackSession(Session aSession, Session aParent) {
         if (mSession == aSession) {
             aParent.setActive(true);
+            setupListeners(aParent);
             setSession(aParent);
             SessionStore.get().setActiveSession(aParent);
             SessionStore.get().destroySession(aSession);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/Windows.java
@@ -1211,7 +1211,9 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             Session moveTo = targetWindow.getSession();
             moveFrom.surfaceDestroyed();
             moveTo.surfaceDestroyed();
+            windowToMove.setupListeners(moveTo);
             windowToMove.setSession(moveTo, WindowWidget.SESSION_DO_NOT_RELEASE_DISPLAY);
+            targetWindow.setupListeners(moveFrom);
             targetWindow.setSession(moveFrom, WindowWidget.SESSION_DO_NOT_RELEASE_DISPLAY);
             SessionStore.get().setActiveSession(targetWindow.getSession());
             windowToMove.setActiveWindow(false);
@@ -1220,6 +1222,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         } else {
             setFirstPaint(targetWindow, aTab);
             targetWindow.getSession().setActive(false);
+            targetWindow.setupListeners(aTab);
             aTab.setActive(true);
             targetWindow.setSession(aTab);
             SessionStore.get().setActiveSession(aTab);
@@ -1234,6 +1237,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
         Session session = SessionStore.get().createSuspendedSession(aUri, targetWindow.getSession().isPrivateMode());
         setFirstPaint(targetWindow, session);
         targetWindow.getSession().setActive(false);
+        targetWindow.setupListeners(session);
         session.setActive(true);
         targetWindow.setSession(session);
         if (aUri == null || aUri.isEmpty()) {
@@ -1297,6 +1301,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
                 Session tab = available.get(0);
                 if (tab != null) {
                     setFirstPaint(window, tab);
+                    window.setupListeners(tab);
                     tab.setActive(true);
                     window.setSession(tab);
                 }
@@ -1336,6 +1341,7 @@ public class Windows implements TrayListener, TopBarWidget.Delegate, TitleBarWid
             if (i == 0 && !fullscreen) {
                 // Set the first received tab of the list the current one.
                 SessionStore.get().setActiveSession(session);
+                targetWindow.setupListeners(session);
                 targetWindow.getSession().setActive(false);
                 targetWindow.setSession(session);
             }


### PR DESCRIPTION
Fixes #3257 Fixes #3256 We are setting the session listeners after activating the sessions. That means that in some cases (like restoring when activating the session) the listeners are not ready. This cause issues like permissions (or anything that we do in the session listeners) not being correctly checked for restored sessions.