### PR TITLE
Fixes #3291 Update URL bar icons visibility based on permissions state

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
@@ -168,7 +168,10 @@ public class WindowViewModel extends AndroidViewModel {
         isDrmUsed = new MutableLiveData<>(new ObservableBoolean(false));
 
         isUrlBarButtonsVisible = new MediatorLiveData<>();
-        isUrlBarButtonsVisible.addSource(url, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isTrackingEnabled, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isDrmUsed, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isPopUpAvailable, mIsUrlBarButtonsVisibleObserver);
+        isUrlBarButtonsVisible.addSource(isWebXRUsed, mIsUrlBarButtonsVisibleObserver);
         isUrlBarButtonsVisible.setValue(new ObservableBoolean(false));
 
         isUrlBarIconsVisible = new MediatorLiveData<>();
@@ -310,15 +313,16 @@ public class WindowViewModel extends AndroidViewModel {
         }
     };
 
-    private Observer<Spannable> mIsUrlBarButtonsVisibleObserver = new Observer<Spannable>() {
+    private Observer<ObservableBoolean> mIsUrlBarButtonsVisibleObserver = new Observer<ObservableBoolean>() {
         @Override
-        public void onChanged(Spannable aUrl) {
+        public void onChanged(ObservableBoolean o) {
+            String aUrl = url.getValue().toString();
             isUrlBarButtonsVisible.postValue(new ObservableBoolean(
                     !isFocused.getValue().get() &&
                             !isLibraryVisible.getValue().get() &&
-                            !UrlUtils.isContentFeed(getApplication(), aUrl.toString()) &&
-                            !UrlUtils.isPrivateAboutPage(getApplication(), aUrl.toString()) &&
-                            (URLUtil.isHttpUrl(aUrl.toString()) || URLUtil.isHttpsUrl(aUrl.toString())) &&
+                            !UrlUtils.isContentFeed(getApplication(), aUrl) &&
+                            !UrlUtils.isPrivateAboutPage(getApplication(), aUrl) &&
+                            (URLUtil.isHttpUrl(aUrl) || URLUtil.isHttpsUrl(aUrl)) &&
                             (
                                     (SettingsStore.getInstance(getApplication()).getTrackingProtectionLevel() != ContentBlocking.EtpLevel.NONE) ||
                                     isPopUpAvailable.getValue().get() ||

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/NavigationURLBar.java
@@ -375,6 +375,8 @@ public class NavigationURLBar extends FrameLayout {
             GleanMetricsService.urlBarEvent(false);
         }
 
+        mViewModel.setUrl(url);
+
         mSession.loadUri(url);
 
         if (mDelegate != null) {

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -51,6 +51,7 @@
                     android:paddingTop="6dp"
                     android:paddingBottom="6dp"
                     android:src="@{viewmodel.isTrackingEnabled ? @drawable/ic_icon_tracking_enabled : @drawable/ic_icon_tracking_disabled}"
+                    tools:src="@drawable/ic_icon_tracking_enabled"
                     app:privateMode="@{viewmodel.isPrivateSession}"
                     android:tint="@color/fog"
                     app:visibleGone="@{!UrlUtils.isPrivateAboutPage(context, viewmodel.url.toString()) &amp;&amp; settingsViewmodel.isTrackingProtectionEnabled &amp;&amp; !UrlUtils.isContentFeed(context, viewmodel.url.toString())}"
@@ -79,6 +80,7 @@
                         android:paddingStart="@{settingsViewmodel.isTrackingProtectionEnabled ? @dimen/navigation_bar_icon_padding_small : @dimen/navigation_bar_icon_padding_big}"
                         android:paddingEnd="2dp"
                         android:src="@{settingsViewmodel.isDrmEnabled ? @drawable/ic_icon_drm_allowed : @drawable/ic_icon_drm_blocked}"
+                        tools:src="@drawable/ic_icon_drm_allowed"
                         android:tint="@color/fog"
                         android:tooltipText="@{settingsViewmodel.isDrmEnabled ? @string/drm_enabled_tooltip : @string/drm_disabled_tooltip}"
                         app:privateMode="@{viewmodel.isPrivateSession}" />
@@ -107,6 +109,7 @@
                         android:paddingStart="@{settingsViewmodel.isTrackingProtectionEnabled || (settingsViewmodel.isDrmEnabled &amp;&amp; viewmodel.isDrmUsed) ? @dimen/navigation_bar_icon_padding_small : @dimen/navigation_bar_icon_padding_big}"
                         android:paddingEnd="2dp"
                         android:src="@{viewmodel.isPopUpBlocked ? @drawable/ic_icon_popup_blocked : @drawable/ic_icon_popup}"
+                        tools:src="@drawable/ic_icon_popup_blocked"
                         android:tint="@color/fog"
                         android:tooltipText="@string/popup_tooltip"
                         app:privateMode="@{viewmodel.isPrivateSession}" />
@@ -135,6 +138,7 @@
                         android:paddingStart="@{settingsViewmodel.isTrackingProtectionEnabled || (settingsViewmodel.isPopUpBlockingEnabled &amp;&amp; viewmodel.isPopUpBlocked) || (settingsViewmodel.isDrmEnabled &amp;&amp; viewmodel.isDrmUsed) ? @dimen/navigation_bar_icon_padding_small : @dimen/navigation_bar_icon_padding_big}"
                         android:paddingEnd="2dp"
                         android:src="@{viewmodel.isWebXRBlocked ? @drawable/ic_icon_webxr_blocked : @drawable/ic_icon_webxr_allowed}"
+                        tools:src="@drawable/ic_icon_webxr_blocked"
                         app:privateMode="@{viewmodel.isPrivateSession}"
                         android:tint="@color/fog"
                         android:tooltipText="@{viewmodel.isWebXRBlocked ? @string/webxr_blocked_tooltip : @string/webxr_allowed_tooltip}" />


### PR DESCRIPTION
Fixes #3291 We were updating based on the url update and that happens onLocationChange but the permission state change is received after that so the URL bar icons visibility property was not being updated after that. This updates the URL bar icons visibility when the permissions change.

Also this PR updates the URL bar url when a url navigated to, otherwise we were having some time until onLocationChange happened when the URL bar was showing the entered characters.