### PR TITLE
Fixes #3620 Fixes #3634 Fix private session restore crash

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -431,6 +431,11 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     private boolean shouldLoadDefaultPage(@NonNull SessionState aState) {
+        // data:text URLs can not be restored.
+        if (mState.mSessionState != null && ((mState.mUri == null) || mState.mUri.startsWith("data:text"))) {
+            return true;
+        }
+
         if (aState.mUri != null && aState.mUri.length() != 0 && !aState.mUri.equals(mContext.getString(R.string.about_blank))) {
             return false;
         }
@@ -467,12 +472,6 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
 
         openSession();
-
-        // data:text URLs can not be restored.
-        if (mState.mSessionState != null && ((mState.mUri == null) || mState.mUri.startsWith("data:text"))) {
-            mState.mSessionState = null;
-            mState.mUri = null;
-        }
 
         if (shouldLoadDefaultPage(mState)) {
             loadDefaultPage();


### PR DESCRIPTION
Fixes #3620 Fixes #3634 We were setting the Session State and Uri to null in the `restore` method just for handling default page loading in `shouldLoadDefaultPage` but now in `restore` we consider a null Session State as a new session creation and we notify to the `BrowserStore` in hat case so we were trying to add a new session to the `BrowserStore` but the session hasn't been removed from the store which triggered the `BrowserStore` crash as it requires unique session ids.