### PR TITLE
Resolve label metrics are _other_ and add legacy client id

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -80,7 +80,8 @@ searches:
   counts:
     type: labeled_counter
     description: >
-      Counting how many searches are queried in a specific search engine. The search engine `identifier`s are used as keys for this metric.
+      Counting how many searches are queried in a specific search engine.
+      The search engine `identifier`s are used as keys for this metric.
     bugs:
       - https://github.com/MozillaReality/FirefoxReality/issues/2230
     data_reviews:
@@ -250,6 +251,23 @@ control:
     data_reviews:
       - https://github.com/MozillaReality/FirefoxReality/pull/2348#issuecomment-564736919
       - https://github.com/MozillaReality/FirefoxReality/pull/3199#issuecomment-617938749
+    notification_emails:
+      - fxr-telemetry@mozilla.com
+      - dmu@mozilla.com
+    expires: "2020-11-01"
+
+legacy_telemetry:
+  client_id:
+    type: uuid
+    description: >
+      A UUID uniquely identifying the legacy telemetry client id.
+      This is used for supporting legacy telemetry in the `deletion-request` ping.
+    send_in_pings:
+      - deletion-request
+    bugs:
+      - https://github.com/MozillaReality/FirefoxReality/issues/2347
+    data_reviews:
+      - https://github.com/MozillaReality/FirefoxReality/pull/2348#issuecomment-564736919
     notification_emails:
       - fxr-telemetry@mozilla.com
       - dmu@mozilla.com

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -194,7 +194,7 @@ public class GleanMetricsService {
         }
 
         public static void receivedTab(@NonNull mozilla.components.concept.sync.DeviceType source) {
-            FirefoxAccount.INSTANCE.getReceivedTab().get(source.name()).add();
+            FirefoxAccount.INSTANCE.getReceivedTab().get(source.name().toLowerCase()).add();
         }
     }
 
@@ -213,7 +213,7 @@ public class GleanMetricsService {
         }
 
         public static void openedCounter(@NonNull TabSource source) {
-            org.mozilla.vrbrowser.GleanMetrics.Tabs.INSTANCE.getOpened().get(source.name()).add();
+            org.mozilla.vrbrowser.GleanMetrics.Tabs.INSTANCE.getOpened().get(source.name().toLowerCase()).add();
         }
 
         public static void activatedEvent() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -7,9 +7,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 
+import org.mozilla.telemetry.TelemetryHolder;
 import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.GleanMetrics.Distribution;
 import org.mozilla.vrbrowser.GleanMetrics.FirefoxAccount;
+import org.mozilla.vrbrowser.GleanMetrics.LegacyTelemetry;
 import org.mozilla.vrbrowser.GleanMetrics.Pings;
 import org.mozilla.vrbrowser.GleanMetrics.Searches;
 import org.mozilla.vrbrowser.GleanMetrics.Url;
@@ -24,6 +26,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.UUID;
 
 import mozilla.components.service.glean.Glean;
 import mozilla.components.service.glean.config.Configuration;
@@ -51,6 +54,8 @@ public class GleanMetricsService {
         } else {
             GleanMetricsService.stop();
         }
+
+        LegacyTelemetry.INSTANCE.clientId().set(UUID.fromString(TelemetryHolder.get().getClientId()));
         Configuration config = new Configuration(Configuration.DEFAULT_TELEMETRY_ENDPOINT, BuildConfig.BUILD_TYPE);
         Glean.INSTANCE.initialize(aContext, true, config);
     }

--- a/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
@@ -7,8 +7,10 @@ import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.telemetry.TelemetryHolder
 import org.mozilla.vrbrowser.GleanMetrics.Distribution
 import org.mozilla.vrbrowser.GleanMetrics.FirefoxAccount
