### PR TITLE
Fix SGBA related brightness issues in Oculus OpenXR builds

### DIFF
--- a/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
+++ b/app/src/openxr/cpp/DeviceDelegateOpenXR.cpp
@@ -244,7 +244,11 @@ struct DeviceDelegateOpenXR::State {
   }
 
   XrSwapchainCreateInfo GetSwapChainCreateInfo(uint32_t w = 0, uint32_t h = 0) {
+#if OCULUSVR
+    const int64_t colorFormat = GL_SRGB8_ALPHA8;
+#else
     const int64_t colorFormat = GL_RGBA8;
+#endif
     CHECK_MSG(SupportsColorFormat(colorFormat), "Runtime doesn't support selected swapChain color format");
 
     CHECK(viewConfig.size() > 0);
@@ -641,6 +645,11 @@ DeviceDelegateOpenXR::StartFrame(const FramePrediction aPrediction) {
     VRB_ERROR("OpenXR StartFrame called while not in VR mode");
     return;
   }
+
+#if OCULUSVR
+  // Fix brigthness issue.
+  glDisable(GL_FRAMEBUFFER_SRGB_EXT);
+#endif
 
   CHECK(m.session != XR_NULL_HANDLE);
   CHECK(m.viewSpace != XR_NULL_HANDLE);


### PR DESCRIPTION
Fixes the brightness issue with the 3D rendering layer (remote controllers, beam, and more).

The skybox also has brightness issues, but I'll address that in a separate PR.