### PR TITLE
Recreate SwapChain before binding if the target FBO is invalid

### DIFF
--- a/app/src/oculusvr/cpp/OculusSwapChain.cpp
+++ b/app/src/oculusvr/cpp/OculusSwapChain.cpp
@@ -56,4 +56,11 @@ OculusEyeSwapChain::Destroy() {
   swapChainLength = 0;
 }
 
+vrb::FBOPtr OculusEyeSwapChain::FBO(const int32_t aIndex) {
+  if (aIndex >=0 && aIndex < fbos.size()) {
+    return fbos[aIndex];
+  }
+  return nullptr;
+}
+
 }

--- a/app/src/oculusvr/cpp/OculusSwapChain.h
+++ b/app/src/oculusvr/cpp/OculusSwapChain.h
@@ -16,11 +16,13 @@ class OculusEyeSwapChain {
 public:
   ovrTextureSwapChain *ovrSwapChain = nullptr;
   int swapChainLength = 0;
-  std::vector<vrb::FBOPtr> fbos;
 
   static OculusEyeSwapChainPtr create();
   void Init(vrb::RenderContextPtr &aContext, device::RenderMode aMode, uint32_t aWidth, uint32_t aHeight);
   void Destroy();
+  vrb::FBOPtr FBO(const int32_t aIndex);
+private:
+  std::vector<vrb::FBOPtr> fbos;
 };
 
 }


### PR DESCRIPTION
Fixes #3712

This is a speculative fix. The crash address is the same (0x10) if I force the FBOs to be invalid and not added to the vector. @Softvision-RemusDranca is trying to find STRs.

I tried to force the FBOs to be invalid for 50 times using a counter and the app is able to recover using the fix included in the PR.