### PR TITLE
Fixes #2960. Updated code to exclude the first row when determining i…

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/HistoryView.java
@@ -204,7 +204,7 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
                 int lastItem = mHistoryAdapter.getItemCount();
                 if ((rowPosition == layoutManager.findLastVisibleItemPosition() || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() ||
                         rowPosition == layoutManager.findLastVisibleItemPosition()-1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition()-1)
-                        && rowPosition != lastItem) {
+                        && (rowPosition != lastItem && rowPosition != 1)) {
                     isLastVisibleItem = true;
                 }
             }


### PR DESCRIPTION
…f a item is the last visible item in history feed.  this prevents the context menu from showing above clear history button