### PR TITLE
Fix crash if mExternalRequestDelegate is not set

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/browser/engine/Session.java
@@ -887,7 +887,7 @@ public class Session implements ContentBlocking.Delegate, GeckoSession.Navigatio
         }
         if (mState.mSession != null) {
             Log.d(LOGTAG, "Loading URI: " + aUri);
-            if (!mExternalRequestDelegate.onHandleExternalRequest(aUri)) {
+            if (mExternalRequestDelegate == null || !mExternalRequestDelegate.onHandleExternalRequest(aUri)) {
                 mState.mSession.loadUri(aUri, flags);
             }
         }


### PR DESCRIPTION
Regression from #3944

STR:
Click on the hamburger menu->addons->mozilla components