### PR TITLE
Fixes #2948 - Added hover listener for the full media control to hand…

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/MediaControlsWidget.java
@@ -207,6 +207,25 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             }
             mVolumeControl.requestFocusFromTouch();
         });
+
+
+        this.setOnHoverListener((v, event) -> {
+            if (mMedia == null) {
+                return false;
+            }
+           /*this handles the case where the user
+              holds the volume slider up/down past the volume control
+              control then hovers, which wont be picked up by the
+              volume control hover listener.  in this case the widget itself
+              needs to handle this case
+            */
+            if ((event.getX() < 0) || (event.getY() < 0)) {
+                mHideVolumeSlider = true;
+                startVolumeCtrlHandler();
+            }
+
+            return false;
+        });
         mMediaVolumeButton.setOnHoverListener((v, event) -> {
             float startY = v.getY();
             float maxY = startY + v.getHeight();
@@ -214,7 +233,6 @@ public class MediaControlsWidget extends UIWidget implements MediaElement.Delega
             if ((event.getX() <= 0) || (event.getX() >= v.getWidth()) || (!(event.getY() > startY && event.getY() < maxY))) {
                 mHideVolumeSlider = true;
                 startVolumeCtrlHandler();
-
             } else {
                 mVolumeControl.setVisibility(View.VISIBLE);
                 mHideVolumeSlider = false;


### PR DESCRIPTION
…le case when over exits outside of controls.  Added hover listener for the full media control widget to handle cases when the volume control slide is clicked and dragged past max/min  (& area) of the volume control