### PR TITLE
Set startup metrics after Glean is initialized

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/telemetry/GleanMetricsService.java
@@ -63,16 +63,13 @@ public class GleanMetricsService {
         initialized = true;
 
         final boolean telemetryEnabled = SettingsStore.getInstance(aContext).isTelemetryEnabled();
-        if (telemetryEnabled) {
-            GleanMetricsService.start();
-        } else {
-            GleanMetricsService.stop();
-        }
         Configuration config = new Configuration(
                 ConceptFetchHttpUploader.fromClient(client),
                 Configuration.DEFAULT_TELEMETRY_ENDPOINT,
                 BuildConfig.BUILD_TYPE);
-        Glean.INSTANCE.initialize(aContext, true, config);
+
+        Glean.INSTANCE.initialize(aContext, telemetryEnabled, config);
+        setStartupMetrics();
     }
 
     // It would be called when users turn on/off the setting of telemetry.

--- a/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/vrbrowser/GleanMetricsServiceTest.kt
@@ -63,8 +63,15 @@ class GleanMetricsServiceTest {
         GleanMetricsService.testSetStartupMetrics()
         assertTrue(Distribution.channelName.testHasValue())
         assertEquals(Distribution.channelName.testGetValue(),
-                if (org.mozilla.vrbrowser.utils.DeviceType.isOculusBuild()) "oculusvr"
-                else BuildConfig.FLAVOR_platform)
+                org.mozilla.vrbrowser.utils.DeviceType.getDeviceTypeId());
+
+        // Make sure the distribution channel name is set after
+        // the telemetry system is switch off/on.
+        GleanMetricsService.stop();
+        GleanMetricsService.start();
+        assertTrue(Distribution.channelName.testHasValue())
+        assertEquals(Distribution.channelName.testGetValue(),
+                org.mozilla.vrbrowser.utils.DeviceType.getDeviceTypeId());
     }
 
     @Test


### PR DESCRIPTION
We were setting  `distribution_channel_name` before `Glean.initialize` and using `org_mozilla_vrbrowser.baseline` schema to query this metrics. But, it seems like the recent changes in Glean side makes us can't see `distribution_channel_name` in baseline pings.

In addition, even in `org_mozilla_vrbrowser.metrics` schema, we still have 20% chance to see the value of `distribution_channel_name` is null, and it starts from A-C around version 44 (https://sql.telemetry.mozilla.org/queries/73600/source#184108). So, I think we need to consider to move it back to `Glean.initialize` and make sure all our metric pings could have its values instead a null.
