### PR TITLE
Fix XRRigidTransform orientation is inverted.

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 // GeckoView versions can be found here:
 // https://maven.mozilla.org/?prefix=maven2/org/mozilla/geckoview/
-versions.gecko_view = "77.0.20200504093644"
+versions.gecko_view = "78.0.20200506093716"
 versions.android_components = "28.0.1"
 // Note that android-components also depends on application-services,
 // and in fact is our main source of appservices-related functionality.


### PR DESCRIPTION
Bump to GV 78.0.20200506093716

Test case: https://playcanv.as/e/p/TAYVQgU2/.
The controllers were inverted in comparison with Oculus Browser. This is because our Gecko [Bug 1635363](https://bugzilla.mozilla.org/show_bug.cgi?id=1635363) when setting a quaternion from a rotation matrix.