### PR TITLE
V11/clear history three dot menu

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
@@ -174,6 +174,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
             mBinding.downloadsList.requestFocusFromTouch();
 
             int rowPosition = mDownloadsAdapter.getItemPosition(item.getId());
+            Log.w(DownloadsView.class.getName(), "rowPosition = " + rowPosition);
             RecyclerView.ViewHolder row = mBinding.downloadsList.findViewHolderForLayoutPosition(rowPosition);
             boolean isLastVisibleItem = false;
             if (mBinding.downloadsList.getLayoutManager() instanceof LinearLayoutManager) {
@@ -181,7 +182,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                 int lastItem = mDownloadsAdapter.getItemCount();
                 if ((rowPosition == layoutManager.findLastVisibleItemPosition() || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() ||
                         rowPosition == layoutManager.findLastVisibleItemPosition()-1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition()-1)
-                        && rowPosition != lastItem) {
+                          && ((rowPosition == (lastItem-1)) && rowPosition >1)) {
                     isLastVisibleItem = true;
                 }
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/DownloadsView.java
@@ -78,7 +78,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
 
         mDownloadsManager = ((VRBrowserActivity) getContext()).getServicesProvider().getDownloadsManager();
         mViewModel = new ViewModelProvider(
-                (VRBrowserActivity)getContext(),
+                (VRBrowserActivity) getContext(),
                 ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
                 .get(DownloadsViewModel.class);
 
@@ -95,7 +95,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.downloads, this, true);
-        mBinding.setLifecycleOwner((VRBrowserActivity)getContext());
+        mBinding.setLifecycleOwner((VRBrowserActivity) getContext());
         mBinding.setCallback(mDownloadsCallback);
         mBinding.setDownloadsViewModel(mViewModel);
         mDownloadsAdapter = new DownloadsAdapter(mDownloadItemCallback, getContext());
@@ -181,8 +181,8 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
                 LinearLayoutManager layoutManager = (LinearLayoutManager) mBinding.downloadsList.getLayoutManager();
                 int lastItem = mDownloadsAdapter.getItemCount();
                 if ((rowPosition == layoutManager.findLastVisibleItemPosition() || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() ||
-                        rowPosition == layoutManager.findLastVisibleItemPosition()-1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition()-1)
-                          && ((rowPosition == (lastItem-1)) && rowPosition >1)) {
+                        rowPosition == layoutManager.findLastVisibleItemPosition() - 1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() - 1)
+                        && ((rowPosition == (lastItem - 1)) && rowPosition > 2)) {
                     isLastVisibleItem = true;
                 }
             }
