### PR TITLE
Implement before unload prompt

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -1470,6 +1470,16 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         return GeckoResult.fromValue(filePrompt.dismiss());
     }
 
+    @Nullable
+    @Override
+    public GeckoResult<PromptResponse> onBeforeUnloadPrompt(@NonNull GeckoSession aSession, @NonNull BeforeUnloadPrompt prompt) {
+        if (mPromptDelegate != null) {
+            return mPromptDelegate.onBeforeUnloadPrompt(aSession, prompt);
+        }
+        return GeckoResult.fromValue(prompt.dismiss());
+    }
+
+
     // MediaDelegate
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1411,6 +1411,16 @@
          '%1$s' will be replace at runtime with the app's name. -->
     <string name="not_entitled_message">%1$s does not have permission to run on this device and will now exit.</string>
 
+
+    <!-- This string is displayed in the title of an Before Unload prompt, which asks for confirmation to stay or leave the current page. -->
+    <string name="before_unload_prompt_title">Leave page?</string>
+    <!-- This string is displayed in the message of an Before Unload prompt, which asks for confirmation to stay or leave the current page. -->
+    <string name="before_unload_prompt_message">This page is asking to confirm that you want to leave. Data you have entered may not be saved.</string>
+    <!-- This string is displayed in a button of the Before Unload prompt. Clicking it cancels the navigation and stays on the same page. -->
+    <string name="before_unload_prompt_stay">Stay on Page</string>
+    <!-- This string is displayed in a button of the Before Unload prompt. Clicking it confirms the navigation and leaves the page. -->
+    <string name="before_unload_prompt_leave">Leave Page</string>
+
     <!-- This string is displayed in a button that when pressed allows a user to view a page that has been blocked from being displayed.-->
     <string name="performance_unblock_page">Unblock Page</string>
     <!-- This string is displayed as the title of a dialog displayed when poor web page performance has been detected. -->


### PR DESCRIPTION
Fixes broken navigation after entering/exiting BabylonJS WebXR in their playground app #3472