### PR TITLE
Prevent duplicated setActive(false) calls

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -767,6 +767,12 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     public void setActive(boolean aActive) {
+        if (!aActive && mState.mSession != null && !mState.isActive()) {
+            // Prevent duplicated setActive(false) calls. There is a GV
+            // bug that makes the session not to be resumed correctly.
+            // See https://github.com/MozillaReality/FirefoxReality/issues/3375.
+            return;
+        }
         // Flush the events queued while the session was inactive
         if (mState.mSession != null && !mState.isActive() && aActive) {
             flushQueuedEvents();


### PR DESCRIPTION
It seems that calling setActiva(false) twice causes some issues. When we enter immersive mode we call setActive(false) on the non focused windows and we call surfaceDestroyed. If we show the Oculus menu later, setActive(false) is called again

Fixes #3375 