@@ -253,7 +253,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
     @Override
     protected void updateLayout() {
         post(() -> {
-            double width = Math.ceil(getWidth()/getContext().getResources().getDisplayMetrics().density);
+            double width = Math.ceil(getWidth() / getContext().getResources().getDisplayMetrics().density);
             boolean isNarrow = width < SettingsStore.WINDOW_WIDTH_DEFAULT;
 
             if (isNarrow != mViewModel.getIsNarrow().getValue().get()) {
@@ -330,8 +330,8 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
         PointF position = new PointF(
                 (offsetViewBounds.left + view.getWidth()) * ratio,
                 -(offsetViewBounds.top + view.getHeight()) * ratio);
-        menu.getPlacement().translationX = position.x - (menu.getWidth()/menu.getPlacement().density);
-        menu.getPlacement().translationY = position.y + getResources().getDimension(R.dimen.library_menu_top_margin)/menu.getPlacement().density;
+        menu.getPlacement().translationX = position.x - (menu.getWidth() / menu.getPlacement().density);
+        menu.getPlacement().translationY = position.y + getResources().getDimension(R.dimen.library_menu_top_margin) / menu.getPlacement().density;
         menu.show(UIWidget.REQUEST_FOCUS);
     }
 
@@ -356,12 +356,12 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
 
     // DownloadsManager.DownloadsListener
 
-    private Comparator<Download> mDownloadIdComparator = (o1, o2) -> (int)(o1.getId() - o2.getId());
+    private Comparator<Download> mDownloadIdComparator = (o1, o2) -> (int) (o1.getId() - o2.getId());
 
     private Comparator<Download> mAZFileNameComparator = (o1, o2) -> {
         int nameDiff = o1.getFilename().compareTo(o2.getFilename());
         if (nameDiff == 0) {
-            return  mDownloadIdComparator.compare(o1, o2);
+            return mDownloadIdComparator.compare(o1, o2);
 
         } else {
             return nameDiff;
@@ -370,7 +370,7 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
     private Comparator<Download> mZAFilenameComparator = (o1, o2) -> {
         int nameDiff = o2.getFilename().compareTo(o1.getFilename());
         if (nameDiff == 0) {
-            return  mDownloadIdComparator.compare(o1, o2);
+            return mDownloadIdComparator.compare(o1, o2);
 
         } else {
             return nameDiff;
@@ -379,16 +379,16 @@ public class DownloadsView extends LibraryView implements DownloadsManager.Downl
     private Comparator<Download> mDownloadDateAscComparator = (o1, o2) -> mDownloadIdComparator.compare(o1, o2);
     private Comparator<Download> mDownloadDateDescComparator = (o1, o2) -> mDownloadIdComparator.compare(o2, o1);
     private Comparator<Download> mDownloadSizeAscComparator = (o1, o2) -> {
-        int sizeDiff = (int)(o1.getSizeBytes() - o2.getSizeBytes());
+        int sizeDiff = (int) (o1.getSizeBytes() - o2.getSizeBytes());
         if (sizeDiff == 0) {
-            return  mDownloadIdComparator.compare(o1, o2);
+            return mDownloadIdComparator.compare(o1, o2);
 
         } else {
             return sizeDiff;
         }
     };
     private Comparator<Download> mDownloadSizeDescComparator = (o1, o2) -> {
-        int sizeDiff = (int)(o2.getSizeBytes() - o1.getSizeBytes());
+        int sizeDiff = (int) (o2.getSizeBytes() - o1.getSizeBytes());
         if (sizeDiff == 0) {
             return mDownloadIdComparator.compare(o1, o2);
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/HistoryView.java
@@ -96,14 +96,14 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
     protected void initialize() {
         super.initialize();
 
-        mAccounts = ((VRBrowserApplication)getContext().getApplicationContext()).getAccounts();
+        mAccounts = ((VRBrowserApplication) getContext().getApplicationContext()).getAccounts();
         if (ACCOUNTS_UI_ENABLED) {
             mAccounts.addAccountListener(mAccountListener);
             mAccounts.addSyncListener(mSyncListener);
         }
 
         mViewModel = new ViewModelProvider(
-                (VRBrowserActivity)getContext(),
+                (VRBrowserActivity) getContext(),
                 ViewModelProvider.AndroidViewModelFactory.getInstance(((VRBrowserActivity) getContext()).getApplication()))
                 .get(HistoryViewModel.class);
 
@@ -120,7 +120,7 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
 
         // Inflate this data binding layout
         mBinding = DataBindingUtil.inflate(inflater, R.layout.history, this, true);
-        mBinding.setLifecycleOwner((VRBrowserActivity)getContext());
+        mBinding.setLifecycleOwner((VRBrowserActivity) getContext());
         mBinding.setHistoryViewModel(mViewModel);
         mBinding.setCallback(mHistoryCallback);
         mHistoryAdapter = new HistoryAdapter(mHistoryItemCallback, getContext());
@@ -203,8 +203,8 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
                 LinearLayoutManager layoutManager = (LinearLayoutManager) mBinding.historyList.getLayoutManager();
                 int lastItem = mHistoryAdapter.getItemCount();
                 if ((rowPosition == layoutManager.findLastVisibleItemPosition() || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() ||
-                        rowPosition == layoutManager.findLastVisibleItemPosition()-1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition()-1)
-                        && (rowPosition != lastItem && rowPosition != 1)) {
+                        rowPosition == layoutManager.findLastVisibleItemPosition() - 1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() - 1)
+                        && (rowPosition != lastItem && rowPosition > 2)) {
                     isLastVisibleItem = true;
                 }
             }
@@ -372,7 +372,7 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
         SessionStore.get().getHistoryStore().getDetailedHistory().thenAcceptAsync((items) -> {
             List<VisitInfo> orderedItems = items.stream()
                     .sorted(Comparator.comparing(VisitInfo::getVisitTime)
-                    .reversed())
+                            .reversed())
                     .filter(distinctByUrl(VisitInfo::getUrl))
                     .collect(Collectors.toList());
 
@@ -391,7 +391,7 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
     }
 
     private void addSection(final @NonNull List<VisitInfo> items, @NonNull String section, long rangeStart, long rangeEnd) {
-        for (int i=0; i< items.size(); i++) {
+        for (int i = 0; i < items.size(); i++) {
             if (items.get(i).getVisitTime() == rangeStart && items.get(i).getVisitType() == VisitType.NOT_A_VISIT)
                 break;
 
@@ -424,7 +424,7 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
     @Override
     protected void updateLayout() {
         post(() -> {
-            double width = Math.ceil(getWidth()/getContext().getResources().getDisplayMetrics().density);
+            double width = Math.ceil(getWidth() / getContext().getResources().getDisplayMetrics().density);
             boolean isNarrow = width < SettingsStore.WINDOW_WIDTH_DEFAULT;
 
             if (isNarrow != mViewModel.getIsNarrow().getValue().get()) {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/HistoryView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/HistoryView.java
@@ -204,7 +204,7 @@ public class HistoryView extends LibraryView implements HistoryStore.HistoryList
                 int lastItem = mHistoryAdapter.getItemCount();
                 if ((rowPosition == layoutManager.findLastVisibleItemPosition() || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition() ||
                         rowPosition == layoutManager.findLastVisibleItemPosition()-1 || rowPosition == layoutManager.findLastCompletelyVisibleItemPosition()-1)
-                        && rowPosition != lastItem) {
+                        && (rowPosition != lastItem && rowPosition != 1)) {
                     isLastVisibleItem = true;
                 }
             }


### PR DESCRIPTION
Fixes #2960 Updated code for the history menu to let index number to determine where the menu should show.  Also updated downloads menu to behave like history menu