### PR TITLE
Call GeckoSession.setActive(true) even if the session is already active

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -773,9 +773,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
 
         if (mState.mSession != null) {
-            if (mState.isActive() != aActive) {
-                mState.mSession.setActive(aActive);
-            }
+            mState.mSession.setActive(aActive);
             mState.setActive(aActive);
         } else if (aActive) {
             restore();


### PR DESCRIPTION
Workaround for #3323