### PR TITLE
Avoid using the public external path as it's not accessible in Oreo

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/downloads/DownloadsManager.java
@@ -115,7 +115,7 @@ public class DownloadsManager {
         request.setVisibleInDownloadsUi(false);
         if (job.getOutputPath() == null) {
             if (storageType == SettingsStore.EXTERNAL) {
-                request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, job.getFilename());
+                request.setDestinationInExternalFilesDir(mContext, Environment.DIRECTORY_DOWNLOADS, job.getFilename());
 
             } else {
                 String outputPath = getOutputPathForJob(job);


### PR DESCRIPTION
`setDestinationInExternalPublicDir` uses `getExternalStoragePublicDirectory` which is no longer directly accessible to apps starting on Android 29