### PR TITLE
Avoid showing Zh-TW and Zh-CN keyboard candidate view when typing symbols.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
@@ -83,7 +83,8 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
 
         // If using non-Zhuyin symbols like numeric, abc, special symbols,
         // we just need to compose them.
-        if (aComposingText.matches(nonZhuyinReg)) {
+        String lastChar = "" + aComposingText.charAt(aComposingText.length() - 1);
+        if (lastChar.matches(nonZhuyinReg)) {
             CandidatesResult result = new CandidatesResult();
             result.words = getDisplays(aComposingText);
             result.action = CandidatesResult.Action.AUTO_COMPOSE;
@@ -224,12 +225,6 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
         return mContext.getString(R.string.zhuyin_keyboard_mode_change);
     }
 
-//    private String getNonZhuyinReg() {
-//        // For characters that not belong to Zhuyin input.
-//        final String reg = "[^ㄅ-ㄩ˙ˊˇˋˉ]";
-//        return reg;
-//    }
-
     private List<Words> getDisplays(String aKey) {
         // Allow completion of uppercase/lowercase letters numbers, and symbols
         // aKey.length() > 1 only happens when switching from other keyboard.
@@ -242,7 +237,22 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
         code = GetTransCode(code);
         loadKeymapIfNotLoaded(code);
         KeyMap map = mKeymaps.get(code);
-        return map != null ? map.displays : null;
+
+        if (map == null) {
+            return Collections.singletonList(new Words(1, aKey, aKey));
+        }
+        // When detecting special symbols at the last character, and
+        // because special symbols are not defined in our code book. We
+        // need to add it back to our generated word for doing following
+        // AUTO_COMPOSE.
+        final String lastChar = "" + aKey.charAt(aKey.length()-1);
+        if (map != null && lastChar.matches(nonZhuyinReg))
+        {
+           Words word = map.displays.get(0);
+           return Collections.singletonList(new Words(1,
+                   word.code + lastChar, word.value + lastChar));
+        }
+        return map.displays;
     }
 
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -1064,6 +1064,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             setAutoCompletionVisible(candidates != null && candidates.words.size() > 0);
             mAutoCompletionView.setItems(candidates != null ? candidates.words : null);
             if (candidates != null && candidates.action == KeyboardInterface.CandidatesResult.Action.AUTO_COMPOSE) {
+                setAutoCompletionVisible(false);
                 onAutoCompletionItemClick(candidates.words.get(0));
             } else if (candidates != null) {
                 postInputCommand(() -> displayComposingText(candidates.composing, ComposingAction.DO_NOT_FINISH));
@@ -1141,6 +1142,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         mComposingDisplayText = aText;
         if (aAction == ComposingAction.FINISH) {
             mInputConnection.finishComposingText();
+            mComposingText = "";
         }
     }
 


### PR DESCRIPTION
Fixes #3506.

When typing symbols, we can just use `AUTO_COMPOSE` mode.

I was trying to make Zh-CN and JPN keyboard have the same behavior when typing symbols, using `AUTO_COMPOSE` instead of `SHOW_CANDIDATES`. But, JPN keyboard will show `．` when inserting `/`。The only way possible is fixing their code book to avoid it, but it is not worth to do. IMO, We can still rely on their code book to feed our data, iOS JPN keyboard uses the same behavior either.
