### PR TITLE
Fixes #3643 Telemetry crash fix

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/utils/SystemUtils.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/utils/SystemUtils.java
@@ -1,9 +1,11 @@
 package org.mozilla.vrbrowser.utils;
 
+import android.app.ActivityManager;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Process;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -111,6 +113,18 @@ public class SystemUtils {
             Log.e(LOGTAG, "Deleting crash file: " + file);
             context.deleteFile(file);
         }
+    }
+
+    public static boolean isMainProcess(@NonNull Context context) {
+        int pid = Process.myPid();
+
+        final ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (activityManager == null) {
+            return false;
+        }
+
+        return activityManager.getRunningAppProcesses().stream().anyMatch(processInfo ->
+                processInfo.pid == pid && processInfo.processName.equals(context.getPackageName()));
     }
 
 }

--- a/app/src/test/java/org/mozilla/vrbrowser/EnvironmentsTest.kt
+++ b/app/src/test/java/org/mozilla/vrbrowser/EnvironmentsTest.kt
@@ -17,7 +17,7 @@ import java.io.File
 
 
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
+@Config(manifest = Config.NONE, application = TestApplication::class)
 class EnvironmentsTest {
 
     @get:Rule
@@ -27,7 +27,7 @@ class EnvironmentsTest {
 
     @Before
     fun setup() {
-        val app = ApplicationProvider.getApplicationContext<VRBrowserApplication>()
+        val app = ApplicationProvider.getApplicationContext<TestApplication>()
         settingStore = SettingsStore.getInstance(app)
         context = ApplicationProvider.getApplicationContext()
     }

--- a/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
@@ -18,7 +18,7 @@ import org.robolectric.annotation.Config
 
 
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
+@Config(manifest = Config.NONE, application = TestApplication::class)
 class GleanMetricsServiceTest {
 
     @get:Rule
@@ -26,7 +26,7 @@ class GleanMetricsServiceTest {
 
     @Before
     fun setup() {
-        val app = ApplicationProvider.getApplicationContext<VRBrowserApplication>()
+        val app = ApplicationProvider.getApplicationContext<TestApplication>()
         // We use the HttpURLConnectionClient for tests as the GeckoWebExecutor based client needs
         // full GeckoRuntime initialization and it crashes in the test environment.
         val client = HttpURLConnectionClient()

--- a/app/src/test/java/org/mozilla/vrbrowser/TestApplication.kt
+++ b/app/src/test/java/org/mozilla/vrbrowser/TestApplication.kt
@@ -1,0 +1,5 @@
+package org.mozilla.vrbrowser
+
+import android.app.Application
+
+class TestApplication: Application()


### PR DESCRIPTION
Fixes #3643 The Telemetry service needs to get initialized in the Application onCreate as the service can be called when the app is not running and that only calls the Application onCreate, otherwise this crash happens.

I had to add a custom TestApplication for testing as the Unit testing initialization doesn't seems to provide a different process for the crash service as defined in the manifest and the GeckoRuntime crashes with:
`java.lang.IllegalArgumentException: Crash handler service must run in a separate process`

Also for some reason the Application onCreate is called from a different process the first time the app is launched and the GeckoRuntime is not correctly initialized and we don't get any content paints. I've added the same check as Fenix does to make sure we are running in the main process or just return otherwise.