### PR TITLE
Assert that vrPrefsWorkAround method is called before creating the Gecko Runtime

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -228,8 +228,6 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        Bundle extras = getIntent() != null ? getIntent().getExtras() : null;
-        SessionStore.prefOverrides(this, extras);
         ((VRBrowserApplication)getApplication()).onActivityCreate(this);
         SettingsStore.getInstance(getBaseContext()).setPid(Process.myPid());
         // Fix for infinite restart on startup crashes.

--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserApplication.java
@@ -17,6 +17,7 @@ import org.mozilla.vrbrowser.browser.Accounts;
 import org.mozilla.vrbrowser.browser.Places;
 import org.mozilla.vrbrowser.browser.Services;
 import org.mozilla.vrbrowser.browser.engine.EngineProvider;
+import org.mozilla.vrbrowser.browser.engine.SessionStore;
 import org.mozilla.vrbrowser.db.AppDatabase;
 import org.mozilla.vrbrowser.db.DataRepository;
 import org.mozilla.vrbrowser.downloads.DownloadsManager;
@@ -52,6 +53,7 @@ public class VRBrowserApplication extends Application implements AppServicesProv
             return;
         }
 
+        SessionStore.prefOverrides(this);
         TelemetryWrapper.init(this, EngineProvider.INSTANCE.getDefaultClient(this));
         GleanMetricsService.init(this, EngineProvider.INSTANCE.getDefaultClient(this));
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/EngineProvider.kt
@@ -58,6 +58,11 @@ object EngineProvider {
         return runtime!!
     }
 
+    @Synchronized
+    fun isRuntimeCreated(): Boolean {
+        return runtime != null
+    }
+
     fun createGeckoWebExecutor(context: Context): GeckoWebExecutor {
         return GeckoWebExecutor(getOrCreateRuntime(context))
     }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -87,9 +87,9 @@ public class SessionStore implements
         mSessions = new ArrayList<>();
     }
 
-    public static void prefOverrides(Context context, Bundle aExtras) {
+    public static void prefOverrides(Context context) {
         // FIXME: Once GeckoView has a prefs API
-        SessionUtils.vrPrefsWorkAround(context, aExtras);
+        SessionUtils.vrPrefsWorkAround(context);
     }
 
     public void initialize(Context context) {


### PR DESCRIPTION
We have had different regressions related to not calling vrPrefsWorkAround before runtime. I'm adding a error in that case to prevent that from happenning again