### PR TITLE
Fix RegisterExternalContext() life cycle issues on WaveVR

### DIFF
--- a/app/src/wavevr/cpp/native-lib.cpp
+++ b/app/src/wavevr/cpp/native-lib.cpp
@@ -45,6 +45,12 @@ JNI_METHOD(void, activityResumed)
 int main(int argc, char *argv[]) {
   sQueue->AttachToThread();
   VRB_LOG("Call WVR_Init");
+  sDevice = DeviceDelegateWaveVR::Create(BrowserWorld::Instance().GetRenderContext());
+  BrowserWorld::Instance().RegisterDeviceDelegate(sDevice);
+  while(!sJavaInitialized) {
+    sQueue->ProcessRunnables();
+  }
+
   WVR_InitError eError = WVR_Init(WVR_AppType_VRContent);
   if (eError != WVR_InitError_None) {
     VRB_LOG("Unable to init VR runtime: %s", WVR_GetInitErrorString(eError));
@@ -70,15 +76,10 @@ int main(int argc, char *argv[]) {
   if (pError != WVR_RenderError_None) {
     VRB_LOG("Present init failed - Error[%d]", pError);
   }
-  sDevice = DeviceDelegateWaveVR::Create(BrowserWorld::Instance().GetRenderContext());
-  BrowserWorld::Instance().RegisterDeviceDelegate(sDevice);
   VRB_GL_CHECK(glEnable(GL_DEPTH_TEST));
   VRB_GL_CHECK(glEnable(GL_CULL_FACE));
   VRB_GL_CHECK(glEnable(GL_BLEND));
   // VRB_GL_CHECK(glDisable(GL_CULL_FACE));
-  while(!sJavaInitialized) {
-    sQueue->ProcessRunnables();
-  }
   VRB_LOG("Java Initialized.");
   BrowserWorld::Instance().InitializeGL();
   BrowserWorld::Instance().Resume();


### PR DESCRIPTION
Fixes #3688

It turns out that WVR_RenderInit() is a blocking call that waits for the activity to be active/resumed to complete the internal work. The function is slow to react so Gecko is initialized earlier and fails all the attempts to detect VR runtimes, because the external shmem is null. We need to process InitializeJava earlier instead of waiting for the slow WVR_RenderInit to complete.

100% reproducible STR:
- Take off the HMD until the screen turns off
- Launch FxR from Android Studio
- Put the HMD AFTER the application has started 