### PR TITLE
Fix the unlinking/removing sessions order 

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -441,11 +441,11 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
             return;
         }
 
-        mSessionChangeListeners.forEach(listener -> listener.onSessionRemoved(mState.mId));
-
         Log.d(LOGTAG, "Suspending Session: " + mState.mId);
         closeSession(mState);
         mState.mSession = null;
+
+        mSessionChangeListeners.forEach(listener -> listener.onSessionRemoved(mState.mId));
     }
 
     private boolean shouldLoadDefaultPage(@NonNull SessionState aState) {


### PR DESCRIPTION
We have to unlink when closing before removing the session from the BrowserStore.