### PR TITLE
Do not override quality on click

### DIFF
--- a/app/src/main/assets/web_extensions/webcompat_youtube/main.js
+++ b/app/src/main/assets/web_extensions/webcompat_youtube/main.js
@@ -131,7 +131,7 @@ class YoutubeExtension {
     }
 
     overrideClick(event) {
-        this.playerFixes();
+        this.overrideVideoProjection();
         const player = this.getPlayer();
         if (!this.isWatchingPage() || !this.hasVideoProjection() || document.fullscreenElement || !player) {
             return; // Only override click in the Youtube watching page for 360 videos.


### PR DESCRIPTION
Fixes https://github.com/MozillaReality/FirefoxReality/issues/2946#issuecomment-638261659 

Quality was being overridden as part of the player fixes when the player settings were clicked.