### PR TITLE
OpenXR 6DOF Controller improvements

### DIFF
--- a/app/src/main/cpp/Controller.h
+++ b/app/src/main/cpp/Controller.h
@@ -40,7 +40,7 @@ struct Controller {
   float scrollDeltaY;
   vrb::TransformPtr transform;
   vrb::TogglePtr beamToggle;
-  vrb::GroupPtr beamParent;
+  vrb::TransformPtr beamParent;
   PointerPtr pointer;
   vrb::Matrix transformMatrix;
   vrb::Matrix beamTransformMatrix;

--- a/app/src/main/cpp/ControllerContainer.cpp
+++ b/app/src/main/cpp/ControllerContainer.cpp
@@ -241,14 +241,10 @@ ControllerContainer::CreateController(const int32_t aControllerIndex, const int3
       controller.transform->AddNode(m.models[aModelIndex]);
       controller.beamToggle = vrb::Toggle::Create(create);
       controller.beamToggle->ToggleAll(true);
-      if (aBeamTransform.IsIdentity()) {
-        controller.beamParent = controller.beamToggle;
-      } else {
-        vrb::TransformPtr beamTransform = Transform::Create(create);
-        beamTransform->SetTransform(aBeamTransform);
-        controller.beamParent = beamTransform;
-        controller.beamToggle->AddNode(beamTransform);
-      }
+      vrb::TransformPtr beamTransform = Transform::Create(create);
+      beamTransform->SetTransform(aBeamTransform);
+      controller.beamParent = beamTransform;
+      controller.beamToggle->AddNode(beamTransform);
       controller.transform->AddNode(controller.beamToggle);
       if (m.beamModel && controller.beamParent) {
         controller.beamParent->AddNode(m.beamModel);
@@ -281,6 +277,16 @@ ControllerContainer::SetImmersiveBeamTransform(const int32_t aControllerIndex,
     return;
   }
   m.list[aControllerIndex].immersiveBeamTransform = aImmersiveBeamTransform;
+}
+
+void
+ControllerContainer::SetBeamTransform(const int32_t aControllerIndex, const vrb::Matrix& aBeamTransform) {
+  if (!m.Contains(aControllerIndex)) {
+    return;
+  }
+  if (m.list[aControllerIndex].beamParent) {
+    m.list[aControllerIndex].beamParent->SetTransform(aBeamTransform);
+  }
 }
 
 void

--- a/app/src/main/cpp/ControllerContainer.h
+++ b/app/src/main/cpp/ControllerContainer.h
@@ -39,6 +39,7 @@ public:
   void CreateController(const int32_t aControllerIndex, const int32_t aModelIndex, const std::string& aImmersiveName) override;
   void CreateController(const int32_t aControllerIndex, const int32_t aModelIndex, const std::string& aImmersiveName, const vrb::Matrix& aBeamTransform) override;
   void SetImmersiveBeamTransform(const int32_t aControllerIndex, const vrb::Matrix& aImmersiveBeamTransform) override;
+  void SetBeamTransform(const int32_t aControllerIndex, const vrb::Matrix& aBeamTransform) override;
   void SetFocused(const int32_t aControllerIndex) override;
   void DestroyController(const int32_t aControllerIndex) override;
   void SetCapabilityFlags(const int32_t aControllerIndex, const device::CapabilityFlags aFlags) override;

--- a/app/src/main/cpp/ControllerDelegate.h
+++ b/app/src/main/cpp/ControllerDelegate.h
@@ -36,6 +36,7 @@ public:
   virtual void CreateController(const int32_t aControllerIndex, const int32_t aModelIndex, const std::string& aImmersiveName) = 0;
   virtual void CreateController(const int32_t aControllerIndex, const int32_t aModelIndex, const std::string& aImmersiveName, const vrb::Matrix& aBeamTransform) = 0;
   virtual void SetImmersiveBeamTransform(const int32_t aControllerIndex, const vrb::Matrix& aImmersiveBeamTransform) = 0;
+  virtual void SetBeamTransform(const int32_t aControllerIndex, const vrb::Matrix& aBeamTransform) = 0;
   virtual void SetFocused(const int32_t aControllerIndex) = 0;
   virtual void DestroyController(const int32_t aControllerIndex) = 0;
   virtual uint32_t GetControllerCount() = 0;

--- a/app/src/openxr/cpp/OpenXRInputMappings.h
+++ b/app/src/openxr/cpp/OpenXRInputMappings.h
@@ -181,6 +181,26 @@ namespace crow {
             }
     };
 
+  const OpenXRInputMapping Hvr6DOF {
+      "/interaction_profiles/huawei/controller",
+      "Haliday: G3HMD by Huawei",
+      "vr_controller_oculusquest_left.obj",
+      "vr_controller_oculusquest_right.obj",
+      std::vector<OpenXRInputProfile> { "oculus-touch-v3", "oculus-touch-v2", "oculus-touch", "generic-trigger-squeeze-thumbstick" },
+      std::vector<OpenXRButton> {
+          { OpenXRButtonType::Trigger, kPathTrigger, OpenXRButtonFlags::All, OpenXRHandFlags::Both },
+          { OpenXRButtonType::Thumbstick, kPathThumbstick, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Both },
+          // { OpenXRButtonType::ButtonX, kPathButtonX, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left },
+          // { OpenXRButtonType::ButtonY, kPathButtonY, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Left, ControllerDelegate::Button::BUTTON_APP },
+          // { OpenXRButtonType::ButtonA, kPathButtonA, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right },
+          // { OpenXRButtonType::ButtonB, kPathButtonB, OpenXRButtonFlags::ClickTouch, OpenXRHandFlags::Right, ControllerDelegate::Button::BUTTON_APP },
+      },
+      std::vector<OpenXRAxis> {
+          { OpenXRAxisType::Thumbstick, kPathThumbstick,  OpenXRHandFlags::Both },
+          { OpenXRAxisType::Trackpad, kPathTrackpad,  OpenXRHandFlags::Both },
+      }
+  };
+
     // Default fallback: https://github.com/immersive-web/webxr-input-profiles/blob/master/packages/registry/profiles/generic/generic-button.json
     const OpenXRInputMapping KHRSimple {
             "/interaction_profiles/khr/simple_controller",
@@ -195,7 +215,7 @@ namespace crow {
     };
 
     const std::array<OpenXRInputMapping, 4> OpenXRInputMappings {
-        OculusTouch, OculusTouch2, Hvr3DOF, KHRSimple
+        OculusTouch, OculusTouch2, Hvr6DOF, KHRSimple
     };
 
 } // namespace crow


### PR DESCRIPTION
- Fix HVR height on 6DOF controllers
- Add HVR 6DOF mapping
- Improve beam transform on Oculus 3D model
- Add SetBeamTransform (previously it could only be passed in the constructor)