### PR TITLE
Ignore tray actions while in immersive mode

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/VRBrowserActivity.java
@@ -1474,6 +1474,11 @@ public class VRBrowserActivity extends PlatformActivity implements WidgetManager
     }
 
     @Override
+    public boolean isWebXRPresenting() {
+        return mIsPresentingImmersive;
+    }
+
+    @Override
     public void addConnectivityListener(Delegate aListener) {
         if (!mConnectivityListeners.contains(aListener)) {
             mConnectivityListeners.add(aListener);

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/TrayWidget.java
@@ -116,6 +116,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.privateButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.privateButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -126,6 +129,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.settingsButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.settingsButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -138,6 +144,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.bookmarksButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.bookmarksButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -148,6 +157,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.historyButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.historyButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -158,6 +170,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.tabsButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.tabsButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -168,6 +183,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.addwindowButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.addwindowButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -179,6 +197,9 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
         mBinding.downloadsButton.setOnHoverListener(mButtonScaleHoverListener);
         mBinding.downloadsButton.setOnClickListener(view -> {
+            if (isImmersive()) {
+                return;
+            }
             if (mAudio != null) {
                 mAudio.playSound(AudioEngine.Sound.CLICK);
             }
@@ -544,6 +565,17 @@ public class TrayWidget extends UIWidget implements WidgetManagerDelegate.Update
 
     private void hideNotifications() {
         NotificationManager.hideAll();
+    }
+
+    private boolean isImmersive() {
+        if (mWidgetManager != null && mWidgetManager.isWebXRPresenting()) {
+            return true;
+        }
+
+        if (mViewModel != null) {
+            return mViewModel.getIsFullscreen().getValue().get();
+        }
+        return false;
     }
 
     private BookmarksStore.BookmarkListener mBookmarksListener = new BookmarksStore.BookmarkListener() {

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WidgetManagerDelegate.java
@@ -98,6 +98,7 @@ public interface WidgetManagerDelegate {
     void removeWebXRListener(WebXRListener aListener);
     void setWebXRIntersitialState(@WebXRInterstitialState int aState);
     boolean isWebXRIntersitialHidden();
+    boolean isWebXRPresenting();
     boolean isPermissionGranted(@NonNull String permission);
     void requestPermission(String uri, @NonNull String permission, GeckoSession.PermissionDelegate.Callback aCallback);
     boolean canOpenNewWindow();


### PR DESCRIPTION
Partially fixes #3678

There is still some possibility that WebXR enters immersive after clicking private mode due to promise or external VR ipc delays. Currently we don't have a way to detect which session starts WebXR mode. It would require some Gecko patch. Ideally we should exit WebXR mode if the session is set to inactive. WebXR currently works even if the session is set to inactive state (but media get's paused, that's why it can be reproduced in DelightVR)