### PR TITLE
Fixes #3281 Fixes #3282 Only show URL buttons for http/https uris

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
@@ -333,8 +333,9 @@ public class WindowViewModel extends AndroidViewModel {
         @Override
         public void onChanged(ObservableBoolean o) {
             isUrlBarIconsVisible.postValue(new ObservableBoolean(
-                    isLoading.getValue().get() ||
-                            isInsecureVisible.getValue().get()
+                    !isLibraryVisible.getValue().get() &&
+                            (isLoading.getValue().get() ||
+                                    isInsecureVisible.getValue().get())
             ));
         }
     };

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
@@ -6,6 +6,7 @@ import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 import android.util.TypedValue;
+import android.webkit.URLUtil;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -316,8 +317,8 @@ public class WindowViewModel extends AndroidViewModel {
                     !isFocused.getValue().get() &&
                             !isLibraryVisible.getValue().get() &&
                             !UrlUtils.isContentFeed(getApplication(), aUrl.toString()) &&
-                            !UrlUtils.isFileUri(aUrl.toString()) &&
                             !UrlUtils.isPrivateAboutPage(getApplication(), aUrl.toString()) &&
+                            (URLUtil.isHttpUrl(aUrl.toString()) || URLUtil.isHttpsUrl(aUrl.toString())) &&
                             (
                                     (SettingsStore.getInstance(getApplication()).getTrackingProtectionLevel() != ContentBlocking.EtpLevel.NONE) ||
                                     isPopUpAvailable.getValue().get() ||
@@ -388,10 +389,6 @@ public class WindowViewModel extends AndroidViewModel {
         }
 
         String aURL = url.toString();
-
-        if (isLibraryVisible.getValue().get()) {
-            return;
-        }
 
         int index = -1;
         try {


### PR DESCRIPTION
Fixes #3281 Fixes #3282 We were excluding protocols individually (like file://) but we really just want to show the URL bar buttons for http/https protocols. This PR also hides the URL icon visibility when in Library mode.