### PR TITLE
Support Thai keyboard.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/BaseKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/BaseKeyboard.java
@@ -49,8 +49,22 @@ public abstract class BaseKeyboard implements KeyboardInterface {
         return mContext.getString(R.string.keyboard_mode_change);
     }
 
+    @Override
+    public float getKeyboardTranslateYInWorld() {
+        return WidgetPlacement.unitFromMeters(mContext, R.dimen.keyboard_y);
+    }
+
+    @Override
+    public float getKeyboardWorldWidth() {
+        return WidgetPlacement.floatDimension(mContext, R.dimen.keyboard_world_width);
+    }
+
     public float getAlphabeticKeyboardWidth() {
         return WidgetPlacement.dpDimension(mContext, R.dimen.keyboard_alphabetic_width);
+    }
+
+    public float  getAlphabeticKeyboardHeight() {
+        return WidgetPlacement.dpDimension(mContext, R.dimen.keyboard_height);
     }
 
     @Override

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChinesePinyinKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChinesePinyinKeyboard.java
@@ -485,4 +485,9 @@ public class ChinesePinyinKeyboard extends BaseKeyboard {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
         }
     }
+
+    @Override
+    public String[] getDomains(String... domains) {
+        return super.getDomains(".cn");
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ChineseZhuyinKeyboard.java
@@ -480,4 +480,9 @@ public class ChineseZhuyinKeyboard extends BaseKeyboard {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
         }
     }
+
+    @Override
+    public String[] getDomains(String... domains) {
+        return super.getDomains(".tw");
+    }
 }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/KeyboardInterface.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/KeyboardInterface.java
@@ -30,6 +30,10 @@ public interface KeyboardInterface {
     }
     @NonNull CustomKeyboard getAlphabeticKeyboard();
     float getAlphabeticKeyboardWidth();
+    float getAlphabeticKeyboardHeight();
+    float getKeyboardTranslateYInWorld();
+    float getKeyboardWorldWidth();
+    default @Nullable CustomKeyboard getAlphabeticCapKeyboard() { return null; }
     default @Nullable CustomKeyboard getSymbolsKeyboard() { return null; }
     default @Nullable CandidatesResult getCandidates(String aComposingText) { return null; }
     default @Nullable String overrideAddText(String aTextBeforeCursor, String aNextText) { return null; }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ThaiKeyboard.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/keyboards/ThaiKeyboard.java
@@ -1,0 +1,110 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.vrbrowser.ui.keyboards;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.mozilla.vrbrowser.R;
+import org.mozilla.vrbrowser.input.CustomKeyboard;
+import org.mozilla.vrbrowser.ui.widgets.WidgetPlacement;
+import org.mozilla.vrbrowser.utils.StringUtils;
+
+import java.util.Locale;
+
+public class ThaiKeyboard extends BaseKeyboard {
+    private Locale mLocale;
+    private CustomKeyboard mKeyboard;
+    private CustomKeyboard mCapKeyboard;
+    private CustomKeyboard mSymbolsKeyboard;
+
+    public ThaiKeyboard(Context aContext) {
+        super(aContext);
+        mLocale = new Locale("th", "TH");
+    }
+
+    @NonNull
+    @Override
+    public CustomKeyboard getAlphabeticKeyboard() {
+        if (mKeyboard == null) {
+            mKeyboard = new CustomKeyboard(mContext.getApplicationContext(), R.xml.keyboard_qwerty_thai);
+            mKeyboard.setShifted(false);
+        }
+        return mKeyboard;
+    }
+
+    @NonNull
+    @Override
+    public CustomKeyboard getAlphabeticCapKeyboard() {
+        if (mCapKeyboard == null) {
+            mCapKeyboard = new CustomKeyboard(mContext.getApplicationContext(), R.xml.keyboard_qwerty_thai_cap);
+            mCapKeyboard.setShifted(true);
+        }
+        return mCapKeyboard;
+    }
+
+    @Nullable
+    @Override
+    public CustomKeyboard getSymbolsKeyboard() {
+        if (mSymbolsKeyboard == null) {
+            mSymbolsKeyboard = new CustomKeyboard(mContext.getApplicationContext(), R.xml.keyboard_symbols_thai);
+        }
+        return mSymbolsKeyboard;
+    }
+
+    @Override
+    public float getKeyboardTranslateYInWorld() {
+        return WidgetPlacement.unitFromMeters(mContext, R.dimen.keyboard_y_extra_row);
+    }
+
+    @Override
+    public float getKeyboardWorldWidth() {
+        return WidgetPlacement.floatDimension(mContext, R.dimen.keyboard_world_extra_row_width);
+    }
+
+    @Override
+    public float getAlphabeticKeyboardWidth() {
+        return WidgetPlacement.dpDimension(mContext, R.dimen.keyboard_alphabetic_width_extra_column);
+    }
+
+    @Override
+    public float getAlphabeticKeyboardHeight() {
+        return WidgetPlacement.dpDimension(mContext, R.dimen.keyboard_alphabetic_height_thai);
+    }
+
+    @Nullable
+    @Override
+    public CandidatesResult getCandidates(String aText) {
+        return null;
+    }
+
+    @Override
+    public String getKeyboardTitle() {
+        return StringUtils.getStringByLocale(mContext, R.string.settings_language_thai, getLocale());
+    }
+
+    @Override
+    public Locale getLocale() {
+        return mLocale;
+    }
+
+    @Override
+    public String getSpaceKeyText(String aComposingText) {
+        return StringUtils.getStringByLocale(mContext, R.string.settings_language_thai, getLocale());
+    }
+
+    @Override
+    public String getModeChangeKeyText() {
+        return mContext.getString(R.string.thai_keyboard_mode_change);
+    }
+
+    @Override
+    public String[] getDomains(String... domains) {
+        return super.getDomains(".th");
+    }
+}

