### PR TITLE
Fixes #3798 Keep current add-ons tittle when reopening

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/LibraryPanel.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/views/library/LibraryPanel.java
@@ -219,10 +219,13 @@ public class LibraryPanel extends FrameLayout {
     }
 
     private void selectAddons() {
+        boolean alreadySelected = mCurrentView == mAddonsView;
         mCurrentView = mAddonsView;
         mBinding.addons.setActiveMode(true);
         mBinding.tabcontent.addView(mAddonsView);
-        mBinding.title.setText(R.string.addons_title);
+        if (!alreadySelected) {
+            mBinding.title.setText(R.string.addons_title);
+        }
     }
 
     public void onViewUpdated(@NonNull String title) {


### PR DESCRIPTION
Fixes #3798 Keep current add-ons tittle when reopening