### PR TITLE
Merge console and debug logging settings

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/SettingsStore.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 import org.mozilla.geckoview.ContentBlocking;
 import org.mozilla.geckoview.GeckoSessionSettings;
 import org.mozilla.telemetry.TelemetryHolder;
+import org.mozilla.vrbrowser.BuildConfig;
 import org.mozilla.vrbrowser.R;
 import org.mozilla.vrbrowser.VRBrowserActivity;
 import org.mozilla.vrbrowser.telemetry.GleanMetricsService;
@@ -62,7 +63,6 @@ public class SettingsStore {
 
     // Developer options default values
     public final static boolean REMOTE_DEBUGGING_DEFAULT = false;
-    public final static boolean CONSOLE_LOGS_DEFAULT = false;
     public final static boolean ENV_OVERRIDE_DEFAULT = false;
     public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT = true;
     public final static boolean UI_HARDWARE_ACCELERATION_DEFAULT_WAVEVR = false;
@@ -89,7 +89,7 @@ public class SettingsStore {
     public final static float CYLINDER_DENSITY_ENABLED_DEFAULT = 4680.0f;
     private final static long CRASH_RESTART_DELTA = 2000;
     public final static boolean AUTOPLAY_ENABLED = false;
-    public final static boolean DEBUG_LOGGING_DEFAULT = false;
+    public final static boolean DEBUG_LOGGING_DEFAULT = BuildConfig.DEBUG;
     public final static boolean POP_UPS_BLOCKING_DEFAULT = true;
     public final static boolean WEBXR_ENABLED_DEFAULT = true;
     public final static boolean TELEMETRY_STATUS_UPDATE_SENT_DEFAULT = false;
@@ -214,16 +214,6 @@ public class SettingsStore {
         editor.commit();
     }
 
-    public boolean isConsoleLogsEnabled() {
-        return mPrefs.getBoolean(
-                mContext.getString(R.string.settings_key_console_logs), CONSOLE_LOGS_DEFAULT);
-    }
-
-    public void setConsoleLogsEnabled(boolean isEnabled) {
-        SharedPreferences.Editor editor = mPrefs.edit();
-        editor.putBoolean(mContext.getString(R.string.settings_key_console_logs), isEnabled);
-        editor.commit();
-    }
 
     public boolean isDrmContentPlaybackEnabled() {
         return mPrefs.getBoolean(

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
@@ -32,7 +32,6 @@ object EngineProvider {
                     .antiTracking(policy.antiTrackingPolicy)
                     .enhancedTrackingProtectionLevel(SettingsStore.getInstance(context).trackingProtectionLevel)
                     .build())
-            builder.consoleOutput(SettingsStore.getInstance(context).isConsoleLogsEnabled)
             builder.displayDensityOverride(SettingsStore.getInstance(context).displayDensity)
             builder.remoteDebuggingEnabled(SettingsStore.getInstance(context).isRemoteDebuggingEnabled)
             builder.displayDpiOverride(SettingsStore.getInstance(context).displayDpi)
@@ -41,6 +40,8 @@ object EngineProvider {
             builder.useMultiprocess(true)
             builder.inputAutoZoomEnabled(false)
             builder.doubleTapZoomingEnabled(false)
+            builder.debugLogging(SettingsStore.getInstance(context).isDebugLoggingEnabled)
+            builder.consoleOutput(SettingsStore.getInstance(context).isDebugLoggingEnabled)
 
             if (SettingsStore.getInstance(context).transparentBorderWidth > 0) {
                 builder.useMaxScreenDepth(true)
@@ -48,10 +49,7 @@ object EngineProvider {
 
             if (BuildConfig.DEBUG) {
                 builder.arguments(arrayOf("-purgecaches"))
-                builder.debugLogging(true)
                 builder.aboutConfigEnabled(true)
-            } else {
-                builder.debugLogging(SettingsStore.getInstance(context).isDebugLoggingEnabled)
             }
 
             runtime = GeckoRuntime.create(context, builder.build())

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DeveloperOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/settings/DeveloperOptionsView.java
@@ -55,8 +55,8 @@ class DeveloperOptionsView extends SettingsView {
         mBinding.remoteDebuggingSwitch.setOnCheckedChangeListener(mRemoteDebuggingListener);
         setRemoteDebugging(SettingsStore.getInstance(getContext()).isRemoteDebuggingEnabled(), false);
 
-        mBinding.showConsoleSwitch.setOnCheckedChangeListener(mConsoleLogsListener);
-        setConsoleLogs(SettingsStore.getInstance(getContext()).isConsoleLogsEnabled(), false);
+        mBinding.debugLoggingSwitch.setOnCheckedChangeListener(mDebugLogginListener);
+        setDebugLogging(SettingsStore.getInstance(getContext()).isDebugLoggingEnabled(), false);
 
         mBinding.performanceMonitorSwitch.setOnCheckedChangeListener(mPerformanceListener);
         setPerformance(SettingsStore.getInstance(getContext()).isPerformanceMonitorEnabled(), false);
@@ -70,13 +70,10 @@ class DeveloperOptionsView extends SettingsView {
         setBypassCacheOnReload(SettingsStore.getInstance(getContext()).isBypassCacheOnReloadEnabled(), false);
 
         if (BuildConfig.DEBUG) {
-            mBinding.debugLoggingSwitch.setVisibility(View.GONE);
             mBinding.multiE10sSwitch.setOnCheckedChangeListener(mMultiE10sListener);
             setMultiE10s(SettingsStore.getInstance(getContext()).isMultiE10s(), false);
         } else {
             mBinding.multiE10sSwitch.setVisibility(View.GONE);
-            mBinding.debugLoggingSwitch.setOnCheckedChangeListener(mDebugLogginListener);
-            setDebugLogging(SettingsStore.getInstance(getContext()).isDebugLoggingEnabled(), false);
         }
 
         if (!isServoAvailable()) {
@@ -90,10 +87,6 @@ class DeveloperOptionsView extends SettingsView {
 
     private SwitchSetting.OnCheckedChangeListener mRemoteDebuggingListener = (compoundButton, value, doApply) -> {
         setRemoteDebugging(value, doApply);
-    };
-
-    private SwitchSetting.OnCheckedChangeListener mConsoleLogsListener = (compoundButton, value, doApply) -> {
-        setConsoleLogs(value, doApply);
     };
 
     private SwitchSetting.OnCheckedChangeListener mPerformanceListener = (compoundButton, value, doApply) -> {
@@ -124,10 +117,6 @@ class DeveloperOptionsView extends SettingsView {
         boolean restart = false;
         if (mBinding.remoteDebuggingSwitch.isChecked() != SettingsStore.REMOTE_DEBUGGING_DEFAULT) {
             setRemoteDebugging(SettingsStore.REMOTE_DEBUGGING_DEFAULT, true);
-        }
-
-        if (mBinding.showConsoleSwitch.isChecked() != SettingsStore.CONSOLE_LOGS_DEFAULT) {
-            setConsoleLogs(SettingsStore.CONSOLE_LOGS_DEFAULT, true);
         }
 
         if (mBinding.servoSwitch.isChecked() != SettingsStore.SERVO_DEFAULT) {
@@ -166,18 +155,6 @@ class DeveloperOptionsView extends SettingsView {
 
         if (doApply) {
             SessionStore.get().setRemoteDebugging(value);
-        }
-    }
-
-    private void setConsoleLogs(boolean value, boolean doApply) {
-        mBinding.showConsoleSwitch.setOnCheckedChangeListener(null);
-        mBinding.showConsoleSwitch.setValue(value, doApply);
-        mBinding.showConsoleSwitch.setOnCheckedChangeListener(mConsoleLogsListener);
-
-        SettingsStore.getInstance(getContext()).setConsoleLogsEnabled(value);
-
-        if (doApply) {
-            SessionStore.get().setConsoleOutputEnabled(value);
         }
     }
 

--- a/app/src/main/res/layout/options_developer.xml
+++ b/app/src/main/res/layout/options_developer.xml
@@ -44,12 +44,6 @@
                     app:description="@string/developer_options_remote_debugging" />
 
                 <org.mozilla.vrbrowser.ui.views.settings.SwitchSetting
-                    android:id="@+id/show_console_switch"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:description="@string/developer_options_show_console" />
-
-                <org.mozilla.vrbrowser.ui.views.settings.SwitchSetting
                     android:id="@+id/performance_monitor_switch"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,10 +363,6 @@
          and is used to toggle remote debugging of website content in the application. -->
     <string name="developer_options_remote_debugging">Enable Remote Debugging</string>
 
-    <!-- This string labels an On/Off switch in the 'Developer Options' dialog
-         and is used to toggle redirecting JavaScript Console output to the Android Logcat (i.e., `adb logcat`). -->
-    <string name="developer_options_show_console">Redirect Console to Logcat</string>
-
     <!-- This string labels an On/Off switch in the developer options dialog
          and is used to customize background environments of the app. -->
     <string name="developer_options_env_override">Enable Environment Override</string>


### PR DESCRIPTION
Due to the way the settings work in gecko, having two switches
doesn't make sense. Having one switch to enable/disable Gecko
logging to logcat makes it easier to manage.