### PR TITLE
Refactor OculusSwapChain code and implement VRProjectionLayer

### DIFF
--- a/app/src/main/cpp/BrowserWorld.h
+++ b/app/src/main/cpp/BrowserWorld.h
@@ -87,6 +87,7 @@ protected:
   void DrawWebXRInterstitial(device::Eye aEye);
   void DrawSplashAnimation(device::Eye aEye);
   void CreateSkyBox(const std::string& aBasePath, const std::string& aExtension);
+  void CreateEnvironment();
 private:
   State& m;
   BrowserWorld() = delete;

--- a/app/src/main/cpp/DeviceDelegate.h
+++ b/app/src/main/cpp/DeviceDelegate.h
@@ -86,6 +86,7 @@ public:
   virtual VRLayerCylinderPtr CreateLayerCylinder(int32_t aWidth, int32_t aHeight,
                                                 VRLayerSurface::SurfaceType aSurfaceType) { return nullptr; }
   virtual VRLayerCylinderPtr CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer) { return nullptr; }
+  virtual VRLayerProjectionPtr CreateLayerProjection(VRLayerSurface::SurfaceType aSurfaceType) { return nullptr; }
   virtual VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) { return nullptr; }
   virtual VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) { return nullptr; }
   virtual void DeleteLayer(const VRLayerPtr& aLayer) {};

