### PR TITLE
Check for available apps when opening a file

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1657,6 +1657,10 @@ the Select` button. When clicked it closes all the previously selected tabs -->
          the system but the system can't handle it either. -->
     <string name="download_open_file_error_title">Error</string>
 
+    <!-- This string is displayed in the body of the dialog displayed when the file type cannot be opened and
+     there is no system app available to handle it either. -->
+    <string name="download_open_file_open_unsupported_body">File type not supported.</string>
+
     <!-- This string is displayed in the body of the dialog displayed when we try to hand over the file open to
          the system but the system can't handle it either. -->
     <string name="download_open_file_error_body">No application found to handle this file type.</string>


### PR DESCRIPTION
Check for available apps when opening a file otherwise we just show that the file is unsupported. It's not easy to test because of the lack of utilities in most platforms at the moment. It can be tested with:
- 3GP, TIFF in Oculus
- 3GP in Pico