### PR TITLE
Fixes #3789 Hide hamburger menu when interacting with the library/scrolling

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/LibraryPanel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/LibraryPanel.java
@@ -73,17 +73,20 @@ public class LibraryPanel extends FrameLayout {
         mBinding.setDelegate(new LibraryNavigationDelegate() {
             @Override
             public void onClose(@NonNull View view) {
+                requestFocus();
                 mWidgetManager.getFocusedWindow().hidePanel();
             }
 
             @Override
             public void onBack(@NonNull View view) {
+                requestFocus();
                 mCurrentView.onBack();
                 mBinding.setCanGoBack(mCurrentView.canGoBack());
             }
 
             @Override
             public void onButtonClick(@NonNull View view) {
+                requestFocus();
                 selectTab(view);
             }
         });

--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -814,6 +814,10 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
             return;
         }
 
+        if (aEvent.getAction() == MotionEvent.ACTION_SCROLL) {
+            requestFocusFromTouch();
+        }
+
         if (mView != null) {
             super.handleHoverEvent(aEvent);
 


### PR DESCRIPTION
Fixes #3789 Hide hamburger menu when interacting with the library/scrolling