### PR TITLE
Adjust Oculus Go controller transform based on WebXR input profile.

### DIFF
--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -371,10 +371,10 @@ struct DeviceDelegateOculusVR::State {
         controllerState.enabled = true;
 
         if (!controllerState.created) {
+          vrb::Matrix beamTransform(vrb::Matrix::Identity());
           if (controllerState.capabilities.ControllerCapabilities &
               ovrControllerCaps_ModelOculusTouch) {
             std::string controllerName;
-            vrb::Matrix beamTransform(vrb::Matrix::Identity());
             if (controllerState.hand == ElbowModel::HandEnum::Left) {
               beamTransform.TranslateInPlace(vrb::Vector(-0.011f, -0.007f, 0.0f));
               controllerName = "Oculus Touch (Left)";
@@ -391,7 +391,6 @@ struct DeviceDelegateOculusVR::State {
             const vrb::Matrix trans = vrb::Matrix::Position(vrb::Vector(0.0f, 0.02f, -0.03f));
             vrb::Matrix transform = vrb::Matrix::Rotation(vrb::Vector(1.0f, 0.0f, 0.0f), -0.77f);
             transform = transform.PostMultiply(trans);
-
             controller->SetImmersiveBeamTransform(controllerState.index, beamTransform.PostMultiply(transform));
           } else {
             // Oculus Go only has one kind of controller model.
@@ -402,6 +401,11 @@ struct DeviceDelegateOculusVR::State {
             // Oculus Go has no haptic feedback.
             controller->SetHapticCount(controllerState.index, 0);
             controller->SetControllerType(controllerState.index, device::OculusGo);
+
+            const vrb::Matrix trans = vrb::Matrix::Position(vrb::Vector(0.0f, 0.028f, -0.072f));
+            vrb::Matrix transform = vrb::Matrix::Rotation(vrb::Vector(1.0f, 0.0f, 0.0f), -0.55f);
+            transform = transform.PostMultiply(trans);
+            controller->SetImmersiveBeamTransform(controllerState.index, beamTransform.PostMultiply(transform));
           }
           controller->SetTargetRayMode(controllerState.index, device::TargetRayMode::TrackedPointer);
           controllerState.created = true;
@@ -458,12 +462,16 @@ struct DeviceDelegateOculusVR::State {
 
       flags |= device::GripSpacePosition;
       controller->SetCapabilityFlags(controllerState.index, flags);
-      if (renderMode == device::RenderMode::Immersive && controllerState.Is6DOF()) {
+      if (renderMode == device::RenderMode::Immersive) {
         static vrb::Matrix transform(vrb::Matrix::Identity());
         if (transform.IsIdentity()) {
-          transform = vrb::Matrix::Rotation(vrb::Vector(1.0f, 0.0f, 0.0f), 0.77f);
-          const vrb::Matrix trans = vrb::Matrix::Position(vrb::Vector(0.0f, 0.0f, 0.025f));
-          transform = transform.PostMultiply(trans);
+          if (controllerState.Is6DOF()) {
+            transform = vrb::Matrix::Rotation(vrb::Vector(1.0f, 0.0f, 0.0f), 0.77f);
+            const vrb::Matrix trans = vrb::Matrix::Position(vrb::Vector(0.0f, 0.0f, 0.025f));
+            transform = transform.PostMultiply(trans);
+          } else {
+            transform = vrb::Matrix::Rotation(vrb::Vector(1.0f, 0.0f, 0.0f), 0.60f);
+          }
         }
         controllerState.transform = controllerState.transform.PostMultiply(transform);
       }

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "77.0.20200501094247"
+versions.gecko_view = "77.0.20200504093644"
 versions.android_components = "28.0.1"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.


### PR DESCRIPTION
We need to adjust it as we did for Quest and Focus Plus. Luckily, for Focus controllers, we don't need it.

It needs to wait for [Bug 1634808](https://bugzilla.mozilla.org/show_bug.cgi?id=1634808) be merged to GV first.