### PR TITLE
Remove superfluous WorkManager initialization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -447,9 +447,6 @@ dependencies {
     implementation deps.android_components.glean
     implementation deps.app_services.rustlog
 
-    // TODO this should not be necessary at all, see Services.kt
-    implementation deps.work.runtime
-
     // Kotlin dependency
     implementation deps.kotlin.stdlib
     implementation deps.kotlin.coroutines

--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/Services.kt
@@ -9,8 +9,6 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.work.Configuration
-import androidx.work.WorkManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -63,20 +61,6 @@ class Services(val context: Context, places: Places): GeckoSession.NavigationDel
 
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Bookmarks to lazy {places.bookmarks})
         GlobalSyncableStoreProvider.configureStore(SyncEngine.History to lazy {places.history})
-
-        // TODO this really shouldn't be necessary, since WorkManager auto-initializes itself, unless
-        // auto-initialization is disabled in the manifest file. We don't disable the initialization,
-        // but i'm seeing crashes locally because WorkManager isn't initialized correctly...
-        // Maybe this is a race of sorts? We're trying to access it before it had a chance to auto-initialize?
-        // It's not well-documented _when_ that auto-initialization is supposed to happen.
-
-        // For now, let's just manually initialize it here, and swallow failures (it's already initialized).
-        try {
-            WorkManager.initialize(
-                    context,
-                    Configuration.Builder().setMinimumLoggingLevel(android.util.Log.INFO).build()
-            )
-        } catch (e: IllegalStateException) {}
     }
 
     // Process received device events, only handling received tabs for now.

--- a/versions.gradle
+++ b/versions.gradle
@@ -110,9 +110,7 @@ support.core_utils = "androidx.legacy:legacy-support-core-utils:$versions.suppor
 support.vector_drawable = "androidx.vectordrawable:vectordrawable:$versions.support"
 deps.support = support
 
-// TODO this should not be necessary at all, see Services.kt
 def work = [:]
-work.runtime = "androidx.work:work-runtime-ktx:$versions.work"
 work.testing = "androidx.work:work-testing:$versions.work"
 deps.work = work
 


### PR DESCRIPTION
Originally the `Service` instance was created in `Application` `onCreate` which happens before any other component has been created so the `WorkManager` was not initialized and that’s why we needed to initialize it during the `Service` instantiation, just to make sure that it was always ready.
We have recently done a code refactor and now the `Service` instance is create in `Activity` `onCreate` so this is not an issue anymore, as the component has already had a chance and should be initialized.