### PR TITLE
Fixes #3868 Show correct permission list when uninstalling the add-on

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/addons/views/AddonOptionsView.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/addons/views/AddonOptionsView.java
@@ -3,9 +3,11 @@ package org.mozilla.vrbrowser.addons.views;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.View;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.mozilla.vrbrowser.R;
@@ -22,6 +24,7 @@ import org.mozilla.vrbrowser.ui.widgets.prompts.PromptData;
 import org.mozilla.vrbrowser.utils.SystemUtils;
 
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import mozilla.components.concept.engine.webextension.EnableSource;
 import mozilla.components.feature.addons.Addon;
@@ -112,11 +115,22 @@ public class AddonOptionsView extends RecyclerView.ViewHolder implements AddonOp
     }
 
     private void showRemoveAddonSuccessDialog(@NonNull Addon addon) {
+        String permissionsHtml = addon.translatePermissions().stream()
+                .map(integer -> {
+                    @StringRes int stringId = integer;
+                    return "<li>&nbsp;" + mContext.getString(stringId) + "</li>";
+                })
+                .sorted()
+                .collect(Collectors.joining());
         PromptData data = new PromptData.Builder()
                 .withIconRes(R.drawable.ic_icon_addons)
                 .withTitle(mContext.getString(
                         R.string.addons_remove_success_dialog_title,
                         ExtensionsKt.getTranslatedName(addon)))
+                .withBody(mContext.getString(
+                        R.string.addons_install_dialog_body,
+                        permissionsHtml))
+                .withBodyGravity(Gravity.START)
                 .withBtnMsg(new String[]{
                         mContext.getString(R.string.addons_remove_success_dialog_ok)
                 })
@@ -133,6 +147,7 @@ public class AddonOptionsView extends RecyclerView.ViewHolder implements AddonOp
                 .withBtnMsg(new String[]{
                         mContext.getString(R.string.addons_remove_error_dialog_ok)
                 })
+                .withBody("")
                 .build();
         mWidgetManager.getFocusedWindow().showConfirmPrompt(data);
     }


### PR DESCRIPTION
Fixes #3868 Show correct permission list when uninstalling the add-on