--- a/app/src/main/res/layout/keyboard.xml
+++ b/app/src/main/res/layout/keyboard.xml
@@ -125,7 +125,7 @@
                     android:padding="15dp"
                     android:layout_gravity="center"
                     android:background="@drawable/dialog_background"
-                    android:alpha="0.5"
+                    android:alpha="0.0"
                     android:visibility="gone"/>
             </FrameLayout>
 

--- a/app/src/main/res/layout/navigation_url.xml
+++ b/app/src/main/res/layout/navigation_url.xml
@@ -186,6 +186,8 @@
                 android:id="@+id/urlEditText"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_marginTop="5dp"
+                android:layout_marginBottom="5dp"
                 android:paddingEnd="10dp"
                 android:layout_toStartOf="@id/endButtonsLayout"
                 android:layout_toEndOf="@id/icons"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -23,21 +23,21 @@
 
     <!-- Keyboard -->
     <item name="keyboard_world_width" format="float" type="dimen">3.25</item>
+    <item name="keyboard_world_extra_row_width" format="float" type="dimen">3.43</item>
     <item name="keyboard_x" format="float" type="dimen">-0.15</item>
     <item name="keyboard_y" format="float" type="dimen">-0.45</item>
-    <item name="zhuyin_keyboard_y" format="float" type="dimen">-0.63</item>
+    <item name="keyboard_y_extra_row" format="float" type="dimen">-0.72</item>
     <item name="keyboard_z" format="float" type="dimen">-2.5</item>
     <item name="keyboard_world_rotation" format="float" type="dimen">-35.0</item>
-    <dimen name="keyboard_height">188dp</dimen>
+    <dimen name="keyboard_height">186dp</dimen>
     <dimen name="keyboard_alphabetic_width">526dp</dimen>
     <dimen name="keyboard_alphabetic_width_danish">540dp</dimen>
     <dimen name="keyboard_alphabetic_width_norwegian">540dp</dimen>
     <dimen name="keyboard_alphabetic_width_swedish">540dp</dimen>
     <dimen name="keyboard_alphabetic_width_finnish">540dp</dimen>
-    <dimen name="keyboard_alphabetic_width_zhuyin">470dp</dimen>
     <dimen name="keyboard_alphabetic_width_extra_column">564dp</dimen>
+    <dimen name="keyboard_alphabetic_height_thai">226dp</dimen>
     <dimen name="keyboard_numeric_width">144dp</dimen>
-    <dimen name="keyboard_zhuyin_height">228dp</dimen>
     <dimen name="keyboard_horizontal_gap">4dp</dimen>
     <dimen name="keyboard_vertical_gap">4dp</dimen>
     <dimen name="keyboard_key_width">36dp</dimen>
@@ -49,6 +49,8 @@
     <dimen name="keyboard_key_zhuyin_space_width">50dp</dimen>
     <dimen name="keyboard_key_zhuyin_space_height">70dp</dimen>
     <dimen name="keyboard_key_zhuyin_enter_width">74dp</dimen>
+    <dimen name="keyboard_key_thai_enter_width">50dp</dimen>
+    <dimen name="keyboard_key_thai_enter_height">72dp</dimen>
     <dimen name="keyboard_key_backspace_width">50dp</dimen>
     <dimen name="keyboard_key_enter_width">72dp</dimen>
     <dimen name="keyboard_key_enter_width_small">62dp</dimen>

