### PR TITLE
Keeping caps setting when switching back from the symbol keyboard.

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/KeyboardWidget.java
@@ -974,8 +974,8 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
 
     private void handleShowKeyboard(Keyboard aKeyboard) {
         Keyboard alphabetic = mCurrentKeyboard.getAlphabeticKeyboard();
-        Keyboard alphabetiCap = mCurrentKeyboard.getAlphabeticCapKeyboard();
-        final boolean switchToAlphabeticMode = aKeyboard == alphabetic || aKeyboard == alphabetiCap;
+        Keyboard alphabeticCap = mCurrentKeyboard.getAlphabeticCapKeyboard();
+        final boolean switchToAlphabeticMode = aKeyboard == alphabetic || aKeyboard == alphabeticCap;
 
         mKeyboardView.setKeyboard(aKeyboard);
         mKeyboardView.setLayoutParams(mKeyboardView.getLayoutParams());
@@ -1005,6 +1005,10 @@ public class KeyboardWidget extends UIWidget implements CustomKeyboardView.OnKey
             mCurrentKeyboard.getAlphabeticKeyboard().setSpaceKeyLabel("");
         }
 
+        if (!switchToSymbolMode && alphabeticCap != null &&
+                alphabeticCap.isShifted()) {
+            alphabetic = alphabeticCap;
+        }
         handleShowKeyboard(switchToSymbolMode ? getSymbolsKeyboard() : alphabetic);
     }
 


### PR DESCRIPTION
Fixes #3687.

Checking `mIsCapsLock` when switching back to the alphabetic keyboard if the input has its own alphabeticCap keyboard.