### PR TITLE
Fixes #2883 Ensure webexts are loaded when restoring sessions

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -93,9 +93,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.mozilla.vrbrowser.ui.widgets.UIWidget.REMOVE_WIDGET;
 
@@ -392,6 +394,19 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
             mWhatsNewWidget.getPlacement().parentHandle = mWindows.getFocusedWindow().getHandle();
             mWhatsNewWidget.show(UIWidget.REQUEST_FOCUS);
         }
+
+        EngineProvider.INSTANCE.loadExtensions()
+                .thenAcceptAsync(aVoid -> {
+                    Log.d(LOGTAG, "WebExtensions loaded");
+                    mWindows.restoreSessions();
+                }, getServicesProvider().getExecutors().mainThread())
+                .exceptionally(throwable -> {
+                    String msg = throwable.getLocalizedMessage();
+                    if (msg != null) {
+                        Log.e(LOGTAG, "Extensions load error: " + msg);
+                    }
+                    return null;
+                });
     }
 
     private void attachToWindow(@NonNull WindowWidget aWindow, @Nullable WindowWidget aPrevWindow) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -405,6 +405,7 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
                     if (msg != null) {
                         Log.e(LOGTAG, "Extensions load error: " + msg);
                     }
+                    mWindows.restoreSessions();
                     return null;
                 });
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
@@ -63,8 +63,8 @@ object EngineProvider {
     fun loadExtensions() : CompletableFuture<Void> {
         val futures : List<CompletableFuture<Void>> = WEB_EXTENSIONS.map {
             val future = CompletableFuture<Void>()
-            val path = "resource://android/assets/web_extensions/$it/"
-            runtime!!.registerWebExtension(WebExtension(path, runtime!!.webExtensionController)).accept {
+            val url = "resource://android/assets/web_extensions/$it/"
+            runtime!!.webExtensionController.installBuiltIn(url).accept {
                 future.complete(null)
             }
             future

--- a/app/src/main/assets/web_extensions/webcompat_vimeo/manifest.json
+++ b/app/src/main/assets/web_extensions/webcompat_vimeo/manifest.json
@@ -3,6 +3,11 @@
   "name": "Firefox Reality Vimeo.com WebCompat Enhancements",
   "version": "1.0",
   "description": "Fixes web-site compatibility quirks for Vimeo.com when using Firefox Reality.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "fxr-webcompat_vimeo@mozilla.org"
+    }
+  },
   "content_scripts": [
     {
       "matches": [

--- a/app/src/main/assets/web_extensions/webcompat_youtube/manifest.json
+++ b/app/src/main/assets/web_extensions/webcompat_youtube/manifest.json
@@ -3,6 +3,11 @@
   "name": "Firefox Reality YouTube.com WebCompat Enhancements",
   "version": "1.0",
   "description": "Fixes web-site compatibility quirks for YouTube.com when using Firefox Reality.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "fxr-webcompat_youtube@mozilla.org"
+    }
+  },
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
Fixes #2883 Web extensions are not being loaded for restored sessions after a restart.

STRs:
- Open a youtube video
- Change the MSAA setting and restart
- See the video URL (it has `app=desktop` appended)
- Change the MSAA setting and restart again

**Actual result**: The loaded url after the first restart has `app=desktop` appended, the webextension hasn't been applied, after the second restart Youtube has an incorrect layout.

**Expected result**: The correct Youtube layout should be used for restored sessions.

This would happen with any extension.