### PR TITLE
Fixes #3658 FxA login signin fix

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TabsWidget.java
@@ -25,6 +25,7 @@ import org.mozilla.vrbrowser.utils.BitmapCache;
 import org.mozilla.vrbrowser.utils.UrlUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class TabsWidget extends UIDialog {
     protected BitmapCache mBitmapCache;
@@ -50,7 +51,7 @@ public class TabsWidget extends UIDialog {
     public interface TabDelegate {
         void onTabSelect(Session aTab);
         void onTabAdd();
-        void onTabsClose(ArrayList<Session> aTabs);
+        void onTabsClose(List<Session> aTabs);
     }
 
     public TabsWidget(Context aContext) {


### PR DESCRIPTION
Fixes #3658 FxA login signin fix. The first time you login after install the FxA login flow does something that prevents GV from correctly replacing the History entry when loading the success page. Works good in the subsequent logins but obviously the first one is the most important. We have moved back to using new tabs instead of loadUri. I have checked that 