### PR TITLE
Fixes #3290 Pico title bar fixes

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/viewmodel/WindowViewModel.java
@@ -551,7 +551,7 @@ public class WindowViewModel extends AndroidViewModel {
     }
 
     public void setIsActiveWindow(boolean isActiveWindow) {
-        this.isActiveWindow.postValue(new ObservableBoolean(isActiveWindow));
+        this.isActiveWindow.setValue(new ObservableBoolean(isActiveWindow));
     }
 
     @NonNull

--- a/app/src/main/res/layout/title_bar.xml
+++ b/app/src/main/res/layout/title_bar.xml
@@ -72,6 +72,7 @@
                 android:paddingEnd="5dp"
                 android:requiresFadingEdge="horizontal"
                 android:singleLine="true"
+                android:textColor="@color/fog"
                 tools:text="@{viewmodel.titleBarUrl}" />
         </LinearLayout>
 


### PR DESCRIPTION
Fixes #3290 Ensure title bar text remains the same color when pressed. Also use setValue for the active window model property to force a quicker switch of the title bar visibility, otherwise when activating another widow there is a split second when both the navigation and the title bar overlaps, specially in Pico devices.