### PR TITLE
BrowserStore sync checks

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/SessionStore.java
@@ -146,6 +146,9 @@ public class SessionStore implements
 
         if (BuildConfig.DEBUG) {
             mStoreSubscription = ComponentsAdapter.get().getStore().observeManually(browserState -> {
+                if (mSessions == null || browserState == null) {
+                    return null;
+                }
                 Log.d(LOGTAG, "Session status BEGIN");
                 Log.d(LOGTAG, "[Total] BrowserStore: " + browserState.getTabs().size() + ", SessionStore: " + mSessions.size());
                 for (int i=0; i<browserState.getTabs().size(); i++) {


### PR DESCRIPTION
- Under some conditions `mSessions` or `browserState` can be null during session loggin. Added null checks to avoid a crash.
- Added a check upon session addition into the `BrowserStore` to avoid adding a duplicated session.