### PR TITLE
Checking Zh-CN code length before looking for a blacklash symbol.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChinesePinyinKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChinesePinyinKeyboard.java
@@ -147,8 +147,9 @@ public class ChinesePinyinKeyboard extends BaseKeyboard {
 
             // When using backslashes ({@code \}) in the replacement string
             // will cause crash at `replaceFirst()`, so we need to replace it first.
-            if (result.words.get(0).code.charAt(result.words.get(0).code.length() - 1)
-                    == kBackslashCode) {
+            if (result.words.get(0).code.length() > 0 &&
+                result.words.get(0).code.charAt(result.words.get(0).code.length() - 1)
+                        == kBackslashCode) {
                 newCode = result.words.get(0).code.replace("\\", "\\\\");
                 aComposingText = aComposingText.replace("\\", "\\\\");
             }


### PR DESCRIPTION
Fixes #3526.

I didn't realize some character's code is "" from our Zh-CN code book.
