### PR TITLE
Do not call addSession in SessionStore.onStackSession()

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -585,7 +585,6 @@ public class SessionStore implements
 
     @Override
     public void onStackSession(Session aSession) {
-        ComponentsAdapter.get().addSession(aSession);
         ComponentsAdapter.get().link(aSession.getId(), aSession.getGeckoSession());
     }
 


### PR DESCRIPTION
Fixes #3681

It's already called in createSession