### PR TITLE
Fix CocurrentlModificationException in debug mode

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -149,8 +149,12 @@ public class SessionStore implements
         if (BuildConfig.DEBUG) {
             mStoreSubscription = ComponentsAdapter.get().getStore().observeManually(browserState -> {
                 Log.d(LOGTAG, "Session status BEGIN");
-                browserState.getTabs().forEach(tabSessionState -> Log.d(LOGTAG, "BrowserStore Session: " + tabSessionState.getId()));
-                mSessions.forEach(session -> Log.d(LOGTAG, "SessionStore Session: " + session.getId()));
+                for (int i=0; i<browserState.getTabs().size(); i++) {
+                    Log.d(LOGTAG, "BrowserStore Session: " + browserState.getTabs().get(i).getId());
+                }
+                for (int i=0; i<mSessions.size(); i++) {
+                    Log.d(LOGTAG, "SessionStore Session: " + mSessions.get(i).getId());
+                }
                 Log.d(LOGTAG, "Session status END");
                 return null;
             });


### PR DESCRIPTION
This caused a crash mostly in the emulator when restoring sessions and only in DEBUG mode (release builds are not affected):

STRs:
- Open a few sessions/windows
- Exist the app (persist sessions)
- Kill the app
- Reopen

Result: Crash
Expected: Sessions should be restored