### PR TITLE
Issue #4006 added comment in the .gitignore file above the .swp vim swap file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ app/.externalNativeBuild
 app/.cxx
 openwnn/.externalNativeBuild
 
+# Swap files created by Vim
 *.swp
 
 # Testing Oculus signature


### PR DESCRIPTION
Added the missing comment in the .gitignore file for the .swp file that stand for the vim swap file.