### PR TITLE
Fixes #3637 Null check the alphabetic Caps Keyboard when switching shift

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -746,7 +746,10 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
         if (mKeyboardView.getKeyboard() != getSymbolsKeyboard()) {
             if (isShifted || mIsCapsLock) {
-                mKeyboardView.setKeyboard(mCurrentKeyboard.getAlphabeticCapKeyboard());
+                if (mCurrentKeyboard.getAlphabeticCapKeyboard() != null) {
+                    mKeyboardView.setKeyboard(mCurrentKeyboard.getAlphabeticCapKeyboard());
+                }
+
             } else {
                 mKeyboardView.setKeyboard(mCurrentKeyboard.getAlphabeticKeyboard());
             }

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -1049,7 +1049,7 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             postInputCommand(() -> connection.commitText(text, 1));
         }
 
-        if (!mIsCapsLock && mCurrentKeyboard.getAlphabeticCapKeyboard() == null) {
+        if (!mIsCapsLock) {
             handleShift(false);
         }
 


### PR DESCRIPTION
Fixes #3637 Null check the alphabetic caps Keyboard when entering a character. 

Also allow the alphabetic caps keyboard to be dismissed when a key is entered, I've checked other keyboards and it seems to work the same way as the rest.