### PR TITLE
Update video projection for currently playing video

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/VideoProjectionMenuWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/menus/VideoProjectionMenuWidget.java
@@ -47,6 +47,7 @@ public class VideoProjectionMenuWidget extends MenuWidget {
     ArrayList<MenuItem> mItems;
     Delegate mDelegate;
     @VideoProjectionFlags int mSelectedProjection = VIDEO_PROJECTION_3D_SIDE_BY_SIDE;
+    boolean mIsProjectionOverridden = false;
 
     public VideoProjectionMenuWidget(Context aContext) {
         super(aContext, R.layout.menu);
@@ -118,6 +119,7 @@ public class VideoProjectionMenuWidget extends MenuWidget {
 
     private void handleClick(@VideoProjectionFlags int aVideoProjection) {
         mSelectedProjection = aVideoProjection;
+        mIsProjectionOverridden = true;
         if (mDelegate != null) {
             mDelegate.onVideoProjectionClick(aVideoProjection);
         }
@@ -172,6 +174,14 @@ public class VideoProjectionMenuWidget extends MenuWidget {
         }
 
         return VIDEO_PROJECTION_NONE;
+    }
+
+    public void resetProjectionOverride () {
+        mIsProjectionOverridden = false;
+    }
+
+    public boolean isIsProjectionOverridden() {
+        return mIsProjectionOverridden;
     }
 
     @Override

--- a/app/src/main/assets/web_extensions/webcompat_youtube/main.js
+++ b/app/src/main/assets/web_extensions/webcompat_youtube/main.js
@@ -118,6 +118,8 @@ class YoutubeExtension {
             this.updateVideoStyle();
             logDebug(`Video projection set to: ${qs.get(VIDEO_PROJECTION_PARAM)}`);
         } else {
+            qs.delete('mozVideoProjection');
+            this.updateURL(qs);
             logDebug(`Video is flat, no projection selected`);
         }
     }


### PR DESCRIPTION
We just set the video projection when we enter full screen so when videos are playing in a list or next video is played, the previous video projection remains set. This PR should address that issue and always set the currently playing video projection. If the user changes the projection for the currently playing video, that would be used until the next video is played or full-screen mode is exited.

STRs:
- Create a playlist with 360 and flat videos
- Play the first video fullscreen
- Click the next button to play the next one or let the video end.

The next video should be played and the correct projection should be used.

**Note**: This will only work when in immersive/full-screen.

Related to https://github.com/MozillaReality/FirefoxReality/pull/3394#issuecomment-631127335