### PR TITLE
Null check for the notification parent view

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NotificationManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/NotificationManager.java
@@ -166,7 +166,10 @@ public class NotificationManager {
         }
 
         Runnable hideTask = () -> hide(notificationId);
-        notification.mView.postDelayed(hideTask, notification.mDuration);
+
+        if (notification.mView != null) {
+            notification.mView.postDelayed(hideTask, notification.mDuration);
+        }
 
         mData.put(notificationId, new NotificationData(notificationView, notification, hideTask));
     }


### PR DESCRIPTION
I've come across a NullPointerException when showing multiple concurrent notifications in the Tray bar during testing.