--- a/app/src/main/cpp/VRLayer.cpp
+++ b/app/src/main/cpp/VRLayer.cpp
@@ -401,6 +401,28 @@ VRLayerCylinder::VRLayerCylinder(State& aState): VRLayerSurface(aState, LayerTyp
 
 VRLayerCylinder::~VRLayerCylinder() {}
 
+// Layer Projection
+
+struct VRLayerProjection::State: public VRLayerSurface::State {
+  State() {}
+};
+
+VRLayerProjectionPtr
+VRLayerProjection::Create(const int32_t aWidth, const int32_t aHeight, VRLayerSurface::SurfaceType aSurfaceType) {
+  auto result = std::make_shared<vrb::ConcreteClass<VRLayerProjection, VRLayerProjection::State>>();
+  result->m.width = aWidth;
+  result->m.height = aHeight;
+  result->m.surfaceType = aSurfaceType;
+  return result;
+}
+
+
+VRLayerProjection::VRLayerProjection(State& aState): VRLayerSurface(aState, LayerType::PROJECTION), m(aState) {
+}
+
+VRLayerProjection::~VRLayerProjection() {
+}
+
 // Layer Cube
 
 struct VRLayerCube::State: public VRLayer::State {

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -26,7 +26,8 @@ public:
   enum class LayerType {
     QUAD,
     CUBEMAP,
-    EQUIRECTANGULAR
+    EQUIRECTANGULAR,
+    PROJECTION
   };
 
   enum class SurfaceChange {
@@ -150,6 +151,20 @@ private:
   VRB_NO_DEFAULTS(VRLayerCylinder)
 };
 
+class VRLayerProjection;
+  typedef std::shared_ptr<VRLayerProjection> VRLayerProjectionPtr;
+
+  class VRLayerProjection: public VRLayerSurface {
+  public:
+    static VRLayerQuadPtr Create(VRLayerSurface::SurfaceType aSurfaceType);
+  protected:
+    struct State;
+    VRLayerProjection(State& aState);
+    virtual ~VRLayerProjection();
+  private:
+    State& m;
+    VRB_NO_DEFAULTS(VRLayerProjection)
+};
 
 class VRLayerCube;
 typedef std::shared_ptr<VRLayerCube> VRLayerCubePtr;

--- a/app/src/main/cpp/VRLayer.h
+++ b/app/src/main/cpp/VRLayer.h
@@ -156,7 +156,7 @@ class VRLayerProjection;
 
   class VRLayerProjection: public VRLayerSurface {
   public:
-    static VRLayerQuadPtr Create(VRLayerSurface::SurfaceType aSurfaceType);
+    static VRLayerProjectionPtr Create(const int32_t aWidth, const int32_t aHeight, VRLayerSurface::SurfaceType aSurfaceType);
   protected:
     struct State;
     VRLayerProjection(State& aState);

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -82,6 +82,7 @@ struct DeviceDelegateOculusVR::State {
   OculusLayerCubePtr cubeLayer;
   OculusLayerEquirectPtr equirectLayer;
   std::vector<OculusLayerPtr> uiLayers;
+  std::vector<OculusLayerProjectionPtr> projectionLayers;
   OculusSwapChainPtr clearColorSwapChain;
   device::RenderMode renderMode = device::RenderMode::StandAlone;
   vrb::FBOPtr currentFBO;
@@ -1087,17 +1088,30 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
   const ovrLayerHeader2* layers[ovrMaxLayerCount] = {};
 
   if (m.cubeLayer && m.cubeLayer->IsLoaded() && m.cubeLayer->IsDrawRequested()) {
-    m.cubeLayer->Update(tracking, m.clearColorSwapChain->SwapChain());
+    m.cubeLayer->Update(m.frameIndex, tracking, m.clearColorSwapChain->SwapChain());
     layers[layerCount++] = m.cubeLayer->Header();
     m.cubeLayer->ClearRequestDraw();
   }
 
   if (m.equirectLayer && m.equirectLayer->IsDrawRequested()) {
-    m.equirectLayer->Update(tracking, m.clearColorSwapChain->SwapChain());
+    m.equirectLayer->Update(m.frameIndex, tracking, m.clearColorSwapChain->SwapChain());
     layers[layerCount++] = m.equirectLayer->Header();
     m.equirectLayer->ClearRequestDraw();
   }
 
+  const float fovX = vrapi_GetSystemPropertyFloat(&m.java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X);
+  const float fovY = vrapi_GetSystemPropertyFloat(&m.java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_Y);
+  const ovrMatrix4f projectionMatrix = ovrMatrix4f_CreateProjectionFov(fovX, fovY, 0.0f, 0.0f, VRAPI_ZNEAR, 0.0f);
+
+  // Add projection layers
+  for (const OculusLayerProjectionPtr& layer: m.projectionLayers) {
+    if (layer->IsDrawRequested() && (layerCount < ovrMaxLayerCount - 1)) {
+      layer->SetProjectionMatrix(projectionMatrix);
+      layer->Update(m.frameIndex, tracking, m.clearColorSwapChain->SwapChain());
+      layers[layerCount++] = layer->Header();
+      layer->ClearRequestDraw();
+    }
+  }
   // Sort quad layers by draw priority
   std::sort(m.uiLayers.begin(), m.uiLayers.end(), [](const OculusLayerPtr & a, OculusLayerPtr & b) -> bool {
     return a->GetLayer()->ShouldDrawBefore(*b->GetLayer());
@@ -1106,17 +1120,13 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
   // Draw back layers
   for (const OculusLayerPtr& layer: m.uiLayers) {
     if (!layer->GetDrawInFront() && layer->IsDrawRequested() && (layerCount < ovrMaxLayerCount - 1)) {
-      layer->Update(tracking, m.clearColorSwapChain->SwapChain());
+      layer->Update(m.frameIndex, tracking, m.clearColorSwapChain->SwapChain());
       layers[layerCount++] = layer->Header();
       layer->ClearRequestDraw();
     }
   }
 
   // Add main eye buffer layer
-  const float fovX = vrapi_GetSystemPropertyFloat(&m.java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X);
-  const float fovY = vrapi_GetSystemPropertyFloat(&m.java, VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_Y);
-  const ovrMatrix4f projectionMatrix = ovrMatrix4f_CreateProjectionFov(fovX, fovY, 0.0f, 0.0f, VRAPI_ZNEAR, 0.0f);
-
   ovrLayerProjection2 projection = vrapi_DefaultLayerProjection2();
   projection.HeadPose = tracking.HeadPose;
   projection.Header.SrcBlend = VRAPI_FRAME_LAYER_BLEND_SRC_ALPHA;
@@ -1127,19 +1137,19 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
     // Set up OVR layer textures
     projection.Textures[i].ColorSwapChain = eyeSwapChain->SwapChain();
     projection.Textures[i].SwapChainIndex = swapChainIndex;
-    projection.Textures[i].TexCoordsFromTanAngles = ovrMatrix4f_TanAngleMatrixFromProjection(&projectionMatrix);
+    projection.Textures[i].TexCoordsFromTanAngles = ovrMatrix4f_TanAngleMatrixFromProjection(
+        &projectionMatrix);
   }
   layers[layerCount++] = &projection.Header;
 
   // Draw front layers
   for (const OculusLayerPtr& layer: m.uiLayers) {
     if (layer->GetDrawInFront() && layer->IsDrawRequested() && layerCount < ovrMaxLayerCount) {
-      layer->Update(tracking, m.clearColorSwapChain->SwapChain());
+      layer->Update(m.frameIndex, tracking, m.clearColorSwapChain->SwapChain());
       layers[layerCount++] = layer->Header();
       layer->ClearRequestDraw();
     }
   }
-
 
   // Submit all layers to TimeWarp
   ovrSubmitFrameDescription2 frameDesc = {};
@@ -1225,6 +1235,26 @@ DeviceDelegateOculusVR::CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer)
   return layer;
 }
 
+VRLayerProjectionPtr
+DeviceDelegateOculusVR::CreateLayerProjection(crow::VRLayerSurface::SurfaceType aSurfaceType) {
+  if (!m.layersEnabled) {
+    return nullptr;
+  }
+  uint32_t width = 0;
+  uint32_t height = 0;
+  m.GetStandaloneRenderSize(width, height);
+  VRLayerProjectionPtr layer = VRLayerProjection::Create(width, height, aSurfaceType);
+  OculusLayerProjectionPtr oculusLayer = OculusLayerProjection::Create(m.java.Env, layer);
+  oculusLayer->SetBindDelegate([=](const OculusSwapChainPtr& aSwapChain, GLenum aTarget, bool bound){
+    if (aSwapChain) {
+      m.HandleLayerBind(aSwapChain, aTarget, bound);
+    }
+  });
+  m.projectionLayers.push_back(oculusLayer);
+
+  return layer;
+}
+
 
 VRLayerCubePtr
 DeviceDelegateOculusVR::CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) {
@@ -1283,6 +1313,13 @@ DeviceDelegateOculusVR::DeleteLayer(const VRLayerPtr& aLayer) {
       return;
     }
   }
+  for (int i = 0; i < m.projectionLayers.size(); ++i) {
+    if (m.projectionLayers[i]->GetLayer() == aLayer) {
+      m.projectionLayers[i]->Destroy();
+      m.projectionLayers.erase(m.projectionLayers.begin() + i);
+      return;
+    }
+  }
 }
 
 void
@@ -1300,6 +1337,9 @@ DeviceDelegateOculusVR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
     m.eyeSwapChains[i] = OculusSwapChain::CreateFBO(render, m.RenderModeAttributes(), m.renderWidth, m.renderHeight);
   }
   vrb::RenderContextPtr context = m.context.lock();
