### PR TITLE
Add missing resumeCompositor call when WindowWidget view is unset

### DIFF
--- a/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
+++ b/app/src/common/shared/org/mozilla/vrbrowser/ui/widgets/WindowWidget.java
@@ -443,6 +443,7 @@ public class WindowWidget extends UIWidget implements SessionChangeListener,
                 mWidgetManager.updateWidget(WindowWidget.this);
                 mWidgetManager.popWorldBrightness(WindowWidget.this);
                 mWidgetManager.popBackHandler(mBackHandler);
+                resumeCompositor();
             }
         }
     }


### PR DESCRIPTION
PauseCompositor is called in WindowWidget.serView() but ResumeCompositor is never called in unsetView()

This is causing the browser window to not render anything after Bookmarks window is display and dismissed on the HVR platform (Harmony OS)