--- a/app/src/main/res/values/non_L10n.xml
+++ b/app/src/main/res/values/non_L10n.xml
@@ -101,6 +101,8 @@
     <string name="japanese_enter_completion" translatable="false">確定</string>
     <string name="japanese_keyboard_mode_change" translatable="false">かな</string>
 
+    <string name="thai_keyboard_mode_change" translatable="false">กขค</string>
+
     <!-- Keyboard -->
     <string name="keyboard_popup_a" translatable="false">aáàäãåâąæā</string>
     <string name="keyboard_popup_b" translatable="false">bƀḃḅḇ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,10 @@
      changes the app and the language of the speech-recognition-based search to 'Dutch'. -->
     <string name="settings_language_dutch">Dutch</string>
 
+    <!-- This string is used to label a radio button in the settings language dialog that, when pressed,
+         changes the app and the language of the speech-recognition-based search to 'Thai'. -->
+    <string name="settings_language_thai">Thai</string>
+
     <!-- This string is used to label a button in the 'Settings' dialog window that, when pressed,
         opens a dialog box that contains display-related settings: window size, pixel density, etc. -->
     <string name="settings_display">Display</string>

--- a/app/src/main/res/xml/keyboard_qwerty_thai.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_thai.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:horizontalGap="@dimen/keyboard_horizontal_gap"
+    android:verticalGap="@dimen/keyboard_vertical_gap"
+    android:keyWidth="@dimen/keyboard_key_width"
+    android:keyHeight="@dimen/keyboard_key_height">
+    <Row>
+        <Key android:keyLabel="ๅ" android:keyEdgeFlags="left"/>
+        <Key android:keyLabel="/" android:popupCharacters="/\\" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:keyLabel="-"/>
+        <Key android:keyLabel="ภ"/>
+        <Key android:keyLabel="ถ"/>
+        <Key android:keyLabel="ุ"/>
+        <Key android:keyLabel="ึ"/>
+        <Key android:keyLabel="ค" android:popupCharacters="คฅ" android:popupKeyboard="@xml/keyboard_popup"/>
+        <Key android:keyLabel="ต"/>
+        <Key android:keyLabel="จ"/>
+        <Key android:keyLabel="ข"/>
+        <Key android:keyLabel="ช"/>
+        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+    </Row>
+
+    <Row>
+        <Key android:keyLabel="ๆ" android:keyEdgeFlags="left"/>
+        <Key android:keyLabel="ไ"/>
+        <Key android:keyLabel="ำ"/>
+        <Key android:keyLabel="พ"/>
+        <Key android:keyLabel="ะ"/>
+        <Key android:keyLabel="ั"/>
+        <Key android:keyLabel="ี"/>
+        <Key android:keyLabel="ร"/>
+        <Key android:keyLabel="น"/>
+        <Key android:keyLabel="ย"/>
+        <Key android:keyLabel="บ"/>
+        <Key android:keyLabel="ล"/>
+        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_thai_enter_width" android:keyHeight="@dimen/keyboard_key_thai_enter_height"/>
+    </Row>
+
+    <Row>
+        <Key android:keyLabel="ฟ"/>
+        <Key android:keyLabel="ห"/>
+        <Key android:keyLabel="ก"/>
+        <Key android:keyLabel="ด"/>
+        <Key android:keyLabel="เ"/>
+        <Key android:keyLabel="้"/>
+        <Key android:keyLabel="่" android:popupCharacters="ฺู๋๊็ํ่์" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:keyLabel="า"/>
+        <Key android:keyLabel="ส"/>
+        <Key android:keyLabel="ว"/>
+        <Key android:keyLabel="ง"/>
+        <Key android:keyLabel="ฃ"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
+        <Key android:keyLabel="ผ"/>
+        <Key android:keyLabel="ป"/>
+        <Key android:keyLabel="แ"/>
+        <Key android:keyLabel="อ"/>
+        <Key android:keyLabel="ิ"/>
+        <Key android:keyLabel="ื"/>
+        <Key android:keyLabel="ท"/>
+        <Key android:keyLabel="ม"/>
+        <Key android:keyLabel="ใ"/>
+        <Key android:keyLabel="ฝ"/>
+        <Key android:keyLabel="\\"/>
+        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+    </Row>
+
+    <Row>
+        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
+        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
+        <Key android:codes="58" android:keyLabel=":"/>
+        <Key android:codes="44" android:keyLabel=","/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="-14" android:keyLabel="\.com" />
+        <Key android:codes="64" android:keyLabel="\@"/>
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/keyboard_qwerty_thai_cap.xml
+++ b/app/src/main/res/xml/keyboard_qwerty_thai_cap.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:horizontalGap="@dimen/keyboard_horizontal_gap"
+    android:verticalGap="@dimen/keyboard_vertical_gap"
+    android:keyWidth="@dimen/keyboard_key_width"
+    android:keyHeight="@dimen/keyboard_key_height">
+    <Row>
+        <Key android:keyLabel="+" android:keyEdgeFlags="left"/>
+        <Key android:keyLabel="๑"/>
+        <Key android:keyLabel="๒"/>
+        <Key android:keyLabel="๓"/>
+        <Key android:keyLabel="๔"/>
+        <Key android:keyLabel="ู"/>
+        <Key android:keyLabel="฿"/>
+        <Key android:keyLabel="๕"/>
+        <Key android:keyLabel="๖"/>
+        <Key android:keyLabel="๗"/>
+        <Key android:keyLabel="๘"/>
+        <Key android:keyLabel="๙"/>
+        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width" />
+    </Row>
+
+    <Row>
+        <Key android:keyLabel="๐" android:keyEdgeFlags="left"/>
+        <Key android:keyLabel="&quot;" android:popupCharacters="“&quot;”„»«" android:popupKeyboard="@xml/keyboard_popup"/>/>
+        <Key android:keyLabel="ฎ"/>
+        <Key android:keyLabel="ฑ"/>
+        <Key android:keyLabel="ธ"/>
+        <Key android:keyLabel="ํ"/>
+        <Key android:keyLabel="๊"/>
+        <Key android:keyLabel="ณ"/>
+        <Key android:keyLabel="ฯ"/>
+        <Key android:keyLabel="ญ"/>
+        <Key android:keyLabel="ฐ"/>
+        <Key android:keyLabel=","/>
+        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_thai_enter_width" android:keyHeight="@dimen/keyboard_key_thai_enter_height"/>
+    </Row>
+
+    <Row>
+        <Key android:keyLabel="ฤ"/>
+        <Key android:keyLabel="ฆ"/>
+        <Key android:keyLabel="ฏ"/>
+        <Key android:keyLabel="โ"/>
+        <Key android:keyLabel="ฌ"/>
+        <Key android:keyLabel="็"/>
+        <Key android:keyLabel="๋"/>
+        <Key android:keyLabel="ษ"/>
+        <Key android:keyLabel="ศ"/>
+        <Key android:keyLabel="ซ"/>
+        <Key android:keyLabel="." android:popupCharacters=".…" android:popupKeyboard="@xml/keyboard_popup"/>/>
+        <Key android:keyLabel="ฅ"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" android:keyEdgeFlags="left"/>
+        <Key android:keyLabel="("/>
+        <Key android:keyLabel=")"/>
+        <Key android:keyLabel="ฉ"/>
+        <Key android:keyLabel="ฮ"/>
+        <Key android:keyLabel="ฺ"/>
+        <Key android:keyLabel="์"/>
+        <Key android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup"/>/>
+        <Key android:keyLabel="ฒ"/>
+        <Key android:keyLabel="ฬ"/>
+        <Key android:keyLabel="ฦ"/>
+        <Key android:keyLabel="/"/>
+        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_off" />
+    </Row>
+
+    <Row>
+        <Key android:codes="-2" android:keyLabel="@string/keyboard_symbol" android:keyEdgeFlags="left"/>
+        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
+        <Key android:codes="58" android:keyLabel=":"/>
+        <Key android:codes="44" android:keyLabel=","/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="-14" android:keyLabel="\.com" />
+        <Key android:codes="64" android:keyLabel="\@"/>
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/keyboard_symbols_swedish.xml
+++ b/app/src/main/res/xml/keyboard_symbols_swedish.xml
@@ -30,7 +30,7 @@
         <Key android:codes="124" android:keyLabel="|"/>
         <Key android:codes="59" android:keyLabel=";"/>
         <Key android:codes="58" android:keyLabel=":"/>
