### PR TITLE
Replace Thai quotation with semicolon.

### DIFF
--- a/app/src/main/res/xml/keyboard_symbols_thai.xml
+++ b/app/src/main/res/xml/keyboard_symbols_thai.xml
@@ -43,7 +43,7 @@
         <Key android:codes="126" android:keyLabel="~"/>
         <Key android:codes="0x2018" android:keyLabel="‘"/>
         <Key android:codes="0x201C" android:keyLabel="“"/>
-        <Key android:codes="34" android:keyLabel="&quot;"/>
+        <Key android:codes="59" android:keyLabel=";"/>
         <Key android:codes="95" android:keyLabel="_" />
         <Key android:codes="45" android:keyLabel="-" />
         <Key android:codes="43" android:keyLabel="+" />


### PR DESCRIPTION
Fixes #3627.

Correct the semicolon symbol according to the [design document](https://trello-attachments.s3.amazonaws.com/5a260c5d480978f87ffad6aa/5e8b6fea4b16537342cd8ab1/a17286b6b2aec8b4c3a5089dc6479291/UIS-92_Thai_Keyboard_001.pdf). 