### PR TITLE
Adjust Oculus Go WebXR exit arrow to the back button instead of the system button.

### DIFF
--- a/app/src/oculusvr/res/layout/webxr_interstitial_controller.xml
+++ b/app/src/oculusvr/res/layout/webxr_interstitial_controller.xml
@@ -89,7 +89,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentBottom="true"
-                android:paddingRight="40dp"
+                android:paddingRight="60dp"
                 android:layout_marginBottom="80dp"
                 android:layout_centerHorizontal="true"
                 android:scaleType="fitCenter"


### PR DESCRIPTION
The arrow currently points to the system button instead of the back button that we exactly wanna users to use. We should do this change.