### PR TITLE
Reset controllers state on pause

### DIFF
--- a/app/src/picovr/cpp/DeviceDelegatePicoVR.cpp
+++ b/app/src/picovr/cpp/DeviceDelegatePicoVR.cpp
@@ -71,6 +71,15 @@ struct DeviceDelegatePicoVR::State {
     bool IsRightHand() const {
       return hand == ElbowModel::HandEnum::Right;
     }
+
+    void Reset() {
+        created = false;
+        enabled = false;
+        touched = false;
+        is6DoF = false;
+        transform = vrb::Matrix::Identity();
+        hand = ElbowModel::HandEnum::Right;
+    }
   };
   vrb::RenderContextWeak context;
   bool initialized = false;
@@ -487,6 +496,9 @@ DeviceDelegatePicoVR::IsControllerLightEnabled() const {
 void
 DeviceDelegatePicoVR::Pause() {
   m.paused = true;
+  for (State::Controller& controller: m.controllers) {
+    controller.Reset();
+  }
 }
 
 void

--- a/app/src/picovr/cpp/native-lib.cpp
+++ b/app/src/picovr/cpp/native-lib.cpp
@@ -72,6 +72,8 @@ JNI_METHOD(void, nativePause)
     return;
   }
   BrowserWorld::Instance().Pause();
+  if (sDevice != nullptr)
+    sDevice->Pause();
 }
 
 JNI_METHOD(void, nativeResume)
@@ -80,6 +82,8 @@ JNI_METHOD(void, nativeResume)
     return;
   }
   BrowserWorld::Instance().Resume();
+  if (sDevice != nullptr)
+    sDevice->Resume();
 }
 
 JNI_METHOD(void, nativeStartFrame)


### PR DESCRIPTION
This PR fixes an issue that caused the controllers not to be rendered after the activity is resumed

