### PR TITLE
Picovr suffix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -168,7 +168,7 @@ android {
                     arguments "-DVR_SDK_LIB=wavevr-lib", "-DWAVEVR=ON"
                 }
             }
-            applicationIdSuffix ".wavevr"
+            applicationIdSuffix ".internal"
         }
 
         wavevrStore {
@@ -184,6 +184,17 @@ android {
         }
 
         picovr {
+            dimension "platform"
+            externalNativeBuild {
+                cmake {
+                    cppFlags " -DPICOVR"
+                    arguments "-DPICOVR=ON"
+                }
+            }
+            applicationIdSuffix ".internal"
+        }
+
+        picovrStore {
             dimension "platform"
             externalNativeBuild {
                 cmake {
@@ -229,6 +240,8 @@ android {
                 'oculusvr3dofStoreArm64Release',
                 'picovrArm64Debug',
                 'picovrArm64Release',
+                'picovrStoreArm64Debug',
+                'picovrStoreArm64Release',
                 'wavevrArm64Debug',
                 'wavevrArm64Release',
                 'wavevrStoreArm64Debug',
@@ -345,6 +358,19 @@ android {
             jniLibs.srcDirs = ["${project.rootDir}/third_party/picovr"]
         }
 
+        picovrStore {
+            java.srcDirs = [
+                    'src/picovr/java'
+            ]
+            assets.srcDirs = [
+                    'src/picovr/assets'
+            ]
+            res.srcDirs = [
+                    'src/picovr/res'
+            ]
+            jniLibs.srcDirs = ["${project.rootDir}/third_party/picovr"]
+        }
+
         noapi {
             java.srcDirs = [
                     'src/noapi/java'
@@ -438,6 +464,7 @@ dependencies {
 
     // Pico
     picovrImplementation fileTree(dir: "${project.rootDir}/third_party/picovr/", include: ['*.aar'])
+    picovrStoreImplementation fileTree(dir: "${project.rootDir}/third_party/picovr/", include: ['*.aar'])
 }
 
 if (findProject(':servo')) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -157,7 +157,7 @@ public class GleanMetricsService {
     }
 
     private static void setStartupMetrics() {
-        Distribution.INSTANCE.channelName().set(DeviceType.isOculusBuild() ? "oculusvr" : BuildConfig.FLAVOR_platform);
+        Distribution.INSTANCE.channelName().set(DeviceType.getDeviceTypeId());
     }
 
     @VisibleForTesting

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/TelemetryWrapper.java
@@ -145,7 +145,7 @@ public class TelemetryWrapper {
             final boolean telemetryEnabled = SettingsStore.getInstance(aContext).isTelemetryEnabled();
             final TelemetryConfiguration configuration = new TelemetryConfiguration(aContext)
                     .setServerEndpoint("https://incoming.telemetry.mozilla.org")
-                    .setAppName(APP_NAME + "_" + (DeviceType.isOculusBuild() ? "oculusvr" : BuildConfig.FLAVOR_platform))
+                    .setAppName(APP_NAME + "_" + DeviceType.getDeviceTypeId())
                     .setUpdateChannel(BuildConfig.BUILD_TYPE)
                     .setPreferencesImportantForTelemetry(resources.getString(R.string.settings_key_locale))
                     .setCollectionEnabled(telemetryEnabled)

--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/DeviceType.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/DeviceType.java
@@ -66,4 +66,17 @@ public class DeviceType {
     public static boolean isPicoVR() {
         return BuildConfig.FLAVOR_platform.toLowerCase().contains("picovr");
     }
+
+    public static String getDeviceTypeId() {
+        String type = BuildConfig.FLAVOR_platform;
+        if (DeviceType.isOculusBuild()) {
+            type = "oculusvr";
+        } else if (DeviceType.isPicoVR()) {
+            type = "picovr";
+        } else if (DeviceType.isWaveBuild()) {
+            type = "wavevrStore";
+        }
+
+        return type;
+    }
 }

--- a/tools/taskcluster/build_targets.py
+++ b/tools/taskcluster/build_targets.py
@@ -12,7 +12,7 @@ Some examples of {{ event.version }} and the resultant output from this script.
 This is the default behaviour with no options. Only the Release build of each
 architecture for each supported platform is built:
 $ python build_targets.py 1.1.4a
-assembleNoapiArm64Release assembleNoapiX86_64Release assembleOculusvrArm64Release assembleWavevrstoreArm64Release assemblePicovrArm64Release assembleOculusvrstoreArm64Release assembleWavevrArm64Release assembleOculusvr3dofstoreArm64Release
+assembleNoapiArm64Release assembleNoapiX86_64Release assembleOculusvrArm64Release assembleWavevrstoreArm64Release assemblePicovrArm64Release assemblePicovrStoreArm64Release assembleOculusvrstoreArm64Release assembleWavevrArm64Release assembleOculusvr3dofstoreArm64Release
 
 Specifies only build the OculusVR platform:
 $ python build_targets.py 1.1.4b+oculusvr
@@ -20,7 +20,7 @@ assembleOculusvrArm64Release
 
 Specifies all build types including Release and Debug:
 $ python build_targets.py 1.1.4c=all
-assembleNoapiArm64 assembleNoapiX86_64 assembleOculusvrArm64 assembleWavevrstoreArm64 assemblePicovrArm64 assembleOculusvrstoreArm64 assembleWavevrArm64 assembleOculusvr3dofstoreArm64
+assembleNoapiArm64 assembleNoapiX86_64 assembleOculusvrArm64 assembleWavevrstoreArm64 assemblePicovrArm64 assemblePicovrStoreArm64 assembleOculusvrstoreArm64 assembleWavevrArm64 assembleOculusvr3dofstoreArm64
 
 Specifies Release builds of Arm64 OculusVR, Arm64 WaveVR, and x86_64 NoAPI:
 $ python build_targets.py 1.1.4d+oculusvr+wavevr+noapi=x86_64
@@ -39,6 +39,7 @@ platforms = {
    'wavevr': ['arm64'],
    'wavevrStore': ['arm64'],
    'picovr': ['arm64'],
+   'picovrStore': ['arm64'],
    'noapi': ['arm64', 'x86_64'],
 }
 


### PR DESCRIPTION
Pico now has a ROM baked version of FxR. We need to provide a suffix so QA can test staging build without colliding with the production appId.