-        <Key android:codes="34" android:keyLabel="•"/>
+        <Key android:codes="0x2022" android:keyLabel="•"/>
         <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width_small"  />
     </Row>
 

--- a/app/src/main/res/xml/keyboard_symbols_thai.xml
+++ b/app/src/main/res/xml/keyboard_symbols_thai.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    android:horizontalGap="@dimen/keyboard_horizontal_gap"
+    android:verticalGap="@dimen/keyboard_vertical_gap"
+    android:keyWidth="@dimen/keyboard_key_width"
+    android:keyHeight="@dimen/keyboard_key_height">
+    <Row>
+        <Key android:codes="8364" android:keyLabel="€" android:keyEdgeFlags="left"/>
+        <Key android:codes="163" android:keyLabel="£"/>
+        <Key android:codes="165" android:keyLabel="¥"/>
+        <Key android:codes="36" android:keyLabel="$"/>
+        <Key android:codes="199" android:keyLabel="ç"/>
+        <Key android:codes="37" android:keyLabel="%"/>
+        <Key android:codes="38" android:keyLabel="&amp;"/>
+        <Key android:codes="40" android:keyLabel="("/>
+        <Key android:codes="41" android:keyLabel=")"/>
+        <Key android:codes="61" android:keyLabel="="/>
+        <Key android:codes="0x2260" android:keyLabel="≠"/>
+        <Key android:codes="0xB1" android:keyLabel="±"/>
+        <Key android:codes="-5" android:keyIcon="@drawable/ic_icon_keyboard_backspace" android:isRepeatable="true" android:keyWidth="@dimen/keyboard_key_backspace_width"/>
+    </Row>
+
+    <Row>
+        <Key android:codes="186" android:keyLabel="º" android:keyEdgeFlags="left" android:horizontalGap="@dimen/keyboard_left_margin"/>
+        <Key android:codes="94" android:keyLabel="^" />
+        <Key android:codes="167" android:keyLabel="§" />
+        <Key android:codes="123" android:keyLabel="{"/>
+        <Key android:codes="125" android:keyLabel="}"/>
+        <Key android:codes="91" android:keyLabel="["/>
+        <Key android:codes="93" android:keyLabel="]"/>
+        <Key android:codes="124" android:keyLabel="|"/>
+        <Key android:codes="39" android:keyLabel="'"/>
+        <Key android:codes="0x2022" android:keyLabel="•"/>
+        <Key android:codes="58" android:keyLabel="/"/>
+        <Key android:codes="-4" android:keyLabel="@string/keyboard_enter_label" android:keyWidth="@dimen/keyboard_key_enter_width"  />
+    </Row>
+
+    <Row>
+        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" android:keyEdgeFlags="left"/>
+        <Key android:codes="60" android:keyLabel="&lt;"/>
+        <Key android:codes="62" android:keyLabel="&gt;"/>
+        <Key android:codes="96" android:keyLabel="`"/>
+        <Key android:codes="126" android:keyLabel="~"/>
+        <Key android:codes="0x2018" android:keyLabel="‘"/>
+        <Key android:codes="0x201C" android:keyLabel="“"/>
+        <Key android:codes="34" android:keyLabel="&quot;"/>
+        <Key android:codes="95" android:keyLabel="_" />
+        <Key android:codes="45" android:keyLabel="-" />
+        <Key android:codes="43" android:keyLabel="+" />
+        <Key android:codes="92" android:keyLabel="\\" />
+        <Key android:codes="-1" android:keyIcon="@drawable/ic_icon_keyboard_shift_on" />
+    </Row>
+
+    <Row>
+        <Key android:codes="-2" android:keyLabel="@string/keyboard_mode_change" android:keyEdgeFlags="left" />
+        <Key android:codes="-12" android:keyIcon="@drawable/ic_icon_keyboard_globe" />
+        <Key android:codes="32" android:keyLabel="" android:keyWidth="@dimen/keyboard_key_space_width" android:isRepeatable="true"/>
+        <Key android:codes="58" android:keyLabel=":"/>
+        <Key android:codes="44" android:keyLabel=","/>
+        <Key android:codes="46" android:keyLabel="."/>
+        <Key android:codes="33" android:keyLabel="!" android:popupCharacters="!¡" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="63" android:keyLabel="\?" android:popupCharacters="\?¿" android:popupKeyboard="@xml/keyboard_popup" />
+        <Key android:codes="-14" android:keyLabel="\.com" />
+        <Key android:codes="64" android:keyLabel="\@"/>
+    </Row>
+</Keyboard>


### PR DESCRIPTION
Fixes #3487.

I notice Android and iOS have different implementation when dealing vowels. Android can't display that little circle under a vowel like  'ึ`.

Besides, Android app will stack the coming vowels even though we can't see the stacked vowels in Android app (I believe they are cut-off), they indeed exist if we backspace them. We also can produce it when using Android Chrome and type a character with multiple vowels in the search bar.

So, I am looking for a way to stop showing the vowels that are out of vertical boundary. It might be an attribute in our EditText. @keianhzo do you have idea about this?
