### PR TITLE
Fixes #2660 Set the correct fullscreen controls and menus curved state

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
@@ -19,6 +19,7 @@ import org.mozilla.telemetry.schedule.jobscheduler.TelemetryJobService;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.geckoview.MediaElement;
 import org.mozilla.vrbrowser.browser.Media;
+import org.mozilla.vrbrowser.browser.SettingsStore;
 import org.mozilla.vrbrowser.ui.views.MediaSeekBar;
 import org.mozilla.vrbrowser.ui.views.UIButton;
 import org.mozilla.vrbrowser.ui.views.VolumeControl;
@@ -123,6 +124,7 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             placement.parentAnchorX = 0.65f;
             placement.parentAnchorY = 0.4f;
             placement.cylinderMapRadius = 0.0f;
+            placement.cylinder = SettingsStore.getInstance(getContext()).isCurvedModeEnabled();
             if (mWidgetManager.getCylinderDensity() > 0) {
                 placement.rotationAxisY = 1.0f;
                 placement.rotation = (float) Math.toRadians(-7);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NavigationBarWidget.java
@@ -16,6 +16,7 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.util.Pair;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.URLUtil;
 import android.widget.EditText;
@@ -385,6 +386,12 @@ public class NavigationBarWidget extends UIWidget implements GeckoSession.Naviga
         if (mAttachedWindow != null) {
             mBinding.navigationBarNavigation.urlBar.attachToWindow(mAttachedWindow);
         }
+
+        setOnTouchListener((v, event) -> {
+            closeFloatingMenus();
+            v.performClick();
+            return true;
+        });
     }
 
     TrackingProtectionStore.TrackingProtectionListener mTrackingListener = new TrackingProtectionStore.TrackingProtectionListener() {


### PR DESCRIPTION
Fixes #2660 Set the correct fullscreen controls and menus curved state. Additionally it fixes an issue with the projection/brightness menus dismiss when clicked in the widget.