### PR TITLE
Add layer priority sorting. Make pointer not affect widget sorting.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -391,6 +391,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
         aPlacement.worldWidth = WidgetPlacement.floatDimension(context, R.dimen.keyboard_world_width);
         aPlacement.visible = false;
         aPlacement.cylinder = true;
+        aPlacement.layerPriority = 1;
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetPlacement.java
@@ -54,6 +54,7 @@ public class WidgetPlacement {
     public boolean showPointer = true;
     public boolean composited = false;
     public boolean layer = true;
+    public int layerPriority = 0; // Used for depth sorting
     public boolean proxifyLayer = false;
     public float textureScale = 0.7f;
     // Widget will be curved if enabled.
@@ -99,6 +100,7 @@ public class WidgetPlacement {
         this.showPointer = w.showPointer;
         this.composited = w.composited;
         this.layer = w.layer;
+        this.layerPriority = w.layerPriority;
         this.proxifyLayer = w.proxifyLayer;
         this.textureScale = w.textureScale;
         this.cylinder = w.cylinder;

--- a/app/src/main/cpp/BrowserWorld.cpp
+++ b/app/src/main/cpp/BrowserWorld.cpp
@@ -686,12 +686,17 @@ BrowserWorld::State::SortWidgets() {
       }
     }
     if (!target) {
+      bool isPointer = false;
       for (Controller& controller: controllers->GetControllers()) {
         if (controller.pointer && controller.pointer->GetRoot() == node) {
-          target = controller.pointer->GetHitWidget().get();
-          zDelta = 0.02f;
+          isPointer = true;
           break;
         }
+      }
+      if (isPointer) {
+        // Always render the pointer on top
+        depthSorting.emplace(node.get(), std::make_pair(target, 0.0f));
+        continue;
       }
     }
 
@@ -717,12 +722,14 @@ BrowserWorld::State::SortWidgets() {
     Widget* wa = da->second.first;
     Widget* wb = db->second.first;
 
-    // Parenting sort
+    // Parenting or layer priority sort
     if (wa && wb && wa->IsVisible() && wb->IsVisible()) {
       if (IsParent(*wa, *wb)) {
         return true;
       } else if (IsParent(*wb, *wa)) {
         return false;
+      } else if (wa->GetPlacement()->layerPriority != wb->GetPlacement()->layerPriority) {
+        return wa->GetPlacement()->layerPriority > wb->GetPlacement()->layerPriority;
       }
     }
 

--- a/app/src/main/cpp/WidgetPlacement.cpp
+++ b/app/src/main/cpp/WidgetPlacement.cpp
@@ -66,6 +66,7 @@ WidgetPlacement::FromJava(JNIEnv* aEnv, jobject& aObject) {
   GET_BOOLEAN_FIELD(showPointer);
   GET_BOOLEAN_FIELD(composited);
   GET_BOOLEAN_FIELD(layer);
+  GET_INT_FIELD(layerPriority);
   GET_BOOLEAN_FIELD(proxifyLayer);
   GET_FLOAT_FIELD(textureScale, "textureScale");
   GET_BOOLEAN_FIELD(cylinder);

--- a/app/src/main/cpp/WidgetPlacement.h
+++ b/app/src/main/cpp/WidgetPlacement.h
@@ -38,6 +38,7 @@ struct WidgetPlacement {
   bool showPointer;
   bool composited;
   bool layer;
+  int32_t layerPriority;
   bool proxifyLayer;
   float textureScale;
   bool cylinder;


### PR DESCRIPTION
Fixes #2442
- Fixed a bug, the input controller position shouldn't affect depth sorting
- The original 2442 issue doesn't seem easy to fix without affecting other use cases. It's not possible to support a real depth buffer so I added a priority field. Unity/Unreal also use the optional priority field (https://developer.oculus.com/documentation/unity/unity-ovroverlay/)