+import org.mozilla.vrbrowser.GleanMetrics.LegacyTelemetry
 import org.mozilla.vrbrowser.GleanMetrics.Tabs
 import org.mozilla.vrbrowser.GleanMetrics.Url
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService
@@ -136,5 +138,13 @@ class GleanMetricsServiceTest {
         GleanMetricsService.Tabs.activatedEvent()
         assertTrue(Tabs.activated.testHasValue())
         assertEquals(Tabs.activated.testGetValue(), 1)
+    }
+
+    @Test
+    fun testLegacyTelemetry() {
+        assertFalse(LegacyTelemetry.clientId.testHasValue())
+        LegacyTelemetry.clientId.set(java.util.UUID.fromString(TelemetryHolder.get().getClientId()))
+        assertTrue(LegacyTelemetry.clientId.testHasValue())
+        assertEquals(LegacyTelemetry.clientId.testGetValue().toString(), TelemetryHolder.get().getClientId())
     }
 }

--- a/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
@@ -119,18 +119,18 @@ class GleanMetricsServiceTest {
         assertTrue(FirefoxAccount.tabSent.testHasValue())
         assertEquals(FirefoxAccount.tabSent.testGetValue(), 1)
 
-        assertFalse(FirefoxAccount.receivedTab[DeviceType.MOBILE.name].testHasValue())
+        assertFalse(FirefoxAccount.receivedTab[DeviceType.MOBILE.name.toLowerCase()].testHasValue())
         GleanMetricsService.FxA.receivedTab(DeviceType.MOBILE)
-        assertTrue(FirefoxAccount.receivedTab[DeviceType.MOBILE.name].testHasValue())
-        assertEquals(FirefoxAccount.receivedTab[DeviceType.MOBILE.name].testGetValue(), 1)
+        assertTrue(FirefoxAccount.receivedTab[DeviceType.MOBILE.name.toLowerCase()].testHasValue())
+        assertEquals(FirefoxAccount.receivedTab[DeviceType.MOBILE.name.toLowerCase()].testGetValue(), 1)
     }
 
     @Test
     fun testTabTelemetry() {
-        assertFalse(Tabs.opened[GleanMetricsService.Tabs.TabSource.BOOKMARKS.name].testHasValue())
+        assertFalse(Tabs.opened[GleanMetricsService.Tabs.TabSource.BOOKMARKS.name.toLowerCase()].testHasValue())
         GleanMetricsService.Tabs.openedCounter(GleanMetricsService.Tabs.TabSource.BOOKMARKS)
-        assertTrue(Tabs.opened[GleanMetricsService.Tabs.TabSource.BOOKMARKS.name].testHasValue())
-        assertEquals(Tabs.opened[GleanMetricsService.Tabs.TabSource.BOOKMARKS.name].testGetValue(), 1)
+        assertTrue(Tabs.opened[GleanMetricsService.Tabs.TabSource.BOOKMARKS.name.toLowerCase()].testHasValue())
+        assertEquals(Tabs.opened[GleanMetricsService.Tabs.TabSource.BOOKMARKS.name.toLowerCase()].testGetValue(), 1)
 
         assertFalse(Tabs.activated.testHasValue())
         GleanMetricsService.Tabs.activatedEvent()

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,6 +8,7 @@ This means you might have to go searching through the dependency tree to get a f
 # Pings
 
  - [baseline](#baseline)
+ - [deletion-request](#deletion-request)
  - [events](#events)
  - [metrics](#metrics)
  - [session-end](#session-end)
@@ -24,6 +25,14 @@ The following metrics are added to the ping:
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
 | distribution.channel_name |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The distribution channel name of this application. We use this field to recognize Firefox Reality is distributed to which channels, such as wavevr, oculusvr, etc.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/1854#issuecomment-546214568), [2](https://github.com/MozillaReality/FirefoxReality/pull/3199#issuecomment-617938749)||2020-11-01 |
+
+## deletion-request
+
+The following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration |
+| --- | --- | --- | --- | --- | --- |
+| legacy_telemetry.client_id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |A UUID uniquely identifying the legacy telemetry client id. This is used for supporting legacy telemetry in the `deletion-request` ping.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/2348#issuecomment-564736919)||2020-11-01 |
 
 ## events
 


### PR DESCRIPTION
Fixes #3212 and #3324.

In #3212, our labels should be converted to lower case, and add legacy client id in deletion request ping for #3324.