### PR TITLE
Fixes #3671 BrowserState-SessionStore sync

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -91,7 +91,6 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     private transient byte[] mPrivatePage;
     private transient boolean mFirstContentfulPaint;
     private transient long mKeepAlive;
-    private transient boolean mSessionAdded;
 
     public interface BitmapChangedListener {
         void onBitmapChanged(Session aSession, Bitmap aBitmap);
@@ -110,25 +109,43 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
     @IntDef(value = { SESSION_OPEN, SESSION_DO_NOT_OPEN})
-    public @interface SessionOpenModeFlags {}
-    public static final int SESSION_OPEN = 0;
-    public static final int SESSION_DO_NOT_OPEN = 1;
+    @interface SessionOpenModeFlags {}
+    static final int SESSION_OPEN = 0;
+    static final int SESSION_DO_NOT_OPEN = 1;
 
-    protected Session(Context aContext, GeckoRuntime aRuntime,
-                      @NonNull SessionSettings aSettings) {
+    @NonNull
+    static Session createSession(Context aContext, GeckoRuntime aRuntime, @NonNull SessionSettings aSettings, @Session.SessionOpenModeFlags int aOpenMode, @NonNull SessionChangeListener listener) {
+        Session session = new Session(aContext, aRuntime, aSettings);
+        session.addSessionChangeListener(listener);
+        listener.onSessionAdded(session);
+        if (aOpenMode == Session.SESSION_OPEN) {
+            session.openSession();
+            session.setActive(true);
+        }
+
+        return session;
+    }
+
+    @NonNull
+    static Session createSuspendedSession(Context aContext, GeckoRuntime aRuntime, @NonNull SessionState aRestoreState, @NonNull SessionChangeListener listener) {
+        Session session = new Session(aContext, aRuntime, aRestoreState);
+        session.addSessionChangeListener(listener);
+
+        return session;
+    }
+
+    private Session(Context aContext, GeckoRuntime aRuntime, @NonNull SessionSettings aSettings) {
         mContext = aContext;
         mRuntime = aRuntime;
         initialize();
-        mState = createSession(aSettings);
-        mSessionAdded = true;
+        mState = createSessionState(aSettings);
     }
 
-    protected Session(Context aContext, GeckoRuntime aRuntime, @NonNull SessionState aRestoreState) {
+    private Session(Context aContext, GeckoRuntime aRuntime, @NonNull SessionState aRestoreState) {
         mContext = aContext;
         mRuntime = aRuntime;
         initialize();
         mState = aRestoreState;
-        mSessionAdded = false;
     }
 
     private void initialize() {
@@ -161,8 +178,8 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
     protected void shutdown() {
         if (mState.mSession != null) {
-            closeSession(mState);
-            mState.mSession = null;
+            setActive(false);
+            suspend();
         }
 
         if (mState.mParentId != null) {
@@ -171,11 +188,6 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
                 parent.mSessionChangeListeners.remove(this);
             }
         }
-
-        mSessionChangeListeners.forEach(listener -> {
-            listener.onSessionRemoved(mState.mId);
-            mSessionAdded = false;
-        });
 
         mQueuedCalls.clear();
         mNavigationListeners.clear();
@@ -430,6 +442,8 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             return;
         }
 
+        mSessionChangeListeners.forEach(listener -> listener.onSessionRemoved(mState.mId));
+
         Log.d(LOGTAG, "Suspending Session: " + mState.mId);
         closeSession(mState);
         mState.mSession = null;
@@ -458,7 +472,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
     }
 
-    private void restore(boolean addSession) {
+    private void restore() {
         SessionSettings settings = mState.mSettings;
         if (settings == null) {
             settings = new SessionSettings.Builder()
@@ -470,12 +484,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
         mState.mSession = createGeckoSession(settings);
 
-        // We call restore when a session is first activated and when it's recreated.
-        // We only need to notify of the session creation if it's not a recreation.
-        if (addSession) {
-            mSessionChangeListeners.forEach(listener -> listener.onSessionAdded(this));
-            mSessionAdded = true;
-        }
+        mSessionChangeListeners.forEach(listener -> listener.onSessionAdded(this));
 
         openSession();
 
@@ -498,7 +507,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
     }
 
 
-    private SessionState createSession(@NonNull SessionSettings aSettings) {
+    private SessionState createSessionState(@NonNull SessionSettings aSettings) {
         SessionState state = new SessionState();
         state.mSettings = aSettings;
         state.mSession = createGeckoSession(aSettings);
@@ -541,7 +550,9 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
 
         mState = mState.recreate();
 
-        restore(false);
+        mSessionChangeListeners.forEach(listener -> listener.onSessionRemoved(mState.mId));
+
+        restore();
 
         for (SessionChangeListener listener: mSessionChangeListeners) {
             listener.onSessionStateChanged(this, true);
@@ -563,9 +574,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             mState.mSession.open(mRuntime);
         }
 
-        mSessionChangeListeners.forEach(listener -> {
-            listener.onSessionOpened(this);
-        });
+        mSessionChangeListeners.forEach(listener -> listener.onSessionOpened(this));
     }
 
     private void closeSession(@NonNull SessionState aState) {
@@ -803,7 +812,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             mState.setActive(aActive);
 
         } else if (aActive) {
-            restore(!mSessionAdded);
+            restore();
 
         } else {
             Log.e(LOGTAG, "ERROR: Setting null GeckoView to inactive!");
@@ -868,7 +877,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
                 .withServo(!isInstanceOfServoSession(mState.mSession))
                 .build();
 
-        mState = createSession(settings);
+        mState = createSessionState(settings);
         openSession();
         closeSession(previous);
 

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -2,7 +2,6 @@ package org.mozilla.vrbrowser.browser.engine;
 
 import android.content.Context;
 import android.content.res.Configuration;
-import android.os.Bundle;
 import android.util.Log;
 import android.util.Pair;
 
@@ -149,6 +148,7 @@ public class SessionStore implements
         if (BuildConfig.DEBUG) {
             mStoreSubscription = ComponentsAdapter.get().getStore().observeManually(browserState -> {
                 Log.d(LOGTAG, "Session status BEGIN");
+                Log.d(LOGTAG, "BrowserStore: " + browserState.getTabs().size() + ", SessionStore: " + mSessions.size());
                 for (int i=0; i<browserState.getTabs().size(); i++) {
                     Log.d(LOGTAG, "BrowserStore Session: " + browserState.getTabs().get(i).getId());
                 }
@@ -188,8 +188,8 @@ public class SessionStore implements
     Session createSession(@NonNull SessionSettings aSettings, @Session.SessionOpenModeFlags int aOpenMode) {
         Session session = new Session(mContext, mRuntime, aSettings);
         session.addSessionChangeListener(this);
+        onSessionAdded(session);
         if (aOpenMode == Session.SESSION_OPEN) {
-            onSessionAdded(session);
             session.openSession();
             session.setActive(true);
         }

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -148,13 +148,21 @@ public class SessionStore implements
         if (BuildConfig.DEBUG) {
             mStoreSubscription = ComponentsAdapter.get().getStore().observeManually(browserState -> {
                 Log.d(LOGTAG, "Session status BEGIN");
-                Log.d(LOGTAG, "BrowserStore: " + browserState.getTabs().size() + ", SessionStore: " + mSessions.size());
+                Log.d(LOGTAG, "[Total] BrowserStore: " + browserState.getTabs().size() + ", SessionStore: " + mSessions.size());
                 for (int i=0; i<browserState.getTabs().size(); i++) {
-                    Log.d(LOGTAG, "BrowserStore Session: " + browserState.getTabs().get(i).getId());
+                    boolean isPrivate = browserState.getTabs().get(i).getContent().getPrivate();
+                    Log.d(LOGTAG, "BrowserStore Session: " + browserState.getTabs().get(i).getId() + (isPrivate ? " (PB)" : ""));
                 }
+                int suspendedCount = 0;
                 for (int i=0; i<mSessions.size(); i++) {
-                    Log.d(LOGTAG, "SessionStore Session: " + mSessions.get(i).getId());
+                    boolean suspended = mSessions.get(i).getSessionState().mSession == null && !mSessions.get(i).isActive();
+                    boolean isPrivate = mSessions.get(i).isPrivateMode();
+                    Log.d(LOGTAG, "SessionStore Session: " + mSessions.get(i).getId() + (isPrivate ? " (PB)" : "") + (suspended ? " (suspended)" : ""));
+                    if (suspended) {
+                        suspendedCount++;
+                    }
                 }
+                Log.d(LOGTAG, "[Alive] BrowserStore: " + browserState.getTabs().size() + ", SessionStore: " + (mSessions.size() - suspendedCount));
                 Log.d(LOGTAG, "Session status END");
                 return null;
             });
@@ -168,6 +176,10 @@ public class SessionStore implements
         aSession.addNavigationListener(mServices);
         mSessions.add(aSession);
         sessionActiveStateChanged();
+
+        if (BuildConfig.DEBUG) {
+            mStoreSubscription.resume();
+        }
 
         return aSession;
     }
@@ -186,20 +198,13 @@ public class SessionStore implements
 
     @NonNull
     Session createSession(@NonNull SessionSettings aSettings, @Session.SessionOpenModeFlags int aOpenMode) {
-        Session session = new Session(mContext, mRuntime, aSettings);
-        session.addSessionChangeListener(this);
-        onSessionAdded(session);
-        if (aOpenMode == Session.SESSION_OPEN) {
-            session.openSession();
-            session.setActive(true);
-        }
+        Session session = Session.createSession(mContext, mRuntime, aSettings, aOpenMode, this);
         return addSession(session);
     }
 
     @NonNull
     public Session createSuspendedSession(SessionState aRestoreState) {
-        Session session = new Session(mContext, mRuntime, aRestoreState);
-        session.addSessionChangeListener(this);
+        Session session = Session.createSuspendedSession(mContext, mRuntime, aRestoreState, this);
         return addSession(session);
     }
 
@@ -208,14 +213,16 @@ public class SessionStore implements
         SessionState state = new SessionState();
         state.mUri = aUri;
         state.mSettings = new SessionSettings(new SessionSettings.Builder().withDefaultSettings(mContext).withPrivateBrowsing(aPrivateMode));
-        Session session = new Session(mContext, mRuntime, state);
-        session.addSessionChangeListener(this);
+        Session session = Session.createSuspendedSession(mContext, mRuntime, state, this);
         return addSession(session);
     }
 
     private void shutdownSession(@NonNull Session aSession) {
         aSession.setPermissionDelegate(null);
         aSession.shutdown();
+        if (BuildConfig.DEBUG) {
+            mStoreSubscription.resume();
+        }
     }
 
     public void destroySession(Session aSession) {
@@ -240,6 +247,9 @@ public class SessionStore implements
             if (!session.isActive()) {
                 session.suspend();
             }
+        }
+        if (BuildConfig.DEBUG) {
+            mStoreSubscription.resume();
         }
     }
 


### PR DESCRIPTION
Fixes #3671

Make sure to test the following scenarios:
- New Window creation: from either Tray/Context menu
- New Tab creation: from either the Tabs panel/Context menu
- New Background tab creation (Long press link and open tab from the Context menu)
- Session restore: quit and reopen app with active&suspended sessions (Suspended sessions won't be added to the Browser Store until first activated)
- Session suspension/restore: open 3+ windows in regular model, switch to private, open another 3+ windows and go back and forth between regular/private
- Session recreation: Open several active/suspeded sessions, got to Settings->Privacy and clear cache/data

**Logcat** filtering by `SessionStore` will show the `BrowserStore`-`SessionStore` sync state including the alive vs suspended totals. 

**Note**: Suspended session will be alive at the `SessionStore` level but not at the `BrowserStore` level, we remove them from the `BrowserStore` when suspended, we only want alive ones there.