### PR TITLE
Fixes #3620 Improved SessionStore/BrowserStore sync

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -2,7 +2,6 @@ package org.mozilla.vrbrowser.browser.engine;
 
 import android.content.Context;
 import android.content.res.Configuration;
-import android.os.Bundle;
 import android.util.Log;
 import android.util.Pair;
 
@@ -149,6 +148,7 @@ public class SessionStore implements
         if (BuildConfig.DEBUG) {
             mStoreSubscription = ComponentsAdapter.get().getStore().observeManually(browserState -> {
                 Log.d(LOGTAG, "Session status BEGIN");
+                Log.d(LOGTAG, "BrowserStore = " + browserState.getTabs().size() + ", SessionStore = " + mSessions.size());
                 for (int i=0; i<browserState.getTabs().size(); i++) {
                     Log.d(LOGTAG, "BrowserStore Session: " + browserState.getTabs().get(i).getId());
                 }


### PR DESCRIPTION
Fixes #3620 When switching and suspending before onSessionStateChange has been called, mSession.mSessionState might be still null and we were adding the session to the BrowserStore twice. I have added a parameter to the recreate method to better track the session recreate origin as it can happen in multiple situations and not all the them require adding the session to the BrowserStore.