+  for (OculusLayerProjectionPtr& layer: m.projectionLayers) {
+    layer->Init(m.java.Env, context);
+  }
   for (OculusLayerPtr& layer: m.uiLayers) {
     layer->Init(m.java.Env, context);
   }
@@ -1349,6 +1389,9 @@ DeviceDelegateOculusVR::LeaveVR() {
 void
 DeviceDelegateOculusVR::OnDestroy() {
   for (OculusLayerPtr& layer: m.uiLayers) {
+    layer->Destroy();
+  }
+  for (OculusLayerProjectionPtr& layer: m.projectionLayers) {
     layer->Destroy();
   }
   for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.cpp
@@ -78,11 +78,11 @@ struct DeviceDelegateOculusVR::State {
   bool layersEnabled = true;
   ovrJava java = {};
   ovrMobile* ovr = nullptr;
-  OculusEyeSwapChainPtr eyeSwapChains[VRAPI_EYE_COUNT];
+  OculusSwapChainPtr eyeSwapChains[VRAPI_EYE_COUNT];
   OculusLayerCubePtr cubeLayer;
   OculusLayerEquirectPtr equirectLayer;
   std::vector<OculusLayerPtr> uiLayers;
-  ovrTextureSwapChain* clearColorSwapChain = nullptr;
+  OculusSwapChainPtr clearColorSwapChain;
   device::RenderMode renderMode = device::RenderMode::StandAlone;
   vrb::FBOPtr currentFBO;
   vrb::FBOPtr previousFBO;
@@ -156,9 +156,9 @@ struct DeviceDelegateOculusVR::State {
     layersEnabled = VRBrowser::AreLayersEnabled();
     SetRenderSize(device::RenderMode::StandAlone);
 
+    auto render = context.lock();
     for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
       cameras[i] = vrb::CameraEye::Create(localContext->GetRenderThreadCreationContext());
-      eyeSwapChains[i] = OculusEyeSwapChain::create();
     }
     UpdatePerspective();
 
@@ -203,6 +203,18 @@ struct DeviceDelegateOculusVR::State {
     } else if (!applicationEntitled) {
       ovr_Entitlement_GetIsViewerEntitled();
     }
+  }
+
+  vrb::FBO::Attributes RenderModeAttributes() {
+    vrb::FBO::Attributes attributes;
+    if (renderMode == device::RenderMode::StandAlone) {
+      attributes.depth = true;
+      attributes.samples = 4;
+    } else {
+      attributes.depth = false;
+      attributes.samples = 0;
+    }
+    return attributes;
   }
 
   void UpdateTrackingMode() {
@@ -253,9 +265,9 @@ struct DeviceDelegateOculusVR::State {
     }
     uiLayers.push_back(aLayer);
     if (aSurfaceType == VRLayerSurface::SurfaceType::FBO) {
-      aLayer->SetBindDelegate([=](const vrb::FBOPtr& aFBO, GLenum aTarget, bool bound){
-        if (aFBO) {
-          HandleQuadLayerBind(aFBO, aTarget, bound);
+      aLayer->SetBindDelegate([=](const OculusSwapChainPtr& aSwapChain, GLenum aTarget, bool bound){
+        if (aSwapChain) {
+          HandleLayerBind(aSwapChain, aTarget, bound);
         }
       });
       if (currentFBO) {
@@ -636,9 +648,12 @@ struct DeviceDelegateOculusVR::State {
     }
   }
 
-  void HandleQuadLayerBind(const vrb::FBOPtr& aFBO, GLenum aTarget, bool bound) {
+  void HandleLayerBind(const OculusSwapChainPtr& aSwapChain, GLenum aTarget, bool bound) {
+    const int32_t swapChainIndex = frameIndex % aSwapChain->SwapChainLength();
+    vrb::FBOPtr targetFBO = aSwapChain->FBO(swapChainIndex);
+
     if (!bound) {
-      if (currentFBO && currentFBO == aFBO) {
+      if (currentFBO && currentFBO == targetFBO) {
         currentFBO->Unbind();
         currentFBO = nullptr;
       }
@@ -650,7 +665,7 @@ struct DeviceDelegateOculusVR::State {
       return;
     }
 
-    if (currentFBO == aFBO) {
+    if (currentFBO == targetFBO) {
       // Layer already bound
       return;
     }
@@ -659,34 +674,29 @@ struct DeviceDelegateOculusVR::State {
       currentFBO->Unbind();
     }
     previousFBO = currentFBO;
-    aFBO->Bind(aTarget);
-    currentFBO = aFBO;
+    targetFBO->Bind(aTarget);
+    currentFBO = targetFBO;
   }
 
-  ovrTextureSwapChain* CreateClearColorSwapChain(const float aWidth, const float aHeight) {
-    ovrTextureSwapChain* result = vrapi_CreateTextureSwapChain(VRAPI_TEXTURE_TYPE_2D, VRAPI_TEXTURE_FORMAT_8888, aWidth, aHeight, 1, false);
-    vrb::RenderContextPtr ctx = context.lock();
-    vrb::FBOPtr fbo = vrb::FBO::Create(ctx);
-    GLuint texture = vrapi_GetTextureSwapChainHandle(result, 0);
-    VRB_GL_CHECK(glBindTexture(GL_TEXTURE_2D, texture));
-    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER_EXT));
-    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER_EXT));
-    float border[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR_EXT, border);
-    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+  OculusSwapChainPtr CreateClearColorSwapChain(const float aWidth, const float aHeight) {
+    vrb::RenderContextPtr render = context.lock();
+
     vrb::FBO::Attributes attributes;
     attributes.depth = false;
     attributes.samples = 0;
-    VRB_GL_CHECK(fbo->SetTextureHandle(texture, aWidth, aHeight, attributes));
-    if (fbo->IsValid()) {
-      fbo->Bind();
-      VRB_GL_CHECK(glClearColor(1.0f, 1.0f, 1.0f, 1.0f));
-      VRB_GL_CHECK(glClear(GL_COLOR_BUFFER_BIT));
-      fbo->Unbind();
-    } else {
-      VRB_WARN("FAILED to make valid FBO for ClearColorSwapChain");
-    }
+
+    vrb::Color clearColor(1.0f, 1.0f, 1.0f, 1.0f);
+
+    OculusSwapChainPtr result = OculusSwapChain::CreateFBO(render, attributes, aWidth, aHeight, false, clearColor);
+
+    // Add a transparent border (required for Oculus Layers)
+    VRB_GL_CHECK(glBindTexture(GL_TEXTURE_2D, result->TextureHandle(0)));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER_EXT));
+    VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER_EXT));
+    float border[] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    VRB_GL_CHECK(glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR_EXT, border));
+    VRB_GL_CHECK(glBindTexture(GL_TEXTURE_2D, 0));
+
     return result;
   }
 };
@@ -714,7 +724,7 @@ DeviceDelegateOculusVR::SetRenderMode(const device::RenderMode aMode) {
   m.SetRenderSize(aMode);
   vrb::RenderContextPtr render = m.context.lock();
   for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
-    m.eyeSwapChains[i]->Init(render, m.renderMode, m.renderWidth, m.renderHeight);
+    m.eyeSwapChains[i] = OculusSwapChain::CreateFBO(render, m.RenderModeAttributes(), m.renderWidth, m.renderHeight);
   }
 
   m.UpdateTrackingMode();
@@ -767,7 +777,7 @@ DeviceDelegateOculusVR::SetImmersiveSize(const uint32_t aEyeWidth, const uint32_
     m.renderHeight = targetHeight;
     vrb::RenderContextPtr render = m.context.lock();
     for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
-      m.eyeSwapChains[i]->Init(render, m.renderMode, m.renderWidth, m.renderHeight);
+      m.eyeSwapChains[i] = OculusSwapChain::CreateFBO(render, m.RenderModeAttributes(), m.renderWidth, m.renderHeight);
     }
     VRB_LOG("Resize immersive mode swapChain: %dx%d", targetWidth, targetHeight);
   }
@@ -1018,15 +1028,16 @@ DeviceDelegateOculusVR::BindEye(const device::Eye aWhich) {
     m.currentFBO->Unbind();
   }
 
-  const auto &swapChain = m.eyeSwapChains[index];
-  int swapChainIndex = m.frameIndex % swapChain->swapChainLength;
+  auto &swapChain = m.eyeSwapChains[index];
+
+  int swapChainIndex = m.frameIndex % swapChain->SwapChainLength();
   m.currentFBO = swapChain->FBO(swapChainIndex);
   if (!m.currentFBO || !m.currentFBO->IsValid()) {
     // See https://github.com/MozillaReality/FirefoxReality/issues/3712
     // There are some crash reports of invalid eye SwapChain FBOs. Try to recreate it.
     VRB_LOG("Recreate SwapChain because no valid FBO was found");
     auto render = m.context.lock();
-    swapChain->Init(render, m.renderMode, m.renderWidth, m.renderHeight);
+    swapChain = OculusSwapChain::CreateFBO(render, m.RenderModeAttributes(), m.renderWidth, m.renderHeight);
     m.currentFBO = swapChain->FBO(swapChainIndex);
   }
 
@@ -1076,13 +1087,13 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
   const ovrLayerHeader2* layers[ovrMaxLayerCount] = {};
 
   if (m.cubeLayer && m.cubeLayer->IsLoaded() && m.cubeLayer->IsDrawRequested()) {
-    m.cubeLayer->Update(tracking, m.clearColorSwapChain);
+    m.cubeLayer->Update(tracking, m.clearColorSwapChain->SwapChain());
     layers[layerCount++] = m.cubeLayer->Header();
     m.cubeLayer->ClearRequestDraw();
   }
 
   if (m.equirectLayer && m.equirectLayer->IsDrawRequested()) {
-    m.equirectLayer->Update(tracking, m.clearColorSwapChain);
+    m.equirectLayer->Update(tracking, m.clearColorSwapChain->SwapChain());
     layers[layerCount++] = m.equirectLayer->Header();
     m.equirectLayer->ClearRequestDraw();
   }
@@ -1095,7 +1106,7 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
   // Draw back layers
   for (const OculusLayerPtr& layer: m.uiLayers) {
     if (!layer->GetDrawInFront() && layer->IsDrawRequested() && (layerCount < ovrMaxLayerCount - 1)) {
-      layer->Update(tracking, m.clearColorSwapChain);
+      layer->Update(tracking, m.clearColorSwapChain->SwapChain());
       layers[layerCount++] = layer->Header();
       layer->ClearRequestDraw();
     }
@@ -1112,9 +1123,9 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
   projection.Header.DstBlend = VRAPI_FRAME_LAYER_BLEND_ONE_MINUS_SRC_ALPHA;
   for (int i = 0; i < VRAPI_FRAME_LAYER_EYE_MAX; ++i) {
     const auto &eyeSwapChain = m.eyeSwapChains[i];
-    const int swapChainIndex = m.frameIndex % eyeSwapChain->swapChainLength;
+    const int swapChainIndex = m.frameIndex % eyeSwapChain->SwapChainLength();
     // Set up OVR layer textures
-    projection.Textures[i].ColorSwapChain = eyeSwapChain->ovrSwapChain;
+    projection.Textures[i].ColorSwapChain = eyeSwapChain->SwapChain();
     projection.Textures[i].SwapChainIndex = swapChainIndex;
     projection.Textures[i].TexCoordsFromTanAngles = ovrMatrix4f_TanAngleMatrixFromProjection(&projectionMatrix);
   }
@@ -1123,7 +1134,7 @@ DeviceDelegateOculusVR::EndFrame(const FrameEndMode aEndMode) {
   // Draw front layers
   for (const OculusLayerPtr& layer: m.uiLayers) {
     if (layer->GetDrawInFront() && layer->IsDrawRequested() && layerCount < ovrMaxLayerCount) {
-      layer->Update(tracking, m.clearColorSwapChain);
+      layer->Update(tracking, m.clearColorSwapChain->SwapChain());
       layers[layerCount++] = layer->Header();
       layer->ClearRequestDraw();
     }
@@ -1286,7 +1297,7 @@ DeviceDelegateOculusVR::EnterVR(const crow::BrowserEGLContext& aEGLContext) {
 
   vrb::RenderContextPtr render = m.context.lock();
   for (int i = 0; i < VRAPI_EYE_COUNT; ++i) {
-    m.eyeSwapChains[i]->Init(render, m.renderMode, m.renderWidth, m.renderHeight);
+    m.eyeSwapChains[i] = OculusSwapChain::CreateFBO(render, m.RenderModeAttributes(), m.renderWidth, m.renderHeight);
   }
   vrb::RenderContextPtr context = m.context.lock();
   for (OculusLayerPtr& layer: m.uiLayers) {
@@ -1350,10 +1361,7 @@ DeviceDelegateOculusVR::OnDestroy() {
     m.equirectLayer->Destroy();
   }
 
-  if (m.clearColorSwapChain) {
-    vrapi_DestroyTextureSwapChain(m.clearColorSwapChain);
-    m.clearColorSwapChain = nullptr;
-  }
+  m.clearColorSwapChain = nullptr;
 }
 
 bool

--- a/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
+++ b/app/src/oculusvr/cpp/DeviceDelegateOculusVR.h
@@ -51,6 +51,7 @@ public:
   VRLayerCylinderPtr CreateLayerCylinder(int32_t aWidth, int32_t aHeight,
                                          VRLayerSurface::SurfaceType aSurfaceType) override;
   VRLayerCylinderPtr CreateLayerCylinder(const VRLayerSurfacePtr& aMoveLayer) override;
+  VRLayerProjectionPtr CreateLayerProjection(VRLayerSurface::SurfaceType aSurfaceType) override;
   VRLayerCubePtr CreateLayerCube(int32_t aWidth, int32_t aHeight, GLint aInternalFormat) override;
   VRLayerEquirectPtr CreateLayerEquirect(const VRLayerPtr &aSource) override;
   void DeleteLayer(const VRLayerPtr& aLayer) override;

--- a/app/src/oculusvr/cpp/OculusSwapChain.cpp
+++ b/app/src/oculusvr/cpp/OculusSwapChain.cpp
@@ -97,11 +97,4 @@ OculusSwapChain::TextureHandle(const int32_t aIndex) const {
   return 0;
 }
 
-vrb::FBOPtr OculusEyeSwapChain::FBO(const int32_t aIndex) {
-  if (aIndex >=0 && aIndex < fbos.size()) {
-    return fbos[aIndex];
-  }
-  return nullptr;
-}
-
 }

--- a/app/src/oculusvr/cpp/OculusSwapChain.cpp
+++ b/app/src/oculusvr/cpp/OculusSwapChain.cpp
@@ -5,55 +5,96 @@
 
 namespace crow {
 
-OculusEyeSwapChainPtr
-OculusEyeSwapChain::create() {
-  return std::make_shared<OculusEyeSwapChain>();
-}
+OculusSwapChainPtr
+OculusSwapChain::CreateFBO(vrb::RenderContextPtr& aContext, const vrb::FBO::Attributes& attributes,
+                           uint32_t aWidth, uint32_t aHeight, bool buffered, const vrb::Color& aClearColor ) {
+  auto result = std::make_shared<OculusSwapChain>();
 
-void
-OculusEyeSwapChain::Init(vrb::RenderContextPtr &aContext, device::RenderMode aMode, uint32_t aWidth,
-          uint32_t aHeight) {
-  Destroy();
-  ovrSwapChain = vrapi_CreateTextureSwapChain(VRAPI_TEXTURE_TYPE_2D,
+  result->mSwapChain = vrapi_CreateTextureSwapChain(VRAPI_TEXTURE_TYPE_2D,
                                               VRAPI_TEXTURE_FORMAT_8888,
-                                              aWidth, aHeight, 1, true);
-  swapChainLength = vrapi_GetTextureSwapChainLength(ovrSwapChain);
+                                              aWidth, aHeight, 1, buffered);
+  result->mSwapChainLength = vrapi_GetTextureSwapChainLength(result->mSwapChain);
+  result->mWidth = aWidth;
+  result->mHeight = aHeight;
 
-  for (int i = 0; i < swapChainLength; ++i) {
+  for (int i = 0; i < result->mSwapChainLength ; ++i) {
     vrb::FBOPtr fbo = vrb::FBO::Create(aContext);
-    auto texture = vrapi_GetTextureSwapChainHandle(ovrSwapChain, i);
+    auto texture = vrapi_GetTextureSwapChainHandle(result->mSwapChain, i);
     VRB_GL_CHECK(glBindTexture(GL_TEXTURE_2D, texture));
     VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
     VRB_GL_CHECK(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
 
-    vrb::FBO::Attributes attributes;
-    if (aMode == device::RenderMode::Immersive) {
-      attributes.depth = true;
-      attributes.samples = 0;
-    } else {
-      attributes.depth = true;
-      attributes.samples = 4;
-    }
-
     VRB_GL_CHECK(fbo->SetTextureHandle(texture, aWidth, aHeight, attributes));
     if (fbo->IsValid()) {
-      fbos.push_back(fbo);
+      result->mFBOs.push_back(fbo);
+      fbo->Bind();
+      VRB_GL_CHECK(glClearColor(aClearColor.Red(), aClearColor.Green(), aClearColor.Blue(), aClearColor.Alpha()));
+      VRB_GL_CHECK(glClear(GL_COLOR_BUFFER_BIT));
+      fbo->Unbind();
     } else {
       VRB_LOG("FAILED to make valid FBO");
     }
   }
+
+  return result;
+}
+
+OculusSwapChainPtr OculusSwapChain::CreateAndroidSurface(JNIEnv* aEnv, uint32_t aWidth, uint32_t aHeight) {
+  auto result = std::make_shared<OculusSwapChain>();
+
+  result->mSwapChain = vrapi_CreateAndroidSurfaceSwapChain(aWidth, aHeight);
+  result->mWidth = aWidth;
+  result->mHeight = aHeight;
+
+  jobject surface = vrapi_GetTextureSwapChainAndroidSurface(result->mSwapChain);
+  result->mEnv = aEnv;
+  result->mSurface = aEnv->NewGlobalRef(surface);
+  return result;
+}
+
+OculusSwapChainPtr OculusSwapChain::CreateCubemap(GLint aFormat, uint32_t aWidth, uint32_t aHeight) {
+  auto result = std::make_shared<OculusSwapChain>();
+  result->mSwapChain = vrapi_CreateTextureSwapChain3(VRAPI_TEXTURE_TYPE_CUBE, aFormat, aWidth, aWidth, 1, 1);
+  result->mWidth = aWidth;
+  result->mHeight = aHeight;
+
+  return result;
+}
+
+OculusSwapChain::~OculusSwapChain() {
+  Destroy();
 }
 
 void
-OculusEyeSwapChain::Destroy() {
-  fbos.clear();
-  if (ovrSwapChain) {
-    vrapi_DestroyTextureSwapChain(ovrSwapChain);
-    ovrSwapChain = nullptr;
+OculusSwapChain::Destroy() {
+  mFBOs.clear();
+  if (mSurface  && mEnv) {
+    mEnv->DeleteGlobalRef(mSurface);
+    mSurface = nullptr;
+    mEnv = nullptr;
   }
-  swapChainLength = 0;
+  if (mSwapChain) {
+    vrapi_DestroyTextureSwapChain(mSwapChain);
+    mSwapChain = nullptr;
+  }
+}
+
+vrb::FBOPtr
+OculusSwapChain::FBO(const int32_t aIndex) const {
+  if (aIndex >= 0 && aIndex < mFBOs.size()) {
+    return mFBOs[aIndex];
+  }
+  return nullptr;
+}
+
+GLuint
+OculusSwapChain::TextureHandle(const int32_t aIndex) const {
+  if (mSwapChain) {
+    return vrapi_GetTextureSwapChainHandle(mSwapChain, aIndex);
+  }
+  return 0;
 }
 
 vrb::FBOPtr OculusEyeSwapChain::FBO(const int32_t aIndex) {

--- a/app/src/oculusvr/cpp/OculusSwapChain.h
+++ b/app/src/oculusvr/cpp/OculusSwapChain.h
@@ -1,28 +1,46 @@
 #pragma once
 
 #include "vrb/Forward.h"
+#include "vrb/GLError.h"
+#include "vrb/Color.h"
 #include "Device.h"
 #include "VrApi.h"
 #include <memory>
 #include <vector>
+#include <vrb/include/vrb/FBO.h>
 
 namespace crow {
 
-class OculusEyeSwapChain;
+class OculusSwapChain;
 
-typedef std::shared_ptr<OculusEyeSwapChain> OculusEyeSwapChainPtr;
+typedef std::shared_ptr<OculusSwapChain> OculusSwapChainPtr;
 
-class OculusEyeSwapChain {
-public:
-  ovrTextureSwapChain *ovrSwapChain = nullptr;
-  int swapChainLength = 0;
-
-  static OculusEyeSwapChainPtr create();
-  void Init(vrb::RenderContextPtr &aContext, device::RenderMode aMode, uint32_t aWidth, uint32_t aHeight);
-  void Destroy();
-  vrb::FBOPtr FBO(const int32_t aIndex);
+class OculusSwapChain {
 private:
-  std::vector<vrb::FBOPtr> fbos;
+  ovrTextureSwapChain * mSwapChain = nullptr;
+  int32_t mSwapChainLength = 1;
+  std::vector<vrb::FBOPtr> mFBOs;
+  jobject mSurface = nullptr;
+  JNIEnv* mEnv = nullptr;
+  int32_t mWidth = 0;
+  int32_t mHeight = 0;
+
+public:
+  static OculusSwapChainPtr CreateFBO(vrb::RenderContextPtr& aContext, const vrb::FBO::Attributes& attributes,
+                                      uint32_t aWidth, uint32_t aHeight, bool buffered = true,
+                                      const vrb::Color& aClearColor = {});
+  static OculusSwapChainPtr CreateAndroidSurface(JNIEnv* aEnv, uint32_t aWidth, uint32_t aHeight);
+  static OculusSwapChainPtr CreateCubemap(GLint aFormat, uint32_t aWidth, uint32_t aHeight);
+  ~OculusSwapChain();
+  void Destroy();
+
+  inline ovrTextureSwapChain* SwapChain() const { return mSwapChain; }
+  inline int32_t SwapChainLength() const { return mSwapChainLength; }
+  vrb::FBOPtr FBO(const int32_t aIndex) const;
+  jobject AndroidSurface() const { return mSurface; }
+  GLuint TextureHandle(const int32_t aIndex) const;
+  inline int32_t Width() const { return mWidth; }
+  inline int32_t Height() const { return mHeight; }
 };
 
 }

--- a/app/src/oculusvr/cpp/OculusVRLayers.cpp
+++ b/app/src/oculusvr/cpp/OculusVRLayers.cpp
@@ -136,8 +136,8 @@ OculusLayerCube::Init(JNIEnv * aEnv, vrb::RenderContextPtr& aContext) {
   ovrLayer.Offset.x = 0.0f;
   ovrLayer.Offset.y = 0.0f;
   ovrLayer.Offset.z = 0.0f;
-  swapChain = vrapi_CreateTextureSwapChain3(VRAPI_TEXTURE_TYPE_CUBE, glFormat, layer->GetWidth(), layer->GetHeight(), 1, 1);
-  layer->SetTextureHandle(vrapi_GetTextureSwapChainHandle(swapChain, 0));
+  swapChain = OculusSwapChain::CreateCubemap(glFormat, layer->GetWidth(), layer->GetHeight());
+  layer->SetTextureHandle(swapChain->TextureHandle(0));
   OculusLayerBase<VRLayerCubePtr, ovrLayerCube2>::Init(aEnv, aContext);
 }
 


### PR DESCRIPTION
This is going to be useful for adding 6DOF envs in the future without the hassle of creating separate widget textures for the alpha blending. VRProjectionLayer will also be used in the future for the WebXR surface bypass. 

High level changes:
- Refactor OculusSwapChain code
- Implement VRProjectionLayer
- Implement BrowserWorld environment render

You can check the https://github.com/MozillaReality/FirefoxReality/tree/experimental/space_env branch with an example of a enabled 6DOF environment