### PR TITLE
Use checks API in taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 version: 1
+reporting: checks-v1
 policy:
   pullRequests: public
 tasks:


### PR DESCRIPTION
I heard from @bluemarvin that when a taskcluster task is re-triggered, the status on github doesn't change. That can be changed if a newer checks API is used. This PR does exactly that

~(It is draft for now because I need to see which scopes are missing)~
ok, it actually seems to work!

As you can see, using a different taskcluster API also changes UX here a bit. You will notice there's a Checks tab up top - that's where the "Details" link will be pointing at now. This can always be changed back.