### PR TITLE
Legacy telemetry data review.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -265,9 +265,9 @@ legacy_telemetry:
     send_in_pings:
       - deletion-request
     bugs:
-      - https://github.com/MozillaReality/FirefoxReality/issues/2347
+      - https://github.com/MozillaReality/FirefoxReality/issues/3324
     data_reviews:
-      - https://github.com/MozillaReality/FirefoxReality/pull/2348#issuecomment-564736919
+      - https://github.com/MozillaReality/FirefoxReality/pull/3467#issuecomment-642847632
     notification_emails:
       - fxr-telemetry@mozilla.com
       - dmu@mozilla.com

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,7 +32,7 @@ The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |
 | --- | --- | --- | --- | --- | --- |
-| legacy_telemetry.client_id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |A UUID uniquely identifying the legacy telemetry client id. This is used for supporting legacy telemetry in the `deletion-request` ping.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/2348#issuecomment-564736919)||2020-11-01 |
+| legacy_telemetry.client_id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |A UUID uniquely identifying the legacy telemetry client id. This is used for supporting legacy telemetry in the `deletion-request` ping.  |[1](https://github.com/MozillaReality/FirefoxReality/pull/3467#issuecomment-642847632)||2020-11-01 |
 
 ## events
 


### PR DESCRIPTION
 # Request for data collection review form
 **All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**
 
 1. **What questions will you answer with this data?**
 
 * Adding a UUID uniquely identifying the legacy telemetry client id.
   This is used for supporting legacy telemetry in the `deletion-request` ping.
 
 2. **Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?**
 
 *  Helping sunset the legacy telemetry.
  
 3. **What alternative methods did you consider to answer these questions? Why were they not sufficient?**
 
 * N/A. this is a new ping
 
 4. **Can current instrumentation answer these questions?**
 
 * N/A, this is a new ping for supporting legacy telemetry in the `deletion-request`.
 
 5. **List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data collection](https://wiki.mozilla.org/Firefox/Data_Collection) [categories](https://wiki.mozilla.org/Firefox/Data_Collection#Data_Collection_Categories) on the found on the Mozilla wiki.**
 
 * All data is Category 2.
 
 6. **How long will this data be collected?**
 
 Until 11/01/2020. Probably, at that time, the legacy telemetry would be no longer exist.
 
 7. **What populations will you measure?**

 * All release, beta, and nightly users with telemetry enabled.
 
 8. **Please provide a general description of how you will analyze this data.**
 
 * Glean
 
 9. **Where do you intend to share the results of your analysis?**
 
 * Only on Glean and with Firefox Reality team.


@chutten, please help data review. It seems like I forget to do the data review at [#3324](https://github.com/MozillaReality/FirefoxReality/issues/3324)
