### PR TITLE
Fixes #3268 Do not exit fullscreen if it was autoentered

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -160,7 +160,8 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         };
         mVRVideoBackHandler = () -> {
             exitVRVideo();
-            if (mAttachedWindow != null) {
+            if (mAttachedWindow != null &&
+                    mViewModel.getAutoEnteredVRVideo().getValue().get()) {
                 mAttachedWindow.setIsFullScreen(false);
             }
         };


### PR DESCRIPTION
Fixes #3268 Do not exit fullscreen if it was autoentered.  This check got lost here: 9c338d8ab037dc6278a1ea38df9a45c94b54e7aa