### PR TITLE
Use main branch for l10n

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -25,7 +25,6 @@ locales = [
 # Expose the following branches to localization
 # Changes to this list should be announced to the l10n team ahead of time.
 branches = [
-    "master",
     "main",
 ]
 


### PR DESCRIPTION
Last step in migrating FirefoxReality l10n